### PR TITLE
Risk-tiered dispatch: size PRs, scale the agent fleet to match

### DIFF
--- a/migrations/0006_review_risk.sql
+++ b/migrations/0006_review_risk.sql
@@ -1,0 +1,5 @@
+-- Risk-tiered dispatch (trivial/lite/full — see src/lib/risk.ts) and
+-- findings-per-review tracking. Both NULL on rows predating the feature and
+-- on mention/manual dispatches, which bypass tiering.
+ALTER TABLE reviews ADD COLUMN risk_tier TEXT;
+ALTER TABLE reviews ADD COLUMN findings_count INTEGER;

--- a/src/app.ts
+++ b/src/app.ts
@@ -47,6 +47,10 @@ export async function dispatchReviewAgent(
 	prNumber: number,
 	prUrl: string,
 	trigger: string,
+	// Auto-dispatch passes the PR's computed risk tier (recorded for the
+	// dashboard) and, for trivial PRs, an optional cheap-model override.
+	// Mention/manual dispatches omit both.
+	opts: { riskTier?: string; modelOverride?: string } = {},
 ): Promise<boolean> {
 	const instanceId = `${agent.slug}--${repo.owner}--${repo.name}--${prNumber}`.toLowerCase();
 	// Snapshot the agent's external MCP connections (non-secret fields only;
@@ -62,7 +66,7 @@ export async function dispatchReviewAgent(
 				attributes: {
 					agent_slug: agent.slug,
 					agent_name: agent.name,
-					model: agent.model,
+					model: opts.modelOverride ?? agent.model,
 					pull_request: `${repo.owner}/${repo.name}#${prNumber}`,
 					trigger,
 					...(connections.length > 0 ? { connections: JSON.stringify(connections) } : {}),
@@ -79,7 +83,15 @@ export async function dispatchReviewAgent(
 		);
 		return false;
 	}
-	await recordReview(repo.id, repo.installation_id, prNumber, trigger, agent.slug, instanceId);
+	await recordReview(
+		repo.id,
+		repo.installation_id,
+		prNumber,
+		trigger,
+		agent.slug,
+		instanceId,
+		opts.riskTier ?? null,
+	);
 	return true;
 }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -134,12 +134,13 @@ export async function recordReview(
 	trigger: string,
 	agentSlug: string,
 	agentInstanceId: string,
+	riskTier: string | null = null,
 ): Promise<void> {
 	await env.DB.prepare(
-		`INSERT INTO reviews (repository_id, installation_id, pr_number, trigger_event, status, agent_slug, agent_instance_id)
-		 VALUES (?1, ?2, ?3, ?4, 'running', ?5, ?6)`,
+		`INSERT INTO reviews (repository_id, installation_id, pr_number, trigger_event, status, agent_slug, agent_instance_id, risk_tier)
+		 VALUES (?1, ?2, ?3, ?4, 'running', ?5, ?6, ?7)`,
 	)
-		.bind(repositoryId, installationId, prNumber, trigger, agentSlug, agentInstanceId)
+		.bind(repositoryId, installationId, prNumber, trigger, agentSlug, agentInstanceId, riskTier)
 		.run();
 }
 
@@ -149,17 +150,18 @@ export async function recordReview(
 export async function completeReview(
 	agentInstanceId: string,
 	reviewUrl: string | null,
+	findingsCount: number | null = null,
 ): Promise<void> {
 	await env.DB.prepare(
 		`UPDATE reviews
-		 SET status = 'completed', completed_at = datetime('now'), review_url = ?2
+		 SET status = 'completed', completed_at = datetime('now'), review_url = ?2, findings_count = ?3
 		 WHERE id = (
 			SELECT id FROM reviews
 			WHERE agent_instance_id = ?1 AND status = 'running'
 			ORDER BY id DESC LIMIT 1
 		 )`,
 	)
-		.bind(agentInstanceId, reviewUrl)
+		.bind(agentInstanceId, reviewUrl, findingsCount)
 		.run();
 }
 
@@ -499,6 +501,8 @@ export interface ReviewActivityRow {
 	model: string | null;
 	agent_slug: string | null; // null on rows predating multi-agent support
 	agent_instance_id: string | null;
+	risk_tier: string | null; // null before tiering, and on mention/manual dispatch
+	findings_count: number | null; // null until post_review completes the row
 	repo_owner: string | null; // null if the repo was since removed
 	repo_name: string | null;
 }
@@ -604,6 +608,7 @@ export interface DashboardStats {
 	month_cost_usd: number;
 	month_tokens: number;
 	avg_duration_s: number | null; // completed reviews this month
+	avg_findings: number | null; // findings per completed review this month
 	running: number;
 }
 
@@ -613,6 +618,7 @@ export async function dashboardStats(installationIds: number[]): Promise<Dashboa
 		month_cost_usd: 0,
 		month_tokens: 0,
 		avg_duration_s: null,
+		avg_findings: null,
 		running: 0,
 	};
 	if (installationIds.length === 0) return empty;
@@ -626,6 +632,9 @@ export async function dashboardStats(installationIds: number[]): Promise<Dashboa
 			AVG(CASE WHEN status = 'completed' AND completed_at IS NOT NULL
 				AND strftime('%Y-%m', created_at) = strftime('%Y-%m', 'now')
 				THEN (julianday(completed_at) - julianday(created_at)) * 86400 END) AS avg_duration_s,
+			AVG(CASE WHEN status = 'completed' AND findings_count IS NOT NULL
+				AND strftime('%Y-%m', created_at) = strftime('%Y-%m', 'now')
+				THEN findings_count END) AS avg_findings,
 			COALESCE(SUM(status = 'running'), 0) AS running
 		 FROM reviews
 		 WHERE installation_id IN (${placeholders})`,

--- a/src/lib/risk.ts
+++ b/src/lib/risk.ts
@@ -1,0 +1,71 @@
+import { env } from 'cloudflare:workers';
+import { gh, NOISE_PATTERNS } from '../tools/github.ts';
+import { installationToken } from './github-app.ts';
+import { DEFAULT_AGENT_SLUG } from './personas.ts';
+
+// Risk-tiered dispatch, after Cloudflare's AI code review setup: small
+// mechanical changes get one generalist pass, mid-size changes a reduced
+// fleet, and large or security-sensitive changes every enabled agent. Only
+// automatic (PR open/ready) dispatch tiers; mentions and the /review
+// endpoint are explicit intent and always run what was asked.
+
+export type RiskTier = 'trivial' | 'lite' | 'full';
+
+// Reviewable (noise-filtered) line budget per tier.
+const TRIVIAL_MAX_LINES = 10;
+const LITE_MAX_LINES = 100;
+// At or past this many changed files it's a full review regardless of lines.
+const FULL_MIN_FILES = 50;
+
+// Paths whose changes always escalate to a full review regardless of size:
+// auth/crypto/secret-adjacent code and CI workflow definitions.
+const SENSITIVE_PATH =
+	/auth|crypto|secret|token|session|password|permission|security|\.github\/workflows\//i;
+
+// Built-in slugs that still run on a mid-size ("lite") PR.
+const LITE_SLUGS = new Set([DEFAULT_AGENT_SLUG, 'security']);
+
+interface PrFileEntry {
+	filename: string;
+	additions: number;
+	deletions: number;
+}
+
+export async function computeRiskTier(
+	installationId: number,
+	owner: string,
+	repo: string,
+	prNumber: number,
+): Promise<RiskTier> {
+	const token = await installationToken(installationId);
+	// One page suffices: at 50+ files the tier is already 'full', so anything
+	// past the first 100 can't change the answer.
+	const res = await gh(token, `/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100`);
+	const files = (await res.json()) as PrFileEntry[];
+
+	if (files.length >= FULL_MIN_FILES) return 'full';
+	if (files.some((f) => SENSITIVE_PATH.test(f.filename))) return 'full';
+
+	const lines = files
+		.filter((f) => !NOISE_PATTERNS.some((n) => n.pattern.test(f.filename)))
+		.reduce((n, f) => n + f.additions + f.deletions, 0);
+	if (lines <= TRIVIAL_MAX_LINES) return 'trivial';
+	return lines <= LITE_MAX_LINES ? 'lite' : 'full';
+}
+
+// The subset of enabled agents a tier dispatches. Installations running only
+// custom agents (no built-ins enabled) keep exactly one reviewer on small
+// PRs: the first enabled agent (the list orders built-ins first, then name).
+export function agentsForTier<T extends { slug: string }>(tier: RiskTier, enabled: T[]): T[] {
+	if (tier === 'full') return enabled;
+	const wanted = tier === 'trivial' ? new Set([DEFAULT_AGENT_SLUG]) : LITE_SLUGS;
+	const subset = enabled.filter((a) => wanted.has(a.slug));
+	return subset.length > 0 ? subset : enabled.slice(0, 1);
+}
+
+// Optional cheap-model override for trivial reviews. TRIVIAL_MODEL is a
+// gateway model id in wrangler.jsonc vars; empty disables the downgrade and
+// trivial reviews run each agent's configured model.
+export function tierModelOverride(tier: RiskTier): string | undefined {
+	return tier === 'trivial' && env.TRIVIAL_MODEL ? env.TRIVIAL_MODEL : undefined;
+}

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -226,7 +226,13 @@ function reviewRow(r: ReviewActivityRow) {
 	return html`<tr>
 		<td>
 			${prUrl ? html`<a href="${prUrl}">${repoFull}#${r.pr_number}</a>` : html`${repoFull}#${r.pr_number}`}
-			<span class="muted">&middot; ${r.agent_slug ?? 'review'} &middot; ${r.trigger_event}</span>
+			<span class="muted"
+				>&middot; ${r.agent_slug ?? 'review'} &middot; ${r.trigger_event}${r.risk_tier
+					? html` &middot; ${r.risk_tier}`
+					: ''}${r.findings_count !== null
+					? html` &middot; ${r.findings_count} finding${r.findings_count === 1 ? '' : 's'}`
+					: ''}</span
+			>
 		</td>
 		<td>${statusPill(r)}</td>
 		<td class="num">${tokens > 0 ? fmtTokens(tokens) : html`<span class="muted">—</span>`}</td>
@@ -384,7 +390,11 @@ export function createSettingsRoutes() {
 						<div class="tile">
 							<div class="label">avg review time</div>
 							<div class="value">${stats.avg_duration_s !== null ? fmtDuration(stats.avg_duration_s) : '—'}</div>
-							<div class="sub">${fmtTokens(stats.month_tokens)} tokens this month</div>
+							<div class="sub">
+								${fmtTokens(stats.month_tokens)} tokens this month${stats.avg_findings !== null
+									? html` &middot; ${stats.avg_findings.toFixed(1)} findings/review`
+									: ''}
+							</div>
 						</div>
 						<div class="tile">
 							<div class="label">connected repos</div>

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -16,8 +16,8 @@ import {
 	type AgentRow,
 	type RepositoryRow,
 } from '../lib/db.ts';
-import { DEFAULT_AGENT_SLUG } from '../lib/personas.ts';
 import { reactToIssueComment, verifyWebhookSignature } from '../lib/github-app.ts';
+import { agentsForTier, computeRiskTier, tierModelOverride, type RiskTier } from '../lib/risk.ts';
 
 // GitHub App webhook receiver. Three jobs:
 //   1. Mirror installation / repository-selection changes into D1.
@@ -83,6 +83,7 @@ export type ReviewDispatcher = (
 	prNumber: number,
 	prUrl: string,
 	trigger: string,
+	opts?: { riskTier?: string; modelOverride?: string },
 ) => Promise<boolean>;
 
 // A Hono sub-app; the caller supplies dispatch so this module doesn't need to
@@ -185,10 +186,25 @@ async function handlePullRequest(
 		return { body: { ok: true, skipped: 'installation missing or suspended' } };
 	}
 
-	const agents = (await listAgentsForRepo(repo)).filter((a) => a.enabled);
-	if (agents.length === 0) return { body: { ok: true, skipped: 'no agents enabled' } };
+	const enabled = (await listAgentsForRepo(repo)).filter((a) => a.enabled);
+	if (enabled.length === 0) return { body: { ok: true, skipped: 'no agents enabled' } };
 
-	// The daily cap counts agent-runs, so N enabled agents consume N units.
+	// Classify the PR before spending budget: small mechanical changes get one
+	// generalist, only large or security-sensitive ones the full fleet. Fail
+	// open to 'full' — a tiering hiccup must widen review, never skip it.
+	let tier: RiskTier = 'full';
+	try {
+		tier = await computeRiskTier(repo.installation_id, repo.owner, repo.name, p.number);
+	} catch (err) {
+		console.warn(
+			`turbodiff: risk tier computation failed for ${p.repository.full_name}#${p.number}, defaulting to full:`,
+			err,
+		);
+	}
+	const agents = agentsForTier(tier, enabled);
+	const modelOverride = tierModelOverride(tier);
+
+	// The daily cap counts agent-runs, so N selected agents consume N units.
 	const budget = await remainingDailyBudget(repo.installation_id, installation.account_login);
 	if (budget <= 0) return { body: { ok: true, skipped: 'daily review limit reached' } };
 	if (agents.length > budget) {
@@ -199,13 +215,14 @@ async function handlePullRequest(
 
 	const dispatched: string[] = [];
 	for (const agent of agents.slice(0, budget)) {
-		if (await dispatch(agent, repo, p.number, p.pull_request.html_url, p.action)) {
+		const opts = { riskTier: tier, ...(modelOverride ? { modelOverride } : {}) };
+		if (await dispatch(agent, repo, p.number, p.pull_request.html_url, p.action, opts)) {
 			dispatched.push(agent.slug);
 		}
 	}
 	if (dispatched.length === 0) return { body: { error: 'dispatch failed' }, status: 502 };
 	return {
-		body: { ok: true, review: `${p.repository.full_name}#${p.number}`, agents: dispatched },
+		body: { ok: true, review: `${p.repository.full_name}#${p.number}`, tier, agents: dispatched },
 	};
 }
 

--- a/src/tools/github.ts
+++ b/src/tools/github.ts
@@ -23,7 +23,7 @@ async function tokenFor(owner: string, repo: string): Promise<string> {
 	return installationToken(row.installation_id);
 }
 
-async function gh(
+export async function gh(
 	token: string,
 	path: string,
 	init?: RequestInit & { accept?: string },
@@ -50,8 +50,10 @@ function truncate(text: string, max: number, label: string): string {
 }
 
 // Files whose diffs are machine noise: no reviewable intent, and large enough
-// to eat the truncation budget before the real code gets seen.
-const NOISE_PATTERNS: { pattern: RegExp; reason: string }[] = [
+// to eat the truncation budget before the real code gets seen. Also consumed
+// by the risk-tier computation (src/lib/risk.ts) so noise churn doesn't
+// inflate a PR's reviewable size.
+export const NOISE_PATTERNS: { pattern: RegExp; reason: string }[] = [
 	{
 		pattern:
 			/(^|\/)(package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb?|deno\.lock|Cargo\.lock|Gemfile\.lock|poetry\.lock|uv\.lock|Pipfile\.lock|composer\.lock|flake\.lock|go\.sum|gradle\.lockfile)$/,
@@ -246,8 +248,9 @@ export const makePostReview = (agentInstanceId: string) =>
 				};
 			}
 			// Flip this dispatch's row to completed so /reviews stops showing it
-			// as running.
-			await completeReview(agentInstanceId, output.url);
+			// as running. The findings count feeds the noise metric on the
+			// dashboard (fallback-posted findings still count — they reached the PR).
+			await completeReview(agentInstanceId, output.url, data.findings.length);
 			return { output };
 		},
 	});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,7 +26,11 @@
 		// install/manage links in the settings UI.
 		"GITHUB_APP_SLUG": "turbodiff",
 		// Max auto-triggered reviews per installation per rolling 24h.
-		"REVIEW_DAILY_LIMIT": "50"
+		"REVIEW_DAILY_LIMIT": "50",
+		// Optional gateway model id used instead of each agent's configured
+		// model on trivial-tier PRs (≤10 reviewable lines) — set a cheap model
+		// (e.g. a haiku-class id) to cut cost. Empty disables the downgrade.
+		"TRIVIAL_MODEL": ""
 	},
 	// Every agent generates a Durable Object class named after its identity
 	// (PrReviewer -> FluePrReviewerAgent), and Cloudflare requires a migration


### PR DESCRIPTION
Second PR adopting patterns from [Cloudflare's AI code review write-up](https://blog.cloudflare.com/ai-code-review/), stacked on #5 (it reuses `NOISE_PATTERNS` so lockfile churn doesn't inflate a PR's size).

## Risk tiers (`src/lib/risk.ts`)
Auto-dispatch classifies each PR from `GET /pulls/N/files` before spending daily budget:

| Tier | Criteria (noise-filtered lines) | Agents dispatched |
|------|------|------|
| trivial | ≤10 lines | default `review` agent only |
| lite | ≤100 lines | `review` + `security` |
| full | >100 lines, ≥50 files, or any security-sensitive path | every enabled agent |

- Security-adjacent paths (`auth|crypto|secret|token|session|password|permission|security`) and `.github/workflows/` always escalate to full, regardless of size.
- Lockfiles/minified/source-map churn is excluded from the line count — a lockfile-only PR is trivial.
- Tiering failures **fail open to full**: an API hiccup widens review, never skips it.
- Installations running only custom agents keep exactly one reviewer on small PRs.
- Mentions and the manual `/review` endpoint bypass tiering — explicit intent runs what was asked.

## Cost lever
New optional `TRIVIAL_MODEL` var: a gateway model id used instead of each agent's configured model on trivial PRs (set a haiku-class id to cut cost; empty disables, which is the default).

## Measurement (migration 0006)
`reviews.risk_tier` and `reviews.findings_count` (recorded by `post_review`). The `/reviews` list shows tier + findings per row, and the dashboard now shows **findings/review** — the noise metric this series exists to move (Cloudflare's production benchmark: ~1.2).

## Validation
- `pnpm exec tsc --noEmit` clean; `vp check --no-fmt` — 0 errors, 0 warnings (the pre-existing unused-import warning in webhooks.ts is resolved as a side effect)
- Tier/selection logic exercised standalone: 17/17 cases pass (thresholds incl. boundaries, sensitive-path and file-count escalation, noise exclusion, per-tier agent subsets, custom-only fallback)
- Deploy note: apply migration 0006 (`wrangler d1 migrations apply turbodiff --remote`) before or with the deploy — `recordReview` now inserts `risk_tier`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)