### PR TITLE
Phase 3: planning intake (requirements → questions → plan → approve)

### DIFF
--- a/migrations/0012_plans.sql
+++ b/migrations/0012_plans.sql
@@ -1,0 +1,22 @@
+-- Phase 3 of the software factory (docs/software-factory-design.md): a plan is
+-- the front half of the pipeline. A user submits requirements; the planning
+-- agent analyzes the repo, asks clarifying questions, and (after answers)
+-- produces an implementation plan plus machine-checkable acceptance criteria.
+-- On approval the plan becomes a feature and flows into generation.
+CREATE TABLE plans (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	repository_id INTEGER NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+	title TEXT NOT NULL,
+	requirements TEXT NOT NULL, -- the user's initial free-form input
+	analysis TEXT,             -- the agent's grounding analysis (markdown)
+	questions TEXT,            -- clarifying questions, JSON array of strings
+	answers TEXT,              -- the user's answers, JSON array of strings
+	plan TEXT,                 -- the implementation plan (markdown)
+	acceptance TEXT,           -- acceptance criteria, JSON array of strings
+	feature_id INTEGER REFERENCES features(id) ON DELETE SET NULL,
+	status TEXT NOT NULL DEFAULT 'analyzing',
+	-- analyzing | awaiting_answers | refining | plan_ready | approved | failed
+	error TEXT,
+	created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_plans_repo ON plans (repository_id);

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,10 +8,13 @@ import { PrReviewer } from './agents/pr-reviewer.ts';
 import {
 	connectionSnapshot,
 	createFeature,
+	createPlan,
 	getAgentBySlug,
 	getFeature,
+	getPlan,
 	getRepoByFullName,
 	setRepoCheckCommand,
+	updatePlan,
 	listAgentConnections,
 	listAgentsForRepo,
 	recordReview,
@@ -19,6 +22,7 @@ import {
 	type RepositoryRow,
 } from './lib/db.ts';
 import { runFix, sandboxSmoke, type FixAuthMode } from './lib/fixer.ts';
+import { approvePlan } from './lib/planner.ts';
 import { registerReviewMetering } from './lib/metering.ts';
 import { createSettingsRoutes } from './routes/settings.ts';
 import { createWebhookRoutes } from './routes/webhooks.ts';
@@ -171,6 +175,72 @@ app.post('/internal/generate', async (c) => {
 	const featureId = await createFeature(repo.id, payload.title.trim(), payload.spec.trim());
 	await env.FACTORY_QUEUE.send({ kind: 'generate', featureId });
 	return c.json({ accepted: true, feature_id: featureId, status_url: `/internal/features/${featureId}` });
+});
+
+// Software-factory planning intake, Phase 3 (docs/software-factory-design.md).
+// The full front half: requirements → clarifying questions → plan + acceptance
+// criteria → approve → generation.
+//   POST /internal/plans { "repo": "<owner>/<name>", "title": "...", "requirements": "..." }
+// Records the plan and enqueues analysis; poll the status route for questions.
+app.post('/internal/plans', async (c) => {
+	const payload = await c.req
+		.json<{ repo?: string; title?: string; requirements?: string }>()
+		.catch(() => null);
+	const match = payload?.repo?.match(/^([\w.-]+)\/([\w.-]+)$/);
+	if (!match || !payload?.title?.trim() || !payload?.requirements?.trim()) {
+		return c.json(
+			{ error: 'body must be {"repo": "<owner>/<name>", "title": "...", "requirements": "..."}' },
+			400,
+		);
+	}
+	const repo = await getRepoByFullName(match[1], match[2]);
+	if (!repo) return c.json({ error: `Turbodiff is not installed on ${payload.repo}` }, 404);
+	if (!repo.enabled) return c.json({ error: 'reviews are disabled for this repository' }, 409);
+
+	const planId = await createPlan(repo.id, payload.title.trim(), payload.requirements.trim());
+	await env.FACTORY_QUEUE.send({ kind: 'plan_analyze', planId });
+	return c.json({ accepted: true, plan_id: planId, status_url: `/internal/plans/${planId}` });
+});
+
+app.get('/internal/plans/:id', async (c) => {
+	const id = Number(c.req.param('id'));
+	const plan = Number.isInteger(id) ? await getPlan(id) : null;
+	if (!plan) return c.json({ error: 'unknown plan' }, 404);
+	return c.json(plan);
+});
+
+// Submit answers to the clarifying questions; enqueues plan refinement.
+app.post('/internal/plans/:id/answers', async (c) => {
+	const id = Number(c.req.param('id'));
+	const plan = Number.isInteger(id) ? await getPlan(id) : null;
+	if (!plan) return c.json({ error: 'unknown plan' }, 404);
+	if (plan.status !== 'awaiting_answers') {
+		return c.json({ error: `plan is ${plan.status}, not awaiting_answers` }, 409);
+	}
+	const payload = await c.req.json<{ answers?: unknown }>().catch(() => null);
+	if (!Array.isArray(payload?.answers)) {
+		return c.json({ error: 'body must be {"answers": ["...", ...]}' }, 400);
+	}
+	await updatePlan(id, { status: 'refining', answers: JSON.stringify(payload.answers.map(String)) });
+	await env.FACTORY_QUEUE.send({ kind: 'plan_refine', planId: id });
+	return c.json({ accepted: true, plan_id: id, status_url: `/internal/plans/${id}` });
+});
+
+// Approve a ready plan: converts it to a generation feature (spec = plan +
+// acceptance criteria) and enqueues generation.
+app.post('/internal/plans/:id/approve', async (c) => {
+	const id = Number(c.req.param('id'));
+	const featureId = await approvePlan(id);
+	if (featureId === null) {
+		return c.json({ error: 'plan not found or not in plan_ready state' }, 409);
+	}
+	await env.FACTORY_QUEUE.send({ kind: 'generate', featureId });
+	return c.json({
+		accepted: true,
+		plan_id: id,
+		feature_id: featureId,
+		status_url: `/internal/features/${featureId}`,
+	});
 });
 
 // Set the sandbox verification gate for a repo (dashboard field lives in

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -9,6 +9,7 @@
 
 import { processFixMessage, type FixQueueMessage } from './lib/fixer.ts';
 import { runGeneration, type GenQueueMessage } from './lib/generator.ts';
+import { runPlanAnalyze, runPlanRefine, type PlanQueueMessage } from './lib/planner.ts';
 
 // The fixer sandbox container (docs/software-factory-design.md). Declared in
 // wrangler.jsonc under containers/durable_objects with migration tag v2.
@@ -18,13 +19,24 @@ export { Sandbox } from '@cloudflare/sandbox';
 // request can wait on, so producers enqueue and these consumers do the work.
 // Both processors never throw (failures land in fix_attempts / features), so
 // every message acks — a broken run is not retried into repeat token spend.
+type FactoryMessage = FixQueueMessage | GenQueueMessage | PlanQueueMessage;
+
 export default {
-	async queue(batch: MessageBatch<FixQueueMessage | GenQueueMessage>): Promise<void> {
+	async queue(batch: MessageBatch<FactoryMessage>): Promise<void> {
 		for (const message of batch.messages) {
-			if (message.body.kind === 'generate') {
-				await runGeneration(message.body.featureId);
-			} else {
-				await processFixMessage(message.body);
+			const body = message.body;
+			switch (body.kind) {
+				case 'generate':
+					await runGeneration(body.featureId);
+					break;
+				case 'plan_analyze':
+					await runPlanAnalyze(body.planId);
+					break;
+				case 'plan_refine':
+					await runPlanRefine(body.planId);
+					break;
+				default:
+					await processFixMessage(body);
 			}
 			message.ack();
 		}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -246,6 +246,80 @@ export async function updateFeature(
 		.run();
 }
 
+// --- plans (Phase 3: requirements → questions → plan → approve → feature) ---
+
+export interface PlanRow {
+	id: number;
+	repository_id: number;
+	title: string;
+	requirements: string;
+	analysis: string | null;
+	questions: string | null; // JSON array of strings
+	answers: string | null; // JSON array of strings
+	plan: string | null;
+	acceptance: string | null; // JSON array of strings
+	feature_id: number | null;
+	status: string;
+	error: string | null;
+	created_at: string;
+}
+
+export async function createPlan(
+	repositoryId: number,
+	title: string,
+	requirements: string,
+): Promise<number> {
+	const row = await env.DB.prepare(
+		'INSERT INTO plans (repository_id, title, requirements) VALUES (?1, ?2, ?3) RETURNING id',
+	)
+		.bind(repositoryId, title, requirements)
+		.first<{ id: number }>();
+	return row!.id;
+}
+
+export async function getPlan(id: number): Promise<PlanRow | null> {
+	return env.DB.prepare('SELECT * FROM plans WHERE id = ?1').bind(id).first<PlanRow>();
+}
+
+export async function updatePlan(
+	id: number,
+	fields: {
+		status?: string;
+		analysis?: string;
+		questions?: string;
+		answers?: string;
+		plan?: string;
+		acceptance?: string;
+		featureId?: number;
+		error?: string;
+	},
+): Promise<void> {
+	await env.DB.prepare(
+		`UPDATE plans SET
+		 status = COALESCE(?2, status),
+		 analysis = COALESCE(?3, analysis),
+		 questions = COALESCE(?4, questions),
+		 answers = COALESCE(?5, answers),
+		 plan = COALESCE(?6, plan),
+		 acceptance = COALESCE(?7, acceptance),
+		 feature_id = COALESCE(?8, feature_id),
+		 error = COALESCE(?9, error)
+		 WHERE id = ?1`,
+	)
+		.bind(
+			id,
+			fields.status ?? null,
+			fields.analysis ?? null,
+			fields.questions ?? null,
+			fields.answers ?? null,
+			fields.plan ?? null,
+			fields.acceptance ?? null,
+			fields.featureId ?? null,
+			fields.error ?? null,
+		)
+		.run();
+}
+
 export async function finishFixAttempt(
 	id: number,
 	status: string,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -281,6 +281,35 @@ export async function getPlan(id: number): Promise<PlanRow | null> {
 	return env.DB.prepare('SELECT * FROM plans WHERE id = ?1').bind(id).first<PlanRow>();
 }
 
+export interface PlanWithRepo extends PlanRow {
+	owner: string;
+	name: string;
+	installation_id: number;
+	pr_number: number | null; // from the linked feature, if generation started
+}
+
+// Plans across the given installations, newest first, with repo + generated-PR
+// context for the dashboard.
+export async function listPlansForInstallations(
+	installationIds: number[],
+	limit = 50,
+): Promise<PlanWithRepo[]> {
+	if (installationIds.length === 0) return [];
+	const placeholders = installationIds.map((_, i) => `?${i + 2}`).join(', ');
+	const res = await env.DB.prepare(
+		`SELECT p.*, r.owner, r.name, r.installation_id, f.pr_number AS pr_number
+		 FROM plans p
+		 JOIN repositories r ON r.id = p.repository_id
+		 LEFT JOIN features f ON f.id = p.feature_id
+		 WHERE r.installation_id IN (${placeholders})
+		 ORDER BY p.id DESC
+		 LIMIT ?1`,
+	)
+		.bind(limit, ...installationIds)
+		.all<PlanWithRepo>();
+	return res.results;
+}
+
 export async function updatePlan(
 	id: number,
 	fields: {

--- a/src/lib/planner.ts
+++ b/src/lib/planner.ts
@@ -1,0 +1,239 @@
+import { getSandbox, type Sandbox } from '@cloudflare/sandbox';
+import { env } from 'cloudflare:workers';
+import { gh } from '../tools/github.ts';
+import { createFeature, getPlan, getRepoById, updatePlan, type PlanRow, type RepositoryRow } from './db.ts';
+import { resolveRunnerAuth } from './fixer.ts';
+import { installationToken } from './github-app.ts';
+
+// Phase 3 of the software factory (docs/software-factory-design.md): the
+// planning front half. A planning agent clones the repo (read-only), analyzes
+// the requirements against the real code, asks clarifying questions, and — once
+// answered — produces an implementation plan plus machine-checkable acceptance
+// criteria. On approval the plan becomes a feature and flows into generation.
+
+const CLONE_DIR = '/workspace/plan-repo';
+const OUT_DIR = '/workspace/plan-out';
+const AGENT_TIMEOUT_MS = 8 * 60_000;
+
+export type PlanQueueMessage =
+	| { kind: 'plan_analyze'; planId: number }
+	| { kind: 'plan_refine'; planId: number };
+
+// Boot a read-only clone of the repo's default branch in a sandbox and return
+// it plus a token scrubber. Callers must scrub the remote in a finally block.
+async function clonePlanRepo(
+	repo: RepositoryRow,
+	planId: number,
+): Promise<{ sandbox: Sandbox; token: string; scrub: (s: string) => string }> {
+	const token = await installationToken(repo.installation_id);
+	const scrub = (s: string) => s.replaceAll(token, '***');
+	const full = `${repo.owner}/${repo.name}`;
+	const info = (await (await gh(token, `/repos/${full}`)).json()) as { default_branch: string };
+
+	const sandbox = getSandbox(
+		env.Sandbox as unknown as DurableObjectNamespace<Sandbox>,
+		`plan--${repo.owner}--${repo.name}--${planId}`.toLowerCase(),
+		{ sleepAfter: '10m' },
+	);
+	await sandbox.exec(`rm -rf ${CLONE_DIR} ${OUT_DIR} && mkdir -p ${OUT_DIR}`);
+	const clone = await sandbox.exec(
+		`git clone --depth 50 --single-branch --branch "$GEN_BASE" ` +
+			`"https://x-access-token:$GIT_TOKEN@github.com/${full}.git" ${CLONE_DIR}`,
+		{ env: { GIT_TOKEN: token, GEN_BASE: info.default_branch }, timeout: 3 * 60_000 },
+	);
+	if (!clone.success) {
+		throw new Error(`git clone failed: ${scrub(clone.stderr).slice(0, 500)}`);
+	}
+	return { sandbox, token, scrub };
+}
+
+async function readJsonArray(sandbox: Sandbox, path: string): Promise<string[]> {
+	try {
+		const parsed = JSON.parse((await sandbox.readFile(path)).content);
+		return Array.isArray(parsed) ? parsed.map(String) : [];
+	} catch {
+		return [];
+	}
+}
+
+async function readText(sandbox: Sandbox, path: string): Promise<string | undefined> {
+	try {
+		return (await sandbox.readFile(path)).content.trim() || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function runAgent(
+	sandbox: Sandbox,
+	prompt: string,
+	scrub: (s: string) => string,
+): Promise<void> {
+	const auth = resolveRunnerAuth();
+	await sandbox.writeFile(`${OUT_DIR}/task.md`, prompt);
+	const res = await sandbox.exec(
+		`claude -p --dangerously-skip-permissions --output-format text < ${OUT_DIR}/task.md`,
+		{
+			cwd: CLONE_DIR,
+			timeout: AGENT_TIMEOUT_MS,
+			env: {
+				...auth.vars,
+				IS_SANDBOX: '1',
+				DISABLE_AUTOUPDATER: '1',
+				CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+			},
+		},
+	);
+	if (!res.success) {
+		throw new Error(
+			`planning agent exited ${res.exitCode}: ${scrub(`${res.stdout}\n${res.stderr}`).trim().slice(-1_000)}`,
+		);
+	}
+}
+
+function analyzePrompt(plan: PlanRow, repo: RepositoryRow): string {
+	return `You are a planning agent for ${repo.owner}/${repo.name}. You are in a read-only checkout — study the code but do NOT modify it.
+
+Analyze the feature requirements below against the actual codebase, then write these files (create the directory if needed):
+
+1. ${OUT_DIR}/analysis.md — a short grounding analysis: which files/modules this touches, how it fits existing conventions, and any risks.
+2. ${OUT_DIR}/questions.json — a JSON array of clarifying questions (strings). Include ONLY genuine ambiguities or decisions the requirements leave open and that would change the implementation. If the requirements are clear enough to implement well, write an empty array [].
+
+## Feature: ${plan.title}
+
+## Requirements
+${plan.requirements}
+`;
+}
+
+function planPrompt(plan: PlanRow, repo: RepositoryRow, qa: string): string {
+	return `You are a planning agent for ${repo.owner}/${repo.name}. You are in a read-only checkout — study the code but do NOT modify it.
+
+Produce an implementation plan for the feature below, grounded in the real code, then write these files:
+
+1. ${OUT_DIR}/plan.md — a file-level implementation plan: what changes in which files, in what order, and why. Concrete enough for an implementation agent to follow without further questions.
+2. ${OUT_DIR}/acceptance.json — a JSON array of machine-checkable acceptance criteria (strings). Each must be objectively verifiable (a specific response shape, a test that would pass, an observable behavior) — not vague ("works well"). These gate whether the generated code satisfies the request.
+
+## Feature: ${plan.title}
+
+## Requirements
+${plan.requirements}
+
+## Prior analysis
+${plan.analysis ?? '(none)'}
+${qa}`;
+}
+
+// plan_analyze: clone, analyze the requirements against the repo, emit questions
+// and a grounding analysis. Empty questions → straight to the plan; otherwise
+// wait for the user's answers (awaiting_answers) before planning.
+export async function runPlanAnalyze(planId: number): Promise<void> {
+	const plan = await getPlan(planId);
+	if (!plan) return;
+	const repo = await getRepoById(plan.repository_id);
+	if (!repo || !repo.enabled) {
+		await updatePlan(planId, { status: 'failed', error: 'repository missing or disabled' });
+		return;
+	}
+	const full = `${repo.owner}/${repo.name}`;
+	let sandbox: Sandbox | undefined;
+	try {
+		const booted = await clonePlanRepo(repo, planId);
+		sandbox = booted.sandbox;
+		await runAgent(sandbox, analyzePrompt(plan, repo), booted.scrub);
+		const analysis = await readText(sandbox, `${OUT_DIR}/analysis.md`);
+		const questions = await readJsonArray(sandbox, `${OUT_DIR}/questions.json`);
+
+		if (questions.length === 0) {
+			// No ambiguities — plan immediately in the same run.
+			await runAgent(sandbox, planPrompt({ ...plan, analysis: analysis ?? null }, repo, ''), booted.scrub);
+			const planMd = await readText(sandbox, `${OUT_DIR}/plan.md`);
+			const acceptance = await readJsonArray(sandbox, `${OUT_DIR}/acceptance.json`);
+			await updatePlan(planId, {
+				status: 'plan_ready',
+				analysis,
+				questions: '[]',
+				plan: planMd,
+				acceptance: JSON.stringify(acceptance),
+			});
+		} else {
+			await updatePlan(planId, {
+				status: 'awaiting_answers',
+				analysis,
+				questions: JSON.stringify(questions),
+			});
+		}
+		console.log(`turbodiff: plan ${planId} analyzed for ${full} (${questions.length} questions)`);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		await updatePlan(planId, { status: 'failed', error: message.slice(0, 500) });
+		console.error(`turbodiff: plan analyze failed for ${full} #${planId}:`, err);
+	} finally {
+		if (sandbox) {
+			await sandbox
+				.exec(`git -C ${CLONE_DIR} remote set-url origin "https://github.com/${full}.git"`)
+				.catch(() => {});
+		}
+	}
+}
+
+// plan_refine: the user has answered the clarifying questions; produce the final
+// plan + acceptance criteria incorporating their answers.
+export async function runPlanRefine(planId: number): Promise<void> {
+	const plan = await getPlan(planId);
+	if (!plan) return;
+	const repo = await getRepoById(plan.repository_id);
+	if (!repo || !repo.enabled) {
+		await updatePlan(planId, { status: 'failed', error: 'repository missing or disabled' });
+		return;
+	}
+	const full = `${repo.owner}/${repo.name}`;
+	const questions: string[] = plan.questions ? JSON.parse(plan.questions) : [];
+	const answers: string[] = plan.answers ? JSON.parse(plan.answers) : [];
+	const qa =
+		'\n## Clarifying questions and answers\n' +
+		questions.map((q, i) => `Q: ${q}\nA: ${answers[i] ?? '(no answer)'}`).join('\n\n');
+
+	let sandbox: Sandbox | undefined;
+	try {
+		const booted = await clonePlanRepo(repo, planId);
+		sandbox = booted.sandbox;
+		await runAgent(sandbox, planPrompt(plan, repo, qa), booted.scrub);
+		const planMd = await readText(sandbox, `${OUT_DIR}/plan.md`);
+		const acceptance = await readJsonArray(sandbox, `${OUT_DIR}/acceptance.json`);
+		await updatePlan(planId, {
+			status: 'plan_ready',
+			plan: planMd,
+			acceptance: JSON.stringify(acceptance),
+		});
+		console.log(`turbodiff: plan ${planId} refined for ${full}`);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		await updatePlan(planId, { status: 'failed', error: message.slice(0, 500) });
+		console.error(`turbodiff: plan refine failed for ${full} #${planId}:`, err);
+	} finally {
+		if (sandbox) {
+			await sandbox
+				.exec(`git -C ${CLONE_DIR} remote set-url origin "https://github.com/${full}.git"`)
+				.catch(() => {});
+		}
+	}
+}
+
+// Approval turns a ready plan into a generation feature: the spec is the plan
+// plus its acceptance criteria, so the generated code is built against them.
+// Returns the new feature id, or null if the plan isn't ready.
+export async function approvePlan(planId: number): Promise<number | null> {
+	const plan = await getPlan(planId);
+	if (!plan || plan.status !== 'plan_ready' || !plan.plan) return null;
+	const acceptance: string[] = plan.acceptance ? JSON.parse(plan.acceptance) : [];
+	const spec =
+		`${plan.plan}\n\n## Acceptance criteria\n\n` +
+		(acceptance.length
+			? acceptance.map((c) => `- ${c}`).join('\n')
+			: '(none specified)') +
+		`\n\nImplement the plan above so that every acceptance criterion holds.`;
+	const featureId = await createFeature(plan.repository_id, plan.title, spec);
+	await updatePlan(planId, { status: 'approved', featureId });
+	return featureId;
+}

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -9,6 +9,10 @@ import {
 	countReviews,
 	createAgent,
 	createAgentConnection,
+	createPlan,
+	getPlan,
+	listPlansForInstallations,
+	updatePlan,
 	dashboardStats,
 	deleteAgent,
 	deleteAgentConnection,
@@ -17,6 +21,7 @@ import {
 	getAgentBySlug,
 	getAgentConnection,
 	getRepoById,
+	getRepoByFullName,
 	listAgentConnections,
 	listAgents,
 	listInstallationsWithRepos,
@@ -34,8 +39,11 @@ import {
 	updateAgent,
 	type AgentConnectionRow,
 	type AgentRow,
+	type PlanRow,
+	type PlanWithRepo,
 	type ReviewActivityRow,
 } from '../lib/db.ts';
+import { approvePlan } from '../lib/planner.ts';
 import { encryptionConfigured, openToken, sealToken } from '../lib/crypto.ts';
 import { testMcpEndpoint } from '../lib/mcp-test.ts';
 import { DEFAULT_MODEL, RESERVED_AGENT_SLUGS } from '../lib/personas.ts';
@@ -265,16 +273,91 @@ function topbar(login: string) {
 	</div>`;
 }
 
-function tabs(active: 'dashboard' | 'reviews' | 'agents' | 'settings') {
+function tabs(active: 'dashboard' | 'factory' | 'reviews' | 'agents' | 'settings') {
 	return html`<nav class="tabs">
 		<a href="/" class="${active === 'dashboard' ? 'active' : ''}">dashboard</a>
+		<a href="/factory" class="${active === 'factory' ? 'active' : ''}">factory</a>
 		<a href="/reviews" class="${active === 'reviews' ? 'active' : ''}">reviews</a>
 		<a href="/agents" class="${active === 'agents' ? 'active' : ''}">agents</a>
 		<a href="/settings" class="${active === 'settings' ? 'active' : ''}">settings</a>
 	</nav>`;
 }
 
+const PLAN_STATUS_HINT: Record<string, string> = {
+	analyzing: 'analyzing the repo and drafting clarifying questions…',
+	awaiting_answers: 'answer the questions below to continue',
+	refining: 'incorporating your answers into the plan…',
+	plan_ready: 'review the plan and approve to generate',
+	approved: 'generating — follow the pull request',
+	failed: 'failed — see the error',
+};
+
+const RUNNING_PLAN_STATUSES = new Set(['analyzing', 'refining']);
+
+// One plan card: status, plus the interactive surface for its current state
+// (answer form when awaiting answers, plan + approve when ready, PR link once
+// generating).
+function renderPlan(p: PlanWithRepo): HtmlEscapedString | Promise<HtmlEscapedString> {
+	const questions: string[] = p.questions ? JSON.parse(p.questions) : [];
+	const acceptance: string[] = p.acceptance ? JSON.parse(p.acceptance) : [];
+	const running = RUNNING_PLAN_STATUSES.has(p.status);
+	return html`<div class="tile" style="margin-top:0.75rem">
+		<div class="topbar">
+			<strong>${p.title}</strong>
+			<span class="pill ${running ? 'running' : p.status === 'failed' ? 'red' : 'on'}">${p.status}</span>
+		</div>
+		<div class="muted" style="margin:0.15rem 0 0.5rem">
+			${p.owner}/${p.name} · ${PLAN_STATUS_HINT[p.status] ?? ''} · ${ago(p.created_at)}
+		</div>
+		${p.status === 'failed' && p.error ? html`<p class="form-error">${p.error}</p>` : ''}
+		${p.status === 'awaiting_answers' && questions.length > 0
+			? html`<form method="post" action="/factory/plans/${p.id}/answers">
+					${questions.map(
+						(q, i) => html`<label
+							>${q}
+							<input type="text" name="answer_${i}" placeholder="your answer" />
+						</label>`,
+					)}
+					<p style="margin-top:0.6rem"><button type="submit">Submit answers</button></p>
+				</form>`
+			: ''}
+		${p.status === 'plan_ready'
+			? html`<details open>
+						<summary class="muted">implementation plan</summary>
+						<pre style="white-space:pre-wrap;margin-top:0.4rem">${p.plan ?? ''}</pre>
+						${acceptance.length > 0
+							? html`<div class="muted" style="margin-top:0.4rem">acceptance criteria</div>
+									<ul>
+										${acceptance.map((a) => html`<li>${a}</li>`)}
+									</ul>`
+							: ''}
+					</details>
+					<form method="post" action="/factory/plans/${p.id}/approve">
+						<p style="margin-top:0.6rem"><button type="submit">Approve &amp; generate</button></p>
+					</form>`
+			: ''}
+		${p.status === 'approved' && p.pr_number
+			? html`<p style="margin-top:0.4rem">
+					<a href="https://github.com/${p.owner}/${p.name}/pull/${p.pr_number}"
+						>pull request #${p.pr_number} &rarr;</a
+					>
+				</p>`
+			: ''}
+	</div>`;
+}
+
 type AuthedUser = { session: Session; installationIds: number[] };
+
+// Load the plan named by the :id param only if the caller may manage the repo
+// it belongs to (its installation is in the user's set). Null otherwise.
+async function authorizedPlan(c: Context, user: AuthedUser): Promise<PlanRow | null> {
+	const id = Number(c.req.param('id'));
+	const plan = Number.isInteger(id) ? await getPlan(id) : null;
+	if (!plan) return null;
+	const repo = await getRepoById(plan.repository_id);
+	if (!repo || !user.installationIds.includes(repo.installation_id)) return null;
+	return plan;
+}
 
 // GitHub is the source of truth for which installations this user may manage;
 // D1 only supplies Turbodiff's per-repo settings and usage. Returns null after
@@ -492,6 +575,106 @@ export function createSettingsRoutes() {
 						: ''}`,
 			),
 		);
+	});
+
+	// Factory (Phase 3): submit a feature as requirements, answer the planning
+	// agent's questions, approve the plan, and it generates a PR.
+	app.get('/factory', async (c) => {
+		const user = await requireUser(c);
+		if (!user) return c.redirect('/auth/login');
+		const { session, installationIds } = user;
+
+		const [groups, plans] = await Promise.all([
+			listInstallationsWithRepos(installationIds),
+			listPlansForInstallations(installationIds),
+		]);
+		const repos = groups.flatMap((g) => g.repos).filter((r) => r.enabled);
+
+		return c.html(
+			page(
+				'Turbodiff — factory',
+				html`${topbar(session.login)} ${tabs('factory')}
+					<h2>new feature</h2>
+					${repos.length === 0
+						? html`<p class="muted">
+								Enable reviews on a repository in
+								<a href="/settings">settings</a> to plan features for it.
+							</p>`
+						: html`<form method="post" action="/factory/plans">
+								<label
+									>repository
+									<select name="repo" required>
+										${repos.map((r) => html`<option value="${r.owner}/${r.name}">${r.owner}/${r.name}</option>`)}
+									</select>
+								</label>
+								<label
+									>title
+									<input type="text" name="title" required placeholder="short feature name" />
+								</label>
+								<label
+									>requirements
+									<textarea
+										name="requirements"
+										required
+										placeholder="Describe what you want built. The planning agent reads your repo, asks clarifying questions, and drafts a plan you approve before any code is written."
+									></textarea>
+								</label>
+								<p style="margin-top:0.75rem"><button type="submit">Plan feature</button></p>
+							</form>`}
+					<h2>plans <span class="muted">(${plans.length})</span></h2>
+					${plans.length === 0
+						? html`<p class="muted">No plans yet.</p>`
+						: plans.map((p) => renderPlan(p))}`,
+			),
+		);
+	});
+
+	app.post('/factory/plans', async (c) => {
+		const user = await requireUser(c);
+		if (!user) return c.redirect('/auth/login');
+		const form = await c.req.parseBody();
+		const repo = typeof form.repo === 'string' ? form.repo : '';
+		const title = typeof form.title === 'string' ? form.title.trim() : '';
+		const requirements = typeof form.requirements === 'string' ? form.requirements.trim() : '';
+		const match = repo.match(/^([\w.-]+)\/([\w.-]+)$/);
+		if (!match || !title || !requirements) return c.redirect('/factory');
+
+		const row = await getRepoByFullName(match[1], match[2]);
+		if (!row || !user.installationIds.includes(row.installation_id)) {
+			return c.text('unknown repository', 404);
+		}
+		const planId = await createPlan(row.id, title, requirements);
+		await env.FACTORY_QUEUE.send({ kind: 'plan_analyze', planId });
+		return c.redirect('/factory');
+	});
+
+	app.post('/factory/plans/:id/answers', async (c) => {
+		const user = await requireUser(c);
+		if (!user) return c.redirect('/auth/login');
+		const plan = await authorizedPlan(c, user);
+		if (!plan) return c.text('unknown plan', 404);
+		if (plan.status !== 'awaiting_answers') return c.redirect('/factory');
+
+		const form = await c.req.parseBody();
+		const questions: string[] = plan.questions ? JSON.parse(plan.questions) : [];
+		const answers = questions.map((_, i) => {
+			const a = form[`answer_${i}`];
+			return typeof a === 'string' ? a : '';
+		});
+		await updatePlan(plan.id, { status: 'refining', answers: JSON.stringify(answers) });
+		await env.FACTORY_QUEUE.send({ kind: 'plan_refine', planId: plan.id });
+		return c.redirect('/factory');
+	});
+
+	app.post('/factory/plans/:id/approve', async (c) => {
+		const user = await requireUser(c);
+		if (!user) return c.redirect('/auth/login');
+		const plan = await authorizedPlan(c, user);
+		if (!plan) return c.text('unknown plan', 404);
+
+		const featureId = await approvePlan(plan.id);
+		if (featureId !== null) await env.FACTORY_QUEUE.send({ kind: 'generate', featureId });
+		return c.redirect('/factory');
 	});
 
 	// Full review history, newest first, paginated.


### PR DESCRIPTION
The front half of the software factory — closes steps 1–2 of the vision.

## What it does
- **Planning agent** (`src/lib/planner.ts`): clones the repo read-only, analyzes requirements against the real code, asks clarifying questions (empty → plans immediately).
- **Answers → plan**: produces a file-level implementation plan plus machine-checkable acceptance criteria.
- **Approve → generate**: the plan becomes a generation feature whose spec embeds the criteria, flowing into the existing Phase 2 → review → auto-fix pipeline.
- **Factory dashboard tab**: submit requirements, answer questions inline, review the plan, approve — all in the browser.

## Design
- Stayed on the queue + DB-state pattern (not Cloudflare Workflows): the approval "wait" is a row in `awaiting_answers`/`plan_ready` transitioned by a POST — no running instance to pause. Noted as a future refactor.
- `plans` table (migration 0012), FACTORY_QUEUE gains `plan_analyze`/`plan_refine` kinds.
- Internal API: `POST /internal/plans`, `GET /internal/plans/:id`, `POST .../answers`, `POST .../approve`.

## Validation
typecheck + lint + build clean. End-to-end demo runs post-deploy against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)