### PR TITLE
Factory trust: re-verify after fixes, dashboard verifications, opt-in auto-merge

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,6 +70,12 @@ rather than a public issue.
   check gate, and review reconciliation bound it, but a malicious blocking
   review body on a repo with auto-fix enabled is an injection channel into
   the fixer; only enable auto-fix on repos whose collaborators you trust.
+- **Auto-merge is double-gated but still autonomous.** With the per-repo
+  `auto_merge` toggle on (default off, and only honored alongside blocking
+  reviews), a factory PR merges itself when the empirical verification passed
+  and no review ever requested changes. The gates are real, but both are
+  produced by agents — enable it only on repos where a bad merge is cheap to
+  revert.
 - **Single-operator deployment.** There is no per-user authorization inside
   an installation beyond GitHub's own (any user who can access the
   installation can configure its repos). Multi-tenant hosting needs a proper

--- a/docs/software-factory-design.md
+++ b/docs/software-factory-design.md
@@ -121,7 +121,15 @@ fix_attempts (
    Evidence lands on the PR as a report comment (✅/❌ table + inline images
    served from R2 via `GET /artifacts/*`); unmet criteria feed the auto-fix
    loop as findings. Screenshots-over-video: they render inline in PR comments.
-5. **Phase 5 — auto-merge + trust**, per-feature token budgets, pipeline dashboard.
+5. **Phase 5 — auto-merge + trust.** *Built:* per-repo `auto_merge` toggle (default
+   off, only honored alongside blocking reviews). A factory PR merges itself only
+   when the latest empirical verification passed AND at least one review exists
+   with zero blocking-intent reviews in the PR's history; both completion paths
+   (verification, review) attempt the gate so ordering cannot race, and any
+   ambiguity declines in favor of a human. Fix pushes re-enqueue verification so
+   evidence and the merge gate always reflect the fixed code (bounded by the
+   3-fix cap). Verification status surfaces on the factory tab. Still open:
+   per-feature token budgets.
 
 ## Phase 1 spike (this repo, now)
 

--- a/migrations/0014_auto_merge.sql
+++ b/migrations/0014_auto_merge.sql
@@ -1,0 +1,5 @@
+-- Opt-in auto-merge for factory PRs (docs/software-factory-design.md, Phase 5).
+-- Trust is earned, not configured: off by default, and even when on, a PR only
+-- merges when the empirical verification passed AND the review is clean — the
+-- factory declines to merge on any ambiguity and leaves it to a human.
+ALTER TABLE repositories ADD COLUMN auto_merge INTEGER NOT NULL DEFAULT 0;

--- a/src/lib/auto-merge.ts
+++ b/src/lib/auto-merge.ts
@@ -1,0 +1,76 @@
+import { gh } from '../tools/github.ts';
+import {
+	getFeatureByRepoPr,
+	latestVerificationForFeature,
+	type RepositoryRow,
+} from './db.ts';
+import { installationToken } from './github-app.ts';
+
+// Phase 5 (docs/software-factory-design.md): opt-in auto-merge for factory
+// PRs. Trust is earned, not configured — even with the toggle on, a PR merges
+// only when BOTH gates are green:
+//   1. the latest empirical verification passed (every acceptance criterion),
+//   2. at least one turbodiff review exists and NO review carries a blocking
+//      verdict (state CHANGES_REQUESTED, or the self-review downgrade marker).
+// Verification and review complete concurrently, so both completion paths call
+// this; whichever finishes second performs the merge. On any ambiguity —
+// missing review, stale block, unmergeable PR — the factory declines and
+// leaves the merge to a human. Never applies to human-authored PRs (those have
+// no feature row).
+export async function maybeAutoMerge(repo: RepositoryRow, prNumber: number): Promise<void> {
+	// Auto-merge is only meaningful when the review gate exists at all.
+	if (repo.auto_merge !== 1 || repo.blocking_reviews !== 1) return;
+	const label = `${repo.owner}/${repo.name}#${prNumber}`;
+	try {
+		const feature = await getFeatureByRepoPr(repo.id, prNumber);
+		if (!feature || !feature.acceptance) return; // not a factory PR / nothing verified
+
+		const verification = await latestVerificationForFeature(feature.id);
+		if (verification?.status !== 'passed') {
+			console.log(`turbodiff: auto-merge waiting on verification for ${label}`);
+			return;
+		}
+
+		const token = await installationToken(repo.installation_id);
+		const reviews = (await (
+			await gh(token, `/repos/${repo.owner}/${repo.name}/pulls/${prNumber}/reviews?per_page=100`)
+		).json()) as { state: string; body: string; user: { type: string } | null }[];
+		const botReviews = reviews.filter((r) => r.user?.type === 'Bot');
+		if (botReviews.length === 0) {
+			console.log(`turbodiff: auto-merge waiting on review for ${label}`);
+			return;
+		}
+		// Conservative: ANY blocking-intent review — even one later superseded by
+		// a clean re-review — declines the auto-merge in favor of a human look.
+		const anyBlocking = botReviews.some(
+			(r) =>
+				r.state === 'CHANGES_REQUESTED' ||
+				(r.state === 'COMMENTED' && r.body.startsWith('**Verdict: REQUEST_CHANGES**')),
+		);
+		if (anyBlocking) {
+			console.log(`turbodiff: auto-merge declined for ${label} (a review requested changes)`);
+			return;
+		}
+
+		const res = await gh(token, `/repos/${repo.owner}/${repo.name}/pulls/${prNumber}/merge`, {
+			method: 'PUT',
+			body: JSON.stringify({ merge_method: 'merge' }),
+		});
+		const merged = (await res.json()) as { merged?: boolean; sha?: string };
+		if (!merged.merged) throw new Error('merge endpoint returned merged=false');
+		console.log(`turbodiff: auto-merged ${label} (${merged.sha?.slice(0, 8)})`);
+
+		await gh(token, `/repos/${repo.owner}/${repo.name}/issues/${prNumber}/comments`, {
+			method: 'POST',
+			body: JSON.stringify({
+				body:
+					'🏭 **Auto-merged by the turbodiff factory** — every acceptance criterion ' +
+					'verified against the running branch and the review found no blocking issues.',
+			}),
+		}).catch(() => {});
+	} catch (err) {
+		// Failure to auto-merge is never an error state for the pipeline: the PR
+		// simply stays open for a human (branch protection, conflicts, races).
+		console.warn(`turbodiff: auto-merge attempt failed for ${label}:`, err);
+	}
+}

--- a/src/lib/auto-merge.ts
+++ b/src/lib/auto-merge.ts
@@ -1,3 +1,4 @@
+import { env } from 'cloudflare:workers';
 import { gh } from '../tools/github.ts';
 import {
 	getFeatureByRepoPr,
@@ -34,8 +35,11 @@ export async function maybeAutoMerge(repo: RepositoryRow, prNumber: number): Pro
 		const token = await installationToken(repo.installation_id);
 		const reviews = (await (
 			await gh(token, `/repos/${repo.owner}/${repo.name}/pulls/${prNumber}/reviews?per_page=100`)
-		).json()) as { state: string; body: string; user: { type: string } | null }[];
-		const botReviews = reviews.filter((r) => r.user?.type === 'Bot');
+		).json()) as { state: string; body: string; user: { type: string; login: string } | null }[];
+		// Only turbodiff's own reviews satisfy the gate — another bot's APPROVE
+		// (CodeRabbit, Copilot, …) must not stand in for our review having run.
+		const ourLogin = `${env.GITHUB_APP_SLUG || 'turbodiff'}[bot]`;
+		const botReviews = reviews.filter((r) => r.user?.type === 'Bot' && r.user.login === ourLogin);
 		if (botReviews.length === 0) {
 			console.log(`turbodiff: auto-merge waiting on review for ${label}`);
 			return;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -21,6 +21,7 @@ export interface RepositoryRow {
 	review_on_push: number; // re-dispatch tiered agents on pushes to open PRs
 	blocking_reviews: number; // P1 → REQUEST_CHANGES, clean → APPROVE
 	auto_fix: number; // dispatch the fix agent when a blocking review lands
+	auto_merge: number; // merge factory PRs when verification + review are clean
 	check_command: string | null; // sandbox verification gate before factory pushes
 	run_command: string | null; // how to launch the app for runtime verification
 	app_port: number | null; // port the launched app listens on
@@ -151,6 +152,12 @@ export async function setRepoAutoFix(id: number, on: boolean): Promise<void> {
 		.run();
 }
 
+export async function setRepoAutoMerge(id: number, on: boolean): Promise<void> {
+	await env.DB.prepare('UPDATE repositories SET auto_merge = ?2 WHERE id = ?1')
+		.bind(id, on ? 1 : 0)
+		.run();
+}
+
 // The sandbox verification gate for factory pushes. Empty string clears it.
 export async function setRepoCheckCommand(id: number, command: string): Promise<void> {
 	const trimmed = command.trim();
@@ -173,6 +180,38 @@ export async function setRepoRunCommand(
 }
 
 // --- verifications (Phase 4: empirical acceptance-criteria checks) ---
+
+export interface VerificationRow {
+	id: number;
+	feature_id: number;
+	status: string;
+	results: string | null;
+	summary: string | null;
+	error: string | null;
+	created_at: string;
+}
+
+// The feature a factory PR belongs to (null for human-authored PRs).
+export async function getFeatureByRepoPr(
+	repositoryId: number,
+	prNumber: number,
+): Promise<FeatureRow | null> {
+	return env.DB.prepare(
+		'SELECT * FROM features WHERE repository_id = ?1 AND pr_number = ?2 ORDER BY id DESC LIMIT 1',
+	)
+		.bind(repositoryId, prNumber)
+		.first<FeatureRow>();
+}
+
+export async function latestVerificationForFeature(
+	featureId: number,
+): Promise<VerificationRow | null> {
+	return env.DB.prepare(
+		'SELECT * FROM verifications WHERE feature_id = ?1 ORDER BY id DESC LIMIT 1',
+	)
+		.bind(featureId)
+		.first<VerificationRow>();
+}
 
 export async function createVerification(featureId: number): Promise<number> {
 	const row = await env.DB.prepare(
@@ -328,6 +367,8 @@ export interface PlanWithRepo extends PlanRow {
 	name: string;
 	installation_id: number;
 	pr_number: number | null; // from the linked feature, if generation started
+	verification_status: string | null; // latest verification for the feature
+	verification_results: string | null; // its per-criterion results JSON
 }
 
 // Plans across the given installations, newest first, with repo + generated-PR
@@ -339,10 +380,13 @@ export async function listPlansForInstallations(
 	if (installationIds.length === 0) return [];
 	const placeholders = installationIds.map((_, i) => `?${i + 2}`).join(', ');
 	const res = await env.DB.prepare(
-		`SELECT p.*, r.owner, r.name, r.installation_id, f.pr_number AS pr_number
+		`SELECT p.*, r.owner, r.name, r.installation_id, f.pr_number AS pr_number,
+		        v.status AS verification_status, v.results AS verification_results
 		 FROM plans p
 		 JOIN repositories r ON r.id = p.repository_id
 		 LEFT JOIN features f ON f.id = p.feature_id
+		 LEFT JOIN verifications v ON v.id =
+		   (SELECT MAX(id) FROM verifications WHERE feature_id = p.feature_id)
 		 WHERE r.installation_id IN (${placeholders})
 		 ORDER BY p.id DESC
 		 LIMIT ?1`,

--- a/src/lib/fixer.ts
+++ b/src/lib/fixer.ts
@@ -1,7 +1,7 @@
 import { getSandbox, type Sandbox } from '@cloudflare/sandbox';
 import { env } from 'cloudflare:workers';
 import { gh } from '../tools/github.ts';
-import { finishFixAttempt, getRepoById, tryRecordFixAttempt } from './db.ts';
+import { finishFixAttempt, getFeatureByRepoPr, getRepoById, tryRecordFixAttempt } from './db.ts';
 import { installationToken, sandboxGitToken } from './github-app.ts';
 import { UNTRUSTED_CONTENT_RULES } from './prompt-security.ts';
 
@@ -381,6 +381,14 @@ export async function processFixMessage(msg: FixQueueMessage): Promise<void> {
 		});
 		await finishFixAttempt(attemptId, outcome.status, outcome.commit);
 		console.log(`turbodiff: fix ${outcome.status} for ${label} (attempt ${attemptId})`);
+		// A fix push invalidates prior verification evidence: re-verify factory
+		// PRs so the report (and the auto-merge gate) reflects the fixed code.
+		if (outcome.status === 'fixed') {
+			const feature = await getFeatureByRepoPr(repo.id, msg.prNumber);
+			if (feature?.acceptance) {
+				await env.FACTORY_QUEUE.send({ kind: 'verify', featureId: feature.id });
+			}
+		}
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		await finishFixAttempt(attemptId, 'failed', undefined, message.slice(0, 500));

--- a/src/lib/verifier.ts
+++ b/src/lib/verifier.ts
@@ -9,6 +9,7 @@ import {
 	type FeatureRow,
 	type RepositoryRow,
 } from './db.ts';
+import { maybeAutoMerge } from './auto-merge.ts';
 import { signArtifactKey } from './crypto.ts';
 import { resolveRunnerAuth } from './fixer.ts';
 import { installationToken, sandboxGitToken } from './github-app.ts';
@@ -176,6 +177,9 @@ async function verify(
 
 		const failed = results.filter((r) => r.verdict === 'fail');
 		await postReport(token, repo, feature, criteria, results, shots, summary);
+		if (failed.length === 0) {
+			await maybeAutoMerge(repo, feature.pr_number!);
+		}
 
 		// Conformance gate: unmet criteria feed the existing fix loop (toggle and
 		// cap are re-validated by the consumer, exactly like review-driven fixes).

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -32,6 +32,7 @@ import {
 	resolveAgentEnabled,
 	setRepoAgentEnabled,
 	setRepoAutoFix,
+	setRepoAutoMerge,
 	setRepoBlockingReviews,
 	setRepoCheckCommand,
 	setRepoEnabled,
@@ -294,6 +295,29 @@ const PLAN_STATUS_HINT: Record<string, string> = {
 
 const RUNNING_PLAN_STATUSES = new Set(['analyzing', 'refining']);
 
+// Latest verification for an approved plan's feature, as a compact pill:
+// passed (n/n) / failed (n unmet) / running / error. Full evidence lives in
+// the PR's report comment.
+function renderVerification(p: PlanWithRepo): HtmlEscapedString | Promise<HtmlEscapedString> | '' {
+	if (!p.verification_status) return '';
+	let detail = '';
+	try {
+		const results = JSON.parse(p.verification_results ?? '[]') as { verdict: string }[];
+		const failed = results.filter((r) => r.verdict === 'fail').length;
+		if (p.verification_status === 'passed') detail = ` (${results.length}/${results.length})`;
+		else if (p.verification_status === 'failed') detail = ` (${failed} unmet)`;
+	} catch {
+		// results unparsable — show the bare status
+	}
+	const cls =
+		p.verification_status === 'passed'
+			? 'on'
+			: p.verification_status === 'running'
+				? 'running'
+				: 'red';
+	return html` <span class="pill ${cls}">verify: ${p.verification_status}${detail}</span>`;
+}
+
 // One plan card: status, plus the interactive surface for its current state
 // (answer form when awaiting answers, plan + approve when ready, PR link once
 // generating).
@@ -341,6 +365,7 @@ function renderPlan(p: PlanWithRepo): HtmlEscapedString | Promise<HtmlEscapedStr
 					<a href="https://github.com/${p.owner}/${p.name}/pull/${p.pr_number}"
 						>pull request #${p.pr_number} &rarr;</a
 					>
+					${renderVerification(p)}
 				</p>`
 			: ''}
 	</div>`;
@@ -1191,6 +1216,16 @@ export function createSettingsRoutes() {
 																				&#128295; auto-fix
 																			</button>
 																		</form>
+																		<form method="post" action="/repos/${r.id}/automerge-toggle">
+																			<button
+																				class="chip ${r.auto_merge ? 'on' : ''}"
+																				title="${r.auto_merge
+																					? 'factory PRs stay open for a human to merge'
+																					: 'factory PRs merge automatically once verification passes and the review is clean (requires blocking reviews)'} — click to ${r.auto_merge ? 'disable' : 'enable'}"
+																			>
+																				&#127981; auto-merge
+																			</button>
+																		</form>
 																		<form method="post" action="/repos/${r.id}/check-command" class="check-cmd">
 																			<input
 																				type="text"
@@ -1282,6 +1317,20 @@ export function createSettingsRoutes() {
 		}
 
 		await setRepoAutoFix(repo.id, !repo.auto_fix);
+		return c.redirect('/settings');
+	});
+
+	app.post('/repos/:id/automerge-toggle', async (c) => {
+		const user = await requireUser(c);
+		if (!user) return c.redirect('/auth/login');
+
+		const repoId = Number(c.req.param('id'));
+		const repo = Number.isInteger(repoId) ? await getRepoById(repoId) : null;
+		if (!repo || !user.installationIds.includes(repo.installation_id)) {
+			return c.text('unknown repository', 404);
+		}
+
+		await setRepoAutoMerge(repo.id, !repo.auto_merge);
 		return c.redirect('/settings');
 	});
 

--- a/src/tools/github.ts
+++ b/src/tools/github.ts
@@ -1,6 +1,7 @@
 import { defineTool } from '@flue/runtime';
 import { env } from 'cloudflare:workers';
 import * as v from 'valibot';
+import { maybeAutoMerge } from '../lib/auto-merge.ts';
 import { completeReview, getRepoByFullName } from '../lib/db.ts';
 import { installationToken } from '../lib/github-app.ts';
 
@@ -429,6 +430,11 @@ export const makePostReview = (agentInstanceId: string) =>
 					prNumber: data.number,
 					trigger: 'blocking_review_self',
 				});
+			}
+			// Clean verdict on a factory PR: the verification may already have
+			// passed while this review was running — try the merge gate now.
+			if (intended !== 'REQUEST_CHANGES') {
+				await maybeAutoMerge(row, data.number);
 			}
 			return { output };
 		},


### PR DESCRIPTION
The trust layer: evidence stays current, is visible, and — when you opt in — acts.

## Re-verification after fix pushes
A successful fix on a factory PR re-enqueues the verify run, so the PR's evidence report and the merge gate always describe the *fixed* code. The verify↔fix chain is bounded: each failed verification enqueues at most one fix, and fixes cap at 3 per PR.

## Verification on the factory tab
Each approved plan now shows its latest verification as a pill next to the PR link — `verify: passed (15/15)`, `failed (2 unmet)`, or `running`. Full evidence stays in the PR report comment.

## Opt-in auto-merge (Phase 5)
- New 🏭 **auto-merge** chip per repo (migration 0014), **default off**, and only honored when blocking reviews are also on — no gate, no auto-merge.
- A factory PR merges itself only when **both** gates are green: latest empirical verification `passed`, and ≥1 review exists with **zero** blocking-intent reviews anywhere in the PR's history (a once-blocked-then-fixed PR deliberately stays for a human).
- Verification and review complete concurrently, so **both** completion paths attempt the gate — no ordering race.
- Any ambiguity or failure (missing review, conflicts, branch protection) declines quietly; the PR stays open for a human. Human-authored PRs are never touched.
- SECURITY.md updated: both gates are agent-produced — enable only where a bad merge is cheap to revert.

## Deploy
Merge → `wrangler d1 migrations apply turbodiff --remote` (0014) → `pnpm run deploy`. No new account resources.

## Validation
typecheck + lint + build clean; migration applied locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)