### PR TITLE
Enable Anthropic prompt caching on the Cloudflare gateway path

### DIFF
--- a/patches/@flue__runtime.patch
+++ b/patches/@flue__runtime.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/cloudflare/workers-ai-provider.mjs b/dist/cloudflare/workers-ai-provider.mjs
+index acfc3f9038ddcc1923a3e6c6d123c12fab747ee1..58d9bb318d66b0a555303851208f04b62e487599 100644
+--- a/dist/cloudflare/workers-ai-provider.mjs
++++ b/dist/cloudflare/workers-ai-provider.mjs
+@@ -486,7 +486,7 @@ function streamCloudflareAnthropicAi(ai, binding, model, context, options) {
+ 	const anthropicOptions = {
+ 		...options,
+ 		client,
+-		cacheRetention: "none",
++		cacheRetention: "short",
+ 		thinkingEnabled: Boolean(options?.reasoning),
+ 		onPayload: async (payload, payloadModel) => {
+ 			const normalized = normalizeAnthropicGatewayPayload(payload);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,13 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@flue/runtime':
+    hash: 6bfbc4c1e00a6c521d7070d99ee25af60a34df651b4b2e5814c18dfa46cc32a9
+    path: patches/@flue__runtime.patch
+
 importers:
 
   .:
     dependencies:
       '@flue/runtime':
         specifier: ^2.0.1
-        version: 2.0.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@7.0.2)(ws@8.21.1)(zod@4.4.3)
+        version: 2.0.1(patch_hash=6bfbc4c1e00a6c521d7070d99ee25af60a34df651b4b2e5814c18dfa46cc32a9)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@7.0.2)(ws@8.21.1)(zod@4.4.3)
       agents:
         specifier: ^0.14.2
         version: 0.14.5(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260801.1)(ai@6.0.240(zod@4.4.3))(react@19.2.8)(rolldown@1.2.2)(vite@8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))(zod@4.4.3)
@@ -2968,7 +2973,7 @@ snapshots:
 
   '@flue/cli@2.0.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/node@22.20.1)(esbuild@0.28.1)(hono@4.12.34)(typescript@7.0.2)(ws@8.21.1)(yaml@2.9.0)(zod@4.4.3)':
     dependencies:
-      '@flue/runtime': 2.0.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@7.0.2)(ws@8.21.1)(zod@4.4.3)
+      '@flue/runtime': 2.0.1(patch_hash=6bfbc4c1e00a6c521d7070d99ee25af60a34df651b4b2e5814c18dfa46cc32a9)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@7.0.2)(ws@8.21.1)(zod@4.4.3)
       '@flue/vite': 2.0.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(hono@4.12.34)(typescript@7.0.2)(vite@8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))(ws@8.21.1)(zod@4.4.3)
       '@vercel/detect-agent': 1.2.3
       cac: 7.0.0
@@ -2999,7 +3004,7 @@ snapshots:
       - yaml
       - zod
 
-  '@flue/runtime@2.0.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@7.0.2)(ws@8.21.1)(zod@4.4.3)':
+  '@flue/runtime@2.0.1(patch_hash=6bfbc4c1e00a6c521d7070d99ee25af60a34df651b4b2e5814c18dfa46cc32a9)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@7.0.2)(ws@8.21.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.1)(zod@4.4.3)
@@ -3021,7 +3026,7 @@ snapshots:
 
   '@flue/vite@2.0.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(hono@4.12.34)(typescript@7.0.2)(vite@8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))(ws@8.21.1)(zod@4.4.3)':
     dependencies:
-      '@flue/runtime': 2.0.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@7.0.2)(ws@8.21.1)(zod@4.4.3)
+      '@flue/runtime': 2.0.1(patch_hash=6bfbc4c1e00a6c521d7070d99ee25af60a34df651b4b2e5814c18dfa46cc32a9)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@7.0.2)(ws@8.21.1)(zod@4.4.3)
       '@hono/node-server': 2.0.12(hono@4.12.34)
       magic-string: 1.1.0
       tinyglobby: 0.2.17

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,5 @@ allowBuilds:
   node-liblzma: false
   protobufjs: false
   workerd: true
+patchedDependencies:
+  '@flue/runtime': patches/@flue__runtime.patch


### PR DESCRIPTION
## Problem

Reviews were paying full price for the entire conversation prefix on every model turn — the PR 254 auto-review consumed **715K input tokens (~\$1.46) with zero cache reads**. With multi-agent reviews on the roadmap, this multiplies per enabled agent.

Root cause: `@flue/runtime`'s `cloudflareBindingProvider` hardcodes `cacheRetention: \"none\"` when serializing Anthropic requests (`streamCloudflareAnthropicAi`), so pi-ai never emits `cache_control` breakpoints. There is no config passthrough — the provider overwrites any caller value. (AI Gateway's own `cacheTtl` caching is identical-request response replay and cannot help an agent loop.)

## Fix

One-line `pnpm patch` (tracked in `patches/@flue__runtime.patch`, applied via `patchedDependencies`): `cacheRetention: \"none\"` → `\"short\"`. pi-ai then places a moving `cache_control` breakpoint on the last message (plus system/tools), so each turn re-reads the shared prefix at the cached rate.

## Verification (production, supermeme-ai/general-api#40)

| | before (PR 254) | after (PR 40 re-review) |
|---|---|---|
| plain input tokens | 715,842 | **4** |
| cache read / write | 0 / 0 | 39,715 / 33,643 |
| cost | \$1.46 | **\$0.11** |

~92% cost reduction on a full review that fetched the diff, reviewed, and posted to GitHub.

## Exit path

The patch should be deleted once upstream exposes the option. Draft issue for withastro/flue:

> **Title:** cloudflareBindingProvider: make cacheRetention configurable (currently hardcoded "none")
> `streamCloudflareAnthropicAi` passes `cacheRetention: "none"` to `anthropicMessagesApi().stream()`, disabling Anthropic prompt caching for all Anthropic models behind the Workers AI binding / AI Gateway path — agent loops pay full input price for the growing conversation prefix every turn. pi-ai already supports `"short"`/`"long"` and the gateway passes `cache_control` through fine (verified in production: 4 plain input tokens, 39.7K cache reads on a multi-turn run). Please expose `cacheRetention` on the `cloudflareBindingProvider` config (or default it to `"short"` to match pi-ai's own default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)