### PR TITLE
Harden the software factory (check gate, factory-PR gate, atomic cap)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@
 # The tag must match the installed @cloudflare/sandbox SDK version.
 FROM docker.io/cloudflare/sandbox:0.12.4
 
-# Coding agent CLI used by the fix runner. Preinstalled so fix runs don't pay
-# an npm install on every container cold start.
-RUN npm install -g @anthropic-ai/claude-code
+# Coding agent CLI used by the fix/generation runners, plus pnpm for repos
+# whose check_command installs dependencies. Preinstalled so runs don't pay
+# the install on every container cold start.
+RUN npm install -g @anthropic-ai/claude-code pnpm
 
 EXPOSE 8080

--- a/migrations/0011_check_command.sql
+++ b/migrations/0011_check_command.sql
@@ -1,0 +1,4 @@
+-- Per-repo verification gate for factory runs (fixer + generator): a shell
+-- command (typically install + typecheck/tests) that must succeed in the
+-- sandbox before any generated or fixed code is pushed. NULL disables the gate.
+ALTER TABLE repositories ADD COLUMN check_command TEXT;

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import {
 	getAgentBySlug,
 	getFeature,
 	getRepoByFullName,
+	setRepoCheckCommand,
 	listAgentConnections,
 	listAgentsForRepo,
 	recordReview,
@@ -170,6 +171,20 @@ app.post('/internal/generate', async (c) => {
 	return c.json({ accepted: true, feature_id: featureId, status_url: `/internal/features/${featureId}` });
 });
 
+// Set the sandbox verification gate for a repo (dashboard field lives in
+// settings; this is the operator/API path). Empty command clears the gate.
+app.post('/internal/repos/check-command', async (c) => {
+	const payload = await c.req.json<{ repo?: string; command?: string }>().catch(() => null);
+	const match = payload?.repo?.match(/^([\w.-]+)\/([\w.-]+)$/);
+	if (!match || typeof payload?.command !== 'string') {
+		return c.json({ error: 'body must be {"repo": "<owner>/<name>", "command": "..."}' }, 400);
+	}
+	const repo = await getRepoByFullName(match[1], match[2]);
+	if (!repo) return c.json({ error: `Turbodiff is not installed on ${payload.repo}` }, 404);
+	await setRepoCheckCommand(repo.id, payload.command);
+	return c.json({ ok: true, repo: payload.repo, check_command: payload.command.trim() || null });
+});
+
 app.get('/internal/features/:id', async (c) => {
 	const id = Number(c.req.param('id'));
 	const feature = Number.isInteger(id) ? await getFeature(id) : null;
@@ -208,7 +223,7 @@ app.post('/internal/fix', async (c) => {
 			installationId: repo.installation_id,
 			findings: payload?.findings,
 			authMode: payload?.auth_mode,
-			testCommand: payload?.test_command,
+			testCommand: payload?.test_command ?? repo.check_command ?? undefined,
 		});
 		return c.json(outcome);
 	} catch (err) {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -21,6 +21,7 @@ export interface RepositoryRow {
 	review_on_push: number; // re-dispatch tiered agents on pushes to open PRs
 	blocking_reviews: number; // P1 → REQUEST_CHANGES, clean → APPROVE
 	auto_fix: number; // dispatch the fix agent when a blocking review lands
+	check_command: string | null; // sandbox verification gate before factory pushes
 	model: string | null;
 	created_at: string; // when the repo was connected (mirrored into D1)
 }
@@ -148,6 +149,14 @@ export async function setRepoAutoFix(id: number, on: boolean): Promise<void> {
 		.run();
 }
 
+// The sandbox verification gate for factory pushes. Empty string clears it.
+export async function setRepoCheckCommand(id: number, command: string): Promise<void> {
+	const trimmed = command.trim();
+	await env.DB.prepare('UPDATE repositories SET check_command = ?2 WHERE id = ?1')
+		.bind(id, trimmed || null)
+		.run();
+}
+
 // --- fix attempts (auto-fix loop bookkeeping + iteration cap) ---
 
 // Every attempt counts toward the cap regardless of outcome, so even a
@@ -161,17 +170,33 @@ export async function countFixAttempts(repositoryId: number, prNumber: number): 
 	return row?.n ?? 0;
 }
 
-export async function recordFixAttempt(
+// Records an attempt only while under the cap, in a single statement so two
+// concurrent consumers can't both slip past the count check. Returns null when
+// the cap is reached. Sweeps zombie rows first: a consumer killed at the
+// platform's wall clock never finishes its row, so old 'running' rows are
+// closed as failed rather than lying on the dashboard forever.
+export async function tryRecordFixAttempt(
 	repositoryId: number,
 	prNumber: number,
 	trigger: string,
-): Promise<number> {
-	const row = await env.DB.prepare(
-		'INSERT INTO fix_attempts (repository_id, pr_number, "trigger") VALUES (?1, ?2, ?3) RETURNING id',
+	cap: number,
+): Promise<number | null> {
+	await env.DB.prepare(
+		`UPDATE fix_attempts SET status = 'failed', error = 'stale: consumer killed before completion'
+		 WHERE repository_id = ?1 AND pr_number = ?2 AND status = 'running'
+		 AND created_at < datetime('now', '-20 minutes')`,
 	)
-		.bind(repositoryId, prNumber, trigger)
+		.bind(repositoryId, prNumber)
+		.run();
+	const row = await env.DB.prepare(
+		`INSERT INTO fix_attempts (repository_id, pr_number, "trigger")
+		 SELECT ?1, ?2, ?3
+		 WHERE (SELECT COUNT(*) FROM fix_attempts WHERE repository_id = ?1 AND pr_number = ?2) < ?4
+		 RETURNING id`,
+	)
+		.bind(repositoryId, prNumber, trigger, cap)
 		.first<{ id: number }>();
-	return row!.id;
+	return row?.id ?? null;
 }
 
 // --- features (Phase 2: spec → generated branch + PR) ---

--- a/src/lib/fixer.ts
+++ b/src/lib/fixer.ts
@@ -1,7 +1,7 @@
 import { getSandbox, type Sandbox } from '@cloudflare/sandbox';
 import { env } from 'cloudflare:workers';
 import { gh } from '../tools/github.ts';
-import { countFixAttempts, finishFixAttempt, getRepoById, recordFixAttempt } from './db.ts';
+import { finishFixAttempt, getRepoById, tryRecordFixAttempt } from './db.ts';
 import { installationToken } from './github-app.ts';
 
 // Phase 1 spike of the software factory fix loop (docs/software-factory-design.md):
@@ -41,9 +41,10 @@ export interface FixOutcome {
 const CLONE_DIR = '/workspace/repo';
 const TASK_FILE = '/workspace/fix-task.md';
 const NOTES_FILE = '/workspace/fix-notes.md';
-// Agent + tests + git must fit inside a queue consumer's 15-minute wall clock.
-const AGENT_TIMEOUT_MS = 10 * 60_000;
-const TEST_TIMEOUT_MS = 3 * 60_000;
+// Clone (2) + agent (8) + checks (4) + push (1) must fit inside a queue
+// consumer's 15-minute wall clock; typical runs use a fraction of each budget.
+const AGENT_TIMEOUT_MS = 8 * 60_000;
+const TEST_TIMEOUT_MS = 4 * 60_000;
 
 // Fix runs per PR across all triggers. A fix push causes a re-review, which
 // can cause another blocking review and another fix — the cap guarantees the
@@ -121,9 +122,16 @@ async function latestBlockingFindings(
 		body: string;
 		user: { login: string; type: string } | null;
 	}[];
-	const blocking = reviews.filter(
-		(r) => r.state === 'CHANGES_REQUESTED' && r.user?.type === 'Bot',
-	).at(-1);
+	// A blocking verdict on a self-authored (factory) PR is downgraded to a
+	// COMMENT review with the intended verdict in the body — match both forms.
+	const blocking = reviews
+		.filter(
+			(r) =>
+				r.user?.type === 'Bot' &&
+				(r.state === 'CHANGES_REQUESTED' ||
+					(r.state === 'COMMENTED' && r.body.startsWith('**Verdict: REQUEST_CHANGES**'))),
+		)
+		.at(-1);
 	if (!blocking) return null;
 
 	const comments = (await (
@@ -257,6 +265,18 @@ export async function runFix(params: FixParams): Promise<FixOutcome> {
 			return { status: 'no_changes', authMode: auth.mode, branch: headRef, notes, agentOutput };
 		}
 
+		// Commit the fix BEFORE running checks so check-command working-tree
+		// mutations (dep installs, config edits) never leak into the pushed
+		// commit. Local until checks pass and we push.
+		const committed = await sandbox.exec(
+			`git -C ${CLONE_DIR} add -A && ` +
+				`git -C ${CLONE_DIR} commit -m "Address review findings on #${prNumber} (turbodiff fix agent)"`,
+			{ timeout: 60_000 },
+		);
+		if (!committed.success) {
+			throw new Error(`git commit failed: ${scrub(committed.stderr).slice(0, 500)}`);
+		}
+
 		let testOutput: string | undefined;
 		if (params.testCommand) {
 			const tests = await sandbox.exec(params.testCommand, {
@@ -277,9 +297,7 @@ export async function runFix(params: FixParams): Promise<FixOutcome> {
 		}
 
 		const push = await sandbox.exec(
-			`git -C ${CLONE_DIR} add -A && ` +
-				`git -C ${CLONE_DIR} commit -m "Address review findings on #${prNumber} (turbodiff fix agent)" && ` +
-				`git -C ${CLONE_DIR} push origin HEAD:"$FIX_BRANCH"`,
+			`git -C ${CLONE_DIR} push origin HEAD:"$FIX_BRANCH"`,
 			{ env: gitEnv, timeout: 2 * 60_000 },
 		);
 		if (!push.success) {
@@ -325,23 +343,35 @@ export async function processFixMessage(msg: FixQueueMessage): Promise<void> {
 	}
 	const label = `${repo.owner}/${repo.name}#${msg.prNumber}`;
 
-	const attempts = await countFixAttempts(repo.id, msg.prNumber);
-	if (attempts >= FIX_MAX_ATTEMPTS) {
-		console.warn(`turbodiff: fix cap reached for ${label} (${attempts} attempts)`);
-		await postHandoffComment(repo.installation_id, repo.owner, repo.name, msg.prNumber, attempts);
+	// The cap check and the attempt insert are one atomic statement — two
+	// concurrent deliveries for the same PR can't both start a run past the cap.
+	const attemptId = await tryRecordFixAttempt(
+		repo.id,
+		msg.prNumber,
+		msg.trigger,
+		FIX_MAX_ATTEMPTS,
+	);
+	if (attemptId === null) {
+		console.warn(`turbodiff: fix cap reached for ${label}`);
+		await postHandoffComment(
+			repo.installation_id,
+			repo.owner,
+			repo.name,
+			msg.prNumber,
+			FIX_MAX_ATTEMPTS,
+		);
 		return;
 	}
-
-	const attemptId = await recordFixAttempt(repo.id, msg.prNumber, msg.trigger);
 	try {
 		const outcome = await runFix({
 			owner: repo.owner,
 			repo: repo.name,
 			prNumber: msg.prNumber,
 			installationId: repo.installation_id,
+			testCommand: repo.check_command ?? undefined,
 		});
 		await finishFixAttempt(attemptId, outcome.status, outcome.commit);
-		console.log(`turbodiff: fix ${outcome.status} for ${label} (attempt ${attempts + 1})`);
+		console.log(`turbodiff: fix ${outcome.status} for ${label} (attempt ${attemptId})`);
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		await finishFixAttempt(attemptId, 'failed', undefined, message.slice(0, 500));

--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -13,8 +13,10 @@ import { installationToken } from './github-app.ts';
 
 const CLONE_DIR = '/workspace/gen';
 const SPEC_FILE = '/workspace/gen-spec.md';
-// Clone + agent + push must fit inside a queue consumer's 15-minute wall clock.
-const AGENT_TIMEOUT_MS = 10 * 60_000;
+// Clone (2) + agent (8) + checks (4) + push (1) must fit inside a queue
+// consumer's 15-minute wall clock.
+const AGENT_TIMEOUT_MS = 8 * 60_000;
+const CHECK_TIMEOUT_MS = 4 * 60_000;
 
 export interface GenQueueMessage {
 	kind: 'generate';
@@ -135,10 +137,37 @@ async function generate(
 			return { status: 'no_changes', error: 'agent produced no file changes' };
 		}
 
-		const push = await sandbox.exec(
+		// Commit the agent's changes BEFORE running checks: the check command may
+		// mutate the working tree (installing deps, editing config), and those
+		// mutations must never end up in the pushed commit. The commit is local
+		// only until the check passes and we push.
+		const commit = await sandbox.exec(
 			`git -C ${CLONE_DIR} add -A && ` +
-				`git -C ${CLONE_DIR} commit -m "${feature.title.replaceAll('"', "'")} (turbodiff generator, feature #${feature.id})" && ` +
-				`git -C ${CLONE_DIR} push origin HEAD:"$GEN_BRANCH"`,
+				`git -C ${CLONE_DIR} commit -m "${feature.title.replaceAll('"', "'")} (turbodiff generator, feature #${feature.id})"`,
+			{ timeout: 60_000 },
+		);
+		if (!commit.success) {
+			throw new Error(`git commit failed: ${scrub(commit.stderr).slice(0, 500)}`);
+		}
+
+		// Verification gate: generated code must pass the repo's checks before the
+		// commit is allowed to become a PR. Runs against the committed tree; any
+		// files the check dirties stay in the working tree and are never pushed.
+		if (repo.check_command) {
+			const checks = await sandbox.exec(repo.check_command, {
+				cwd: CLONE_DIR,
+				timeout: CHECK_TIMEOUT_MS,
+			});
+			if (!checks.success) {
+				return {
+					status: 'checks_failed',
+					error: scrub(`${checks.stdout}\n${checks.stderr}`.trim()).slice(-500),
+				};
+			}
+		}
+
+		const push = await sandbox.exec(
+			`git -C ${CLONE_DIR} push origin HEAD:"$GEN_BRANCH"`,
 			{ env: gitEnv, timeout: 2 * 60_000 },
 		);
 		if (!push.success) {

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -28,6 +28,7 @@ import {
 	setRepoAgentEnabled,
 	setRepoAutoFix,
 	setRepoBlockingReviews,
+	setRepoCheckCommand,
 	setRepoEnabled,
 	setRepoReviewOnPush,
 	updateAgent,
@@ -1005,6 +1006,15 @@ export function createSettingsRoutes() {
 																				&#128295; auto-fix
 																			</button>
 																		</form>
+																		<form method="post" action="/repos/${r.id}/check-command" class="check-cmd">
+																			<input
+																				type="text"
+																				name="command"
+																				value="${r.check_command ?? ''}"
+																				placeholder="check command (e.g. npm ci && npm test) — blocks factory pushes on failure"
+																			/>
+																			<button class="chip">save</button>
+																		</form>
 																	</div>`
 																: ''}
 														</td>
@@ -1087,6 +1097,21 @@ export function createSettingsRoutes() {
 		}
 
 		await setRepoAutoFix(repo.id, !repo.auto_fix);
+		return c.redirect('/settings');
+	});
+
+	app.post('/repos/:id/check-command', async (c) => {
+		const user = await requireUser(c);
+		if (!user) return c.redirect('/auth/login');
+
+		const repoId = Number(c.req.param('id'));
+		const repo = Number.isInteger(repoId) ? await getRepoById(repoId) : null;
+		if (!repo || !user.installationIds.includes(repo.installation_id)) {
+			return c.text('unknown repository', 404);
+		}
+
+		const form = await c.req.parseBody();
+		await setRepoCheckCommand(repo.id, typeof form.command === 'string' ? form.command : '');
 		return c.redirect('/settings');
 	});
 

--- a/src/tools/github.ts
+++ b/src/tools/github.ts
@@ -1,4 +1,5 @@
 import { defineTool } from '@flue/runtime';
+import { env } from 'cloudflare:workers';
 import * as v from 'valibot';
 import { completeReview, getRepoByFullName } from '../lib/db.ts';
 import { installationToken } from '../lib/github-app.ts';
@@ -370,41 +371,65 @@ export const makePostReview = (agentInstanceId: string) =>
 				body: f.body,
 			}));
 
-			let output: { posted: boolean; inline: number; url: string | null; fallback: string | null };
-			try {
-				const res = await gh(token, path, {
-					method: 'POST',
-					body: JSON.stringify({ body: data.body, event, comments }),
-				});
-				const review = (await res.json()) as { html_url?: string };
-				output = {
-					posted: true,
-					inline: comments.length,
-					url: review.html_url ?? null,
-					fallback: null,
-				};
-			} catch (err) {
-				// GitHub 422s the whole review if any single comment anchors outside
-				// the diff. Rather than lose the review, repost with the findings
-				// folded into the summary body.
-				if (comments.length === 0 || !String(err).includes('422')) throw err;
-				const fallbackBody = `${data.body}\n\n### Findings\n\n${findingsAsMarkdown(data.findings)}`;
-				const res = await gh(token, path, {
-					method: 'POST',
-					body: JSON.stringify({ body: fallbackBody, event }),
-				});
-				const review = (await res.json()) as { html_url?: string };
-				output = {
-					posted: true,
-					inline: 0,
-					url: review.html_url ?? null,
-					fallback: 'inline comments failed to anchor; findings were folded into the review body',
-				};
+			// Two recoverable 422 classes, retried in a bounded loop:
+			//   - self-authored PR: GitHub refuses APPROVE/REQUEST_CHANGES from the
+			//     PR author (factory-generated PRs) — downgrade to COMMENT, keeping
+			//     the intended verdict visible in the body.
+			//   - bad anchor: any single comment outside the diff fails the whole
+			//     review — fold findings into the summary body.
+			const intended = event;
+			let postEvent = event;
+			let postBody = data.body;
+			let postComments = comments;
+			let fallback: string | null = null;
+			let review: { html_url?: string };
+			for (let attempt = 0; ; attempt++) {
+				try {
+					const res = await gh(token, path, {
+						method: 'POST',
+						body: JSON.stringify({ body: postBody, event: postEvent, comments: postComments }),
+					});
+					review = (await res.json()) as { html_url?: string };
+					break;
+				} catch (err) {
+					const msg = String(err);
+					if (!msg.includes('422') || attempt >= 2) throw err;
+					if (/own pull request/i.test(msg) && postEvent !== 'COMMENT') {
+						postEvent = 'COMMENT';
+						postBody =
+							`**Verdict: ${intended}** _(posted as a comment — GitHub does not let the PR author ` +
+							`review its own pull request)_\n\n${postBody}`;
+						fallback = 'self-authored PR: verdict downgraded to COMMENT';
+					} else if (postComments.length > 0) {
+						postBody = `${postBody}\n\n### Findings\n\n${findingsAsMarkdown(data.findings)}`;
+						postComments = [];
+						fallback = 'inline comments failed to anchor; findings were folded into the review body';
+					} else {
+						throw err;
+					}
+				}
 			}
+			const output = {
+				posted: true,
+				inline: postComments.length,
+				url: review.html_url ?? null,
+				fallback,
+			};
 			// Flip this dispatch's row to completed so /reviews stops showing it
 			// as running. The findings count feeds the noise metric on the
 			// dashboard (fallback-posted findings still count — they reached the PR).
 			await completeReview(agentInstanceId, output.url, data.findings.length);
+			// Factory-PR gate: a blocking verdict on a self-authored PR never fires
+			// the pull_request_review webhook trigger (the posted state is COMMENT),
+			// so enqueue the fix directly. The consumer re-validates toggle and cap.
+			if (intended === 'REQUEST_CHANGES' && postEvent === 'COMMENT' && row.auto_fix === 1) {
+				await env.FACTORY_QUEUE.send({
+					kind: 'fix',
+					repoId: row.id,
+					prNumber: data.number,
+					trigger: 'blocking_review_self',
+				});
+			}
 			return { output };
 		},
 	});


### PR DESCRIPTION
Second iteration on the factory — hardening surfaced by dogfooding Phase 2.

## Changes
- **Verification gate** — per-repo `check_command` runs in the sandbox before any generated or fixed code is pushed. Dashboard field + `POST /internal/repos/check-command` + migration 0011.
- **Commit-before-check ordering** — the check command may mutate the working tree (dep installs, config edits); committing first keeps those mutations out of the pushed commit. (Found via a generated PR polluted with a reformatted `package.json`.)
- **Factory-PR gate** — GitHub 422s a blocking review from the PR author (all factory PRs). We downgrade to a COMMENT with the verdict preserved in the body, and enqueue the fix directly since the `pull_request_review` webhook never fires for a COMMENT.
- **Atomic fix cap** — cap check + attempt insert in one statement; stale `running` rows swept before counting.
- pnpm in the sandbox image.

## Proven this session
- Full pipeline E2E: spec → generated PR (#10, #11) via `/internal/generate`.
- Check gate correctly blocks pushes on failure (repeatedly).
- Deferred to next iteration: prompt-injection posture, prod validation, dependency-install ergonomics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)