### PR TITLE
Phase 4: empirical verification + spec-conformance gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,17 @@ FROM docker.io/cloudflare/sandbox:0.12.4
 # the install on every container cold start.
 RUN npm install -g @anthropic-ai/claude-code pnpm
 
+# Headless browser for the verification step (Phase 4): the verifier agent
+# drives Chrome via puppeteer-core to capture screenshot evidence of the
+# running app. The base is Ubuntu 22.04 where apt's chromium is a snap stub,
+# so install Google's .deb (apt resolves its dependencies). NODE_PATH lets
+# ad-hoc scripts require the global puppeteer-core install.
+RUN apt-get update && \
+	curl -fsSL -o /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+	apt-get install -y --no-install-recommends /tmp/chrome.deb && \
+	rm /tmp/chrome.deb && rm -rf /var/lib/apt/lists/* && \
+	npm install -g puppeteer-core
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
+ENV NODE_PATH=/usr/local/lib/node_modules
+
 EXPOSE 8080

--- a/docs/software-factory-design.md
+++ b/docs/software-factory-design.md
@@ -112,8 +112,15 @@ fix_attempts (
 3. **Phase 3 — planning intake.** Dashboard feature entry; planning agent asks
    clarifying questions, produces plan + acceptance criteria; `waitForEvent` approval
    gate; spec-conformance reviewer persona.
-4. **Phase 4 — verification artifacts.** Playwright video in the sandbox for frontend
-   work → R2 → PR comment.
+4. **Phase 4 — verification artifacts.** *Built:* an empirical verification step
+   doubling as the spec-conformance gate. After generation opens a PR, a verify
+   run checks each acceptance criterion against the checked-out branch — static
+   criteria by reading the tree, runtime criteria by launching the app
+   (per-repo `run_command` + `app_port`), visual criteria by driving headless
+   Chromium (puppeteer-core in the sandbox image) and capturing screenshots.
+   Evidence lands on the PR as a report comment (✅/❌ table + inline images
+   served from R2 via `GET /artifacts/*`); unmet criteria feed the auto-fix
+   loop as findings. Screenshots-over-video: they render inline in PR comments.
 5. **Phase 5 — auto-merge + trust**, per-feature token budgets, pipeline dashboard.
 
 ## Phase 1 spike (this repo, now)

--- a/migrations/0013_verification.sql
+++ b/migrations/0013_verification.sql
@@ -1,0 +1,24 @@
+-- Phase 4 (docs/software-factory-design.md): empirical verification of factory
+-- PRs. After generation, a verify run checks each acceptance criterion against
+-- the checked-out branch — static criteria by reading the tree, runtime
+-- criteria by launching the app — and captures screenshots as evidence.
+
+-- How to launch the repo's app inside the sandbox for runtime/visual checks.
+-- NULL disables runtime verification (static checks still run).
+ALTER TABLE repositories ADD COLUMN run_command TEXT;
+ALTER TABLE repositories ADD COLUMN app_port INTEGER;
+
+-- Structured acceptance criteria (JSON array of strings), populated by plan
+-- approval; the verifier checks against these rather than re-parsing the spec.
+ALTER TABLE features ADD COLUMN acceptance TEXT;
+
+CREATE TABLE verifications (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	feature_id INTEGER NOT NULL REFERENCES features(id) ON DELETE CASCADE,
+	status TEXT NOT NULL DEFAULT 'running', -- running | passed | failed | error | skipped
+	results TEXT, -- JSON: [{index, verdict, note, screenshot?}]
+	summary TEXT, -- agent's "how it works" narrative for the PR comment
+	error TEXT,
+	created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_verifications_feature ON verifications (feature_id);

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import {
 	getPlan,
 	getRepoByFullName,
 	setRepoCheckCommand,
+	setRepoRunCommand,
 	updatePlan,
 	listAgentConnections,
 	listAgentsForRepo,
@@ -59,6 +60,22 @@ app.get('/healthz', async (c) => {
 // deploy tooling can confirm which build is running. No auth, like /healthz.
 app.get('/version', (c) => {
 	return c.json({ id: env.CF_VERSION_METADATA.id, tag: env.CF_VERSION_METADATA.tag });
+});
+
+// Verification evidence (Phase 4): screenshots from verify runs, stored in R2
+// and embedded in PR comments — public so GitHub can render them inline. Keys
+// are harness-generated (verify/<featureId>/<name>.png), never user input.
+app.get('/artifacts/*', async (c) => {
+	const key = c.req.path.replace(/^\/artifacts\//, '');
+	if (!key || key.includes('..')) return c.notFound();
+	const object = await env.ARTIFACTS.get(key);
+	if (!object) return c.notFound();
+	return new Response(object.body, {
+		headers: {
+			'content-type': object.httpMetadata?.contentType ?? 'application/octet-stream',
+			'cache-control': 'public, max-age=31536000, immutable',
+		},
+	});
 });
 
 // Dispatches one configured agent against one PR and records the review row.
@@ -251,6 +268,29 @@ app.post('/internal/plans/:id/approve', async (c) => {
 
 // Set the sandbox verification gate for a repo (dashboard field lives in
 // settings; this is the operator/API path). Empty command clears the gate.
+// How the verify step launches this repo's app for runtime/visual checks
+// (Phase 4). Empty command disables runtime verification for the repo.
+app.post('/internal/repos/run-command', async (c) => {
+	const payload = await c.req
+		.json<{ repo?: string; command?: string; port?: number }>()
+		.catch(() => null);
+	const match = payload?.repo?.match(/^([\w.-]+)\/([\w.-]+)$/);
+	if (!match || typeof payload?.command !== 'string') {
+		return c.json(
+			{ error: 'body must be {"repo": "<owner>/<name>", "command": "...", "port": 3000}' },
+			400,
+		);
+	}
+	const port = Number.isInteger(payload.port) ? (payload.port as number) : null;
+	if (payload.command.trim() && !port) {
+		return c.json({ error: 'port is required when command is set' }, 400);
+	}
+	const repo = await getRepoByFullName(match[1], match[2]);
+	if (!repo) return c.json({ error: `Turbodiff is not installed on ${payload.repo}` }, 404);
+	await setRepoRunCommand(repo.id, payload.command, port);
+	return c.json({ ok: true, repo: payload.repo, run_command: payload.command.trim() || null, app_port: port });
+});
+
 app.post('/internal/repos/check-command', async (c) => {
 	const payload = await c.req.json<{ repo?: string; command?: string }>().catch(() => null);
 	const match = payload?.repo?.match(/^([\w.-]+)\/([\w.-]+)$/);

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -10,6 +10,7 @@
 import { processFixMessage, type FixQueueMessage } from './lib/fixer.ts';
 import { runGeneration, type GenQueueMessage } from './lib/generator.ts';
 import { runPlanAnalyze, runPlanRefine, type PlanQueueMessage } from './lib/planner.ts';
+import { runVerification, type VerifyQueueMessage } from './lib/verifier.ts';
 
 // The fixer sandbox container (docs/software-factory-design.md). Declared in
 // wrangler.jsonc under containers/durable_objects with migration tag v2.
@@ -19,7 +20,7 @@ export { Sandbox } from '@cloudflare/sandbox';
 // request can wait on, so producers enqueue and these consumers do the work.
 // Both processors never throw (failures land in fix_attempts / features), so
 // every message acks — a broken run is not retried into repeat token spend.
-type FactoryMessage = FixQueueMessage | GenQueueMessage | PlanQueueMessage;
+type FactoryMessage = FixQueueMessage | GenQueueMessage | PlanQueueMessage | VerifyQueueMessage;
 
 export default {
 	async queue(batch: MessageBatch<FactoryMessage>): Promise<void> {
@@ -34,6 +35,9 @@ export default {
 					break;
 				case 'plan_refine':
 					await runPlanRefine(body.planId);
+					break;
+				case 'verify':
+					await runVerification(body.featureId);
 					break;
 				default:
 					await processFixMessage(body);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -22,6 +22,8 @@ export interface RepositoryRow {
 	blocking_reviews: number; // P1 → REQUEST_CHANGES, clean → APPROVE
 	auto_fix: number; // dispatch the fix agent when a blocking review lands
 	check_command: string | null; // sandbox verification gate before factory pushes
+	run_command: string | null; // how to launch the app for runtime verification
+	app_port: number | null; // port the launched app listens on
 	model: string | null;
 	created_at: string; // when the repo was connected (mirrored into D1)
 }
@@ -157,6 +159,42 @@ export async function setRepoCheckCommand(id: number, command: string): Promise<
 		.run();
 }
 
+// How the verify step launches the repo's app for runtime/visual checks.
+// Empty command clears both fields (static verification only).
+export async function setRepoRunCommand(
+	id: number,
+	command: string,
+	port: number | null,
+): Promise<void> {
+	const trimmed = command.trim();
+	await env.DB.prepare('UPDATE repositories SET run_command = ?2, app_port = ?3 WHERE id = ?1')
+		.bind(id, trimmed || null, trimmed ? port : null)
+		.run();
+}
+
+// --- verifications (Phase 4: empirical acceptance-criteria checks) ---
+
+export async function createVerification(featureId: number): Promise<number> {
+	const row = await env.DB.prepare(
+		'INSERT INTO verifications (feature_id) VALUES (?1) RETURNING id',
+	)
+		.bind(featureId)
+		.first<{ id: number }>();
+	return row!.id;
+}
+
+export async function finishVerification(
+	id: number,
+	status: string,
+	fields: { results?: string; summary?: string; error?: string } = {},
+): Promise<void> {
+	await env.DB.prepare(
+		'UPDATE verifications SET status = ?2, results = ?3, summary = ?4, error = ?5 WHERE id = ?1',
+	)
+		.bind(id, status, fields.results ?? null, fields.summary ?? null, fields.error ?? null)
+		.run();
+}
+
 // --- fix attempts (auto-fix loop bookkeeping + iteration cap) ---
 
 // Every attempt counts toward the cap regardless of outcome, so even a
@@ -206,6 +244,7 @@ export interface FeatureRow {
 	repository_id: number;
 	title: string;
 	spec: string;
+	acceptance: string | null; // JSON array of acceptance criteria strings
 	branch: string | null;
 	pr_number: number | null;
 	status: string;
@@ -217,11 +256,14 @@ export async function createFeature(
 	repositoryId: number,
 	title: string,
 	spec: string,
+	// JSON array of acceptance criteria strings; the verify step checks these
+	// empirically against the generated branch.
+	acceptance?: string,
 ): Promise<number> {
 	const row = await env.DB.prepare(
-		'INSERT INTO features (repository_id, title, spec) VALUES (?1, ?2, ?3) RETURNING id',
+		'INSERT INTO features (repository_id, title, spec, acceptance) VALUES (?1, ?2, ?3, ?4) RETURNING id',
 	)
-		.bind(repositoryId, title, spec)
+		.bind(repositoryId, title, spec, acceptance ?? null)
 		.first<{ id: number }>();
 	return row!.id;
 }

--- a/src/lib/fixer.ts
+++ b/src/lib/fixer.ts
@@ -329,6 +329,9 @@ export interface FixQueueMessage {
 	repoId: number;
 	prNumber: number;
 	trigger: string;
+	// Explicit work order (e.g. unmet acceptance criteria from a verification
+	// run). When absent, the latest blocking bot review on the PR is used.
+	findings?: string;
 }
 
 // Queue consumer body: re-validate against current state (the toggle may have
@@ -368,6 +371,7 @@ export async function processFixMessage(msg: FixQueueMessage): Promise<void> {
 			repo: repo.name,
 			prNumber: msg.prNumber,
 			installationId: repo.installation_id,
+			findings: msg.findings,
 			testCommand: repo.check_command ?? undefined,
 		});
 		await finishFixAttempt(attemptId, outcome.status, outcome.commit);

--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -69,6 +69,11 @@ export async function runGeneration(featureId: number): Promise<void> {
 		const outcome = await generate(feature, repo);
 		await updateFeature(featureId, outcome);
 		console.log(`turbodiff: generation ${outcome.status} for ${label}`);
+		// Phase 4: a fresh PR with acceptance criteria gets an empirical
+		// verification run (its own queue message → own consumer wall clock).
+		if (outcome.status === 'pr_opened' && feature.acceptance) {
+			await env.FACTORY_QUEUE.send({ kind: 'verify', featureId });
+		}
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		await updateFeature(featureId, { status: 'failed', error: message.slice(0, 500) });

--- a/src/lib/planner.ts
+++ b/src/lib/planner.ts
@@ -233,7 +233,14 @@ export async function approvePlan(planId: number): Promise<number | null> {
 			? acceptance.map((c) => `- ${c}`).join('\n')
 			: '(none specified)') +
 		`\n\nImplement the plan above so that every acceptance criterion holds.`;
-	const featureId = await createFeature(plan.repository_id, plan.title, spec);
+	// Criteria travel structured (not only embedded in the spec text) so the
+	// verify step can check them one by one after generation.
+	const featureId = await createFeature(
+		plan.repository_id,
+		plan.title,
+		spec,
+		plan.acceptance ?? undefined,
+	);
 	await updatePlan(planId, { status: 'approved', featureId });
 	return featureId;
 }

--- a/src/lib/verifier.ts
+++ b/src/lib/verifier.ts
@@ -1,0 +1,301 @@
+import { getSandbox, type Sandbox } from '@cloudflare/sandbox';
+import { env } from 'cloudflare:workers';
+import { gh } from '../tools/github.ts';
+import {
+	createVerification,
+	finishVerification,
+	getFeature,
+	getRepoById,
+	type FeatureRow,
+	type RepositoryRow,
+} from './db.ts';
+import { resolveRunnerAuth } from './fixer.ts';
+import { installationToken } from './github-app.ts';
+
+// Phase 4 (docs/software-factory-design.md): empirical verification of factory
+// PRs, doubling as the spec-conformance gate. A verifier agent checks each
+// acceptance criterion against the checked-out PR branch — static criteria by
+// reading the tree, runtime criteria by launching the app (repo.run_command)
+// and exercising it, visual criteria by driving headless Chromium and
+// capturing screenshots. The evidence lands on the PR as a report comment;
+// failed criteria feed the existing auto-fix loop.
+
+const CLONE_DIR = '/workspace/verify-repo';
+const OUT_DIR = '/workspace/verify-out';
+const SHOTS_DIR = `${OUT_DIR}/screenshots`;
+const AGENT_TIMEOUT_MS = 10 * 60_000;
+
+export interface VerifyQueueMessage {
+	kind: 'verify';
+	featureId: number;
+}
+
+interface CriterionResult {
+	index: number;
+	verdict: 'pass' | 'fail' | 'skip';
+	note: string;
+	screenshot?: string;
+}
+
+function verifyPrompt(feature: FeatureRow, repo: RepositoryRow, criteria: string[]): string {
+	const runtime = repo.run_command
+		? `## Running the app
+The app can be launched with:
+
+    ${repo.run_command}
+
+It listens on port ${repo.app_port ?? '(unknown — check the repo)'} once ready.
+Start it in the background (e.g. \`nohup ... > /tmp/app.log 2>&1 &\`), wait for
+the port to accept connections, and verify runtime criteria against it with
+curl or small node scripts. If it fails to start, mark runtime criteria as
+"skip" with a note quoting the relevant log lines — do NOT mark them "fail"
+for infrastructure reasons.
+
+## Screenshots
+A headless Chrome binary is installed (its path is in the env var
+PUPPETEER_EXECUTABLE_PATH) and puppeteer-core is globally available via
+NODE_PATH. For criteria with user-visible behavior, write a small node script
+that opens the relevant page/state and captures PNG screenshots into
+${SHOTS_DIR}/ (create it). Write capture scripts as CommonJS (.cjs files using
+require('puppeteer-core')) — ESM import cannot resolve the global install.
+Launch with args ['--no-sandbox', '--disable-dev-shm-usage']. Use descriptive
+kebab-case filenames and reference each screenshot from the matching
+criterion result.`
+		: `## Running the app
+No run command is configured for this repository, so runtime and visual checks
+are unavailable. Verify what can be verified statically from the tree; mark
+criteria that would need a running app as "skip" with a note saying why.`;
+
+	return `You are a verification agent for ${repo.owner}/${repo.name}. You are in a checkout of the pull request branch for "${feature.title}". You may read anything and run the app, but do NOT modify tracked files, commit, or push.
+
+Check every acceptance criterion below against reality — the actual tree and
+(where possible) the actually running app. Do not infer from the diff what you
+can observe directly.
+
+${runtime}
+
+## Output (write these files, creating ${OUT_DIR} first)
+1. ${OUT_DIR}/results.json — a JSON array, one entry per criterion, in order:
+   [{"index": 0, "verdict": "pass" | "fail" | "skip", "note": "one or two sentences of evidence — what you did and what you observed", "screenshot": "optional-filename.png"}]
+   "fail" means the criterion is genuinely not met by the code; "skip" means it
+   could not be checked here (say why).
+2. ${OUT_DIR}/summary.md — a short reviewer-facing narrative titled "How it
+   works": what was implemented and how it behaves, referencing the evidence.
+
+## Acceptance criteria
+${criteria.map((c, i) => `${i}. ${c}`).join('\n')}
+`;
+}
+
+export async function runVerification(featureId: number): Promise<void> {
+	const feature = await getFeature(featureId);
+	if (!feature || !feature.branch || !feature.pr_number) {
+		console.warn(`turbodiff: verify skipped, feature ${featureId} has no branch/PR`);
+		return;
+	}
+	const repo = await getRepoById(feature.repository_id);
+	if (!repo || !repo.enabled) return;
+	const criteria: string[] = feature.acceptance ? JSON.parse(feature.acceptance) : [];
+	if (criteria.length === 0) {
+		console.log(`turbodiff: verify skipped for feature ${featureId} (no acceptance criteria)`);
+		return;
+	}
+	const label = `${repo.owner}/${repo.name}#${feature.pr_number}`;
+	const verificationId = await createVerification(featureId);
+
+	try {
+		const outcome = await verify(feature, repo, criteria);
+		await finishVerification(verificationId, outcome.status, {
+			results: JSON.stringify(outcome.results),
+			summary: outcome.summary,
+		});
+		console.log(`turbodiff: verification ${outcome.status} for ${label}`);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		await finishVerification(verificationId, 'error', { error: message.slice(0, 500) });
+		console.error(`turbodiff: verification errored for ${label}:`, err);
+	}
+}
+
+async function verify(
+	feature: FeatureRow,
+	repo: RepositoryRow,
+	criteria: string[],
+): Promise<{ status: string; results: CriterionResult[]; summary?: string }> {
+	const token = await installationToken(repo.installation_id);
+	const auth = resolveRunnerAuth();
+	const scrub = (s: string) => s.replaceAll(token, '***');
+	const full = `${repo.owner}/${repo.name}`;
+
+	const sandbox = getSandbox(
+		env.Sandbox as unknown as DurableObjectNamespace<Sandbox>,
+		`verify--${repo.owner}--${repo.name}--${feature.id}`.toLowerCase(),
+		{ sleepAfter: '15m' },
+	);
+
+	try {
+		await sandbox.exec(`rm -rf ${CLONE_DIR} ${OUT_DIR} && mkdir -p ${SHOTS_DIR}`);
+		const clone = await sandbox.exec(
+			`git clone --depth 50 --single-branch --branch "$VERIFY_BRANCH" ` +
+				`"https://x-access-token:$GIT_TOKEN@github.com/${full}.git" ${CLONE_DIR}`,
+			{ env: { GIT_TOKEN: token, VERIFY_BRANCH: feature.branch! }, timeout: 3 * 60_000 },
+		);
+		if (!clone.success) {
+			throw new Error(`git clone failed: ${scrub(clone.stderr).slice(0, 500)}`);
+		}
+
+		await sandbox.writeFile(`${OUT_DIR}/task.md`, verifyPrompt(feature, repo, criteria));
+		const agent = await sandbox.exec(
+			`claude -p --dangerously-skip-permissions --output-format text < ${OUT_DIR}/task.md`,
+			{
+				cwd: CLONE_DIR,
+				timeout: AGENT_TIMEOUT_MS,
+				env: {
+					...auth.vars,
+					IS_SANDBOX: '1',
+					DISABLE_AUTOUPDATER: '1',
+					CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+				},
+			},
+		);
+		if (!agent.success) {
+			throw new Error(
+				`verifier agent exited ${agent.exitCode}: ${scrub(`${agent.stdout}\n${agent.stderr}`).trim().slice(-1_000)}`,
+			);
+		}
+
+		const results = await readResults(sandbox, criteria.length);
+		const summary = await readText(sandbox, `${OUT_DIR}/summary.md`);
+		const shots = await uploadScreenshots(sandbox, feature.id, results);
+
+		const failed = results.filter((r) => r.verdict === 'fail');
+		await postReport(token, repo, feature, criteria, results, shots, summary);
+
+		// Conformance gate: unmet criteria feed the existing fix loop (toggle and
+		// cap are re-validated by the consumer, exactly like review-driven fixes).
+		if (failed.length > 0 && repo.auto_fix === 1) {
+			await env.FACTORY_QUEUE.send({
+				kind: 'fix',
+				repoId: repo.id,
+				prNumber: feature.pr_number!,
+				trigger: 'verification_failed',
+				findings: failed
+					.map((f) => `**P1** — Acceptance criterion not met: ${criteria[f.index]}\n\nEvidence: ${f.note}`)
+					.join('\n\n'),
+			});
+		}
+		return { status: failed.length > 0 ? 'failed' : 'passed', results, summary };
+	} finally {
+		await sandbox
+			.exec(`git -C ${CLONE_DIR} remote set-url origin "https://github.com/${full}.git"`)
+			.catch(() => {});
+	}
+}
+
+async function readResults(sandbox: Sandbox, count: number): Promise<CriterionResult[]> {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse((await sandbox.readFile(`${OUT_DIR}/results.json`)).content);
+	} catch {
+		throw new Error('verifier agent did not produce a parseable results.json');
+	}
+	if (!Array.isArray(parsed)) throw new Error('results.json is not an array');
+	const byIndex = new Map<number, CriterionResult>();
+	for (const raw of parsed as Record<string, unknown>[]) {
+		const index = Number(raw.index);
+		if (!Number.isInteger(index) || index < 0 || index >= count) continue;
+		const verdict = raw.verdict === 'pass' || raw.verdict === 'fail' ? raw.verdict : 'skip';
+		byIndex.set(index, {
+			index,
+			verdict,
+			note: String(raw.note ?? '').slice(0, 500),
+			screenshot: typeof raw.screenshot === 'string' ? raw.screenshot : undefined,
+		});
+	}
+	// A criterion the agent silently dropped is unverified, not passed.
+	return Array.from({ length: count }, (_, i) => {
+		return byIndex.get(i) ?? { index: i, verdict: 'skip', note: 'no result reported' };
+	});
+}
+
+async function readText(sandbox: Sandbox, path: string): Promise<string | undefined> {
+	try {
+		return (await sandbox.readFile(path)).content.trim() || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+// Screenshots leave the sandbox base64-encoded (binary-safe over the exec
+// transport) and land in R2 under verify/<featureId>/, served publicly by the
+// GET /artifacts/* route so they render inline in the PR comment.
+async function uploadScreenshots(
+	sandbox: Sandbox,
+	featureId: number,
+	results: CriterionResult[],
+): Promise<Map<string, string>> {
+	const urls = new Map<string, string>();
+	const wanted = [...new Set(results.map((r) => r.screenshot).filter((s): s is string => !!s))];
+	for (const name of wanted) {
+		const safe = name.replace(/[^\w.-]/g, '');
+		if (!safe.endsWith('.png')) continue;
+		const b64 = await sandbox.exec(`base64 < "${SHOTS_DIR}/${safe}" | tr -d '\\n'`, {
+			timeout: 30_000,
+		});
+		if (!b64.success || !b64.stdout.trim()) continue;
+		const bytes = Uint8Array.from(atob(b64.stdout.trim()), (c) => c.charCodeAt(0));
+		const key = `verify/${featureId}/${safe}`;
+		await env.ARTIFACTS.put(key, bytes, { httpMetadata: { contentType: 'image/png' } });
+		urls.set(name, `${env.PUBLIC_BASE_URL}/artifacts/${key}`);
+	}
+	return urls;
+}
+
+const VERDICT_BADGE: Record<CriterionResult['verdict'], string> = {
+	pass: '✅',
+	fail: '❌',
+	skip: '⚪',
+};
+
+async function postReport(
+	token: string,
+	repo: RepositoryRow,
+	feature: FeatureRow,
+	criteria: string[],
+	results: CriterionResult[],
+	shots: Map<string, string>,
+	summary?: string,
+): Promise<void> {
+	const failed = results.filter((r) => r.verdict === 'fail').length;
+	const lines = [
+		`## 🔍 Turbodiff verification — ${failed === 0 ? 'all criteria met' : `${failed} criteria not met`}`,
+		'',
+		'| | Criterion | Evidence |',
+		'|---|---|---|',
+		...results.map((r) => {
+			const note = r.note.replaceAll('|', '\\|').replaceAll('\n', ' ');
+			return `| ${VERDICT_BADGE[r.verdict]} | ${criteria[r.index].replaceAll('|', '\\|')} | ${note} |`;
+		}),
+	];
+	const embedded = results
+		.map((r) => (r.screenshot && shots.get(r.screenshot) ? { r, url: shots.get(r.screenshot)! } : null))
+		.filter((x): x is { r: CriterionResult; url: string } => x !== null);
+	if (embedded.length > 0) {
+		lines.push('', '### Evidence');
+		for (const { r, url } of embedded) {
+			lines.push('', `**${criteria[r.index]}**`, `![${r.screenshot}](${url})`);
+		}
+	}
+	if (summary) lines.push('', '### How it works', '', summary.slice(0, 3_000));
+	if (failed > 0 && repo.auto_fix === 1) {
+		lines.push('', '_The unmet criteria have been handed to the fix agent._');
+	}
+	try {
+		await gh(token, `/repos/${repo.owner}/${repo.name}/issues/${feature.pr_number}/comments`, {
+			method: 'POST',
+			body: JSON.stringify({ body: lines.join('\n') }),
+		});
+	} catch (err) {
+		console.error('turbodiff: verification report comment failed:', err);
+	}
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -22,9 +22,16 @@
 			"migrations_dir": "migrations"
 		}
 	],
+	// Verification evidence (Phase 4): screenshots captured in the sandbox land
+	// here and are served publicly via GET /artifacts/*. Create once per account:
+	//   npx wrangler r2 bucket create turbodiff-artifacts
+	"r2_buckets": [{ "binding": "ARTIFACTS", "bucket_name": "turbodiff-artifacts" }],
 	"vars": {
 		// The name of your existing Cloudflare AI Gateway.
 		"AI_GATEWAY_ID": "default",
+		// Public origin of this deployment — used to build absolute artifact URLs
+		// embedded in PR comments.
+		"PUBLIC_BASE_URL": "https://turbodiff.dev",
 		// URL slug of your GitHub App (github.com/apps/<slug>) — used for
 		// install/manage links in the settings UI.
 		"GITHUB_APP_SLUG": "turbodiff",


### PR DESCRIPTION
Closes the last two gaps in the factory vision: visual evidence and spec conformance — as one step, since they verify the same thing from the same vantage point.

## How it works
After generation opens a PR (and the feature has acceptance criteria from its plan), a `verify` queue run:
1. Clones the PR branch into the sandbox.
2. A verifier agent checks **every acceptance criterion empirically** — static criteria by reading the tree, runtime criteria by launching the app (per-repo `run_command` + `app_port`) and exercising it, visual criteria by driving headless Chrome (puppeteer-core, baked into the image) and capturing screenshots.
3. Posts a **verification report comment** on the PR: ✅/❌/⚪ table with evidence notes, inline screenshots (R2 → public `GET /artifacts/*`), and a "How it works" narrative.
4. **Unmet criteria feed the existing auto-fix loop** as explicit findings (same toggle, same cap) — this is the conformance gate: it proves the built thing against the plan's criteria, not the diff against a description.

## Design choices
- **Screenshots over video**: they render inline in PR comments — evidence at a glance, no player, no hosting complexity. Chrome screencast can be layered on later if wanted.
- **In-sandbox Chrome over Cloudflare Browser Rendering**: avoids exposing sandbox preview URLs publicly (wildcard DNS) just to look at them.
- Ubuntu 22.04 base has no apt chromium (snap stub) → Google Chrome .deb. Screenshot capture smoke-tested inside the built image (CommonJS require — ESM import can't resolve the global install; the agent prompt encodes this).

## Deploy needs
- `npx wrangler r2 bucket create turbodiff-artifacts`
- migration 0013 `--remote`
- image rebuild via `pnpm run deploy` (~500MB layer for Chrome)
- per-repo `run_command`/`app_port` via `POST /internal/repos/run-command` to enable runtime/visual checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)