### PR TITLE
Factory PR cockpit v1: SSR diff viewer, demo recordings, merge action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install -g @anthropic-ai/claude-code pnpm
 # ad-hoc scripts require the global puppeteer-core install.
 RUN apt-get update && \
 	curl -fsSL -o /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-	apt-get install -y --no-install-recommends /tmp/chrome.deb && \
+	apt-get install -y --no-install-recommends /tmp/chrome.deb ffmpeg && \
 	rm /tmp/chrome.deb && rm -rf /var/lib/apt/lists/* && \
 	npm install -g puppeteer-core
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable

--- a/migrations/0015_demo_recording.sql
+++ b/migrations/0015_demo_recording.sql
@@ -1,0 +1,4 @@
+-- Demo recordings: the verifier records a short screen capture (WebM) of the
+-- feature's happy path. The R2 key is stored as JSON {"video": key}; the
+-- factory PR cockpit signs it at render time and plays it natively.
+ALTER TABLE verifications ADD COLUMN demo TEXT;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	"dependencies": {
 		"@cloudflare/sandbox": "^0.12.4",
 		"@flue/runtime": "^2.0.1",
+		"@pierre/diffs": "^1.3.4",
 		"agents": "^0.14.2",
 		"hono": "^4.7.0",
 		"valibot": "^1.4.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@flue/runtime':
         specifier: ^2.0.1
         version: 2.0.1(patch_hash=6bfbc4c1e00a6c521d7070d99ee25af60a34df651b4b2e5814c18dfa46cc32a9)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@7.0.2)(ws@8.21.1)(zod@4.4.3)
+      '@pierre/diffs':
+        specifier: ^1.3.4
+        version: 1.3.4(@shikijs/themes@4.4.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       agents:
         specifier: ^0.14.2
         version: 0.14.5(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260801.1)(ai@6.0.240(zod@4.4.3))(react@19.2.8)(rolldown@1.2.2)(vite@8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))(zod@4.4.3)
@@ -846,6 +849,36 @@ packages:
   '@oxc-project/types@0.142.0':
     resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
+  '@pierre/diffs@1.3.4':
+    resolution: {integrity: sha512-6Dt48jQIL+H54QyNB943Oqn5p4uRw7NpiXLSEapnaYgYvTmSHNPAUCDfg6AcRC+W02z0IYJnJJvcs3lsNp7gCw==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+
+  '@pierre/theme@2.0.0':
+    resolution: {integrity: sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw==}
+    engines: {vscode: ^1.0.0}
+
+  '@pierre/theming@1.0.1':
+    resolution: {integrity: sha512-WCI5Qd7iprDpISL9fBYOLe8RV53+b7mFNA3bPzl60/2CKCSrsKN8zEcep6Y3BAzvARlmca50zGjDodqPGiTUKA==}
+    peerDependencies:
+      '@pierre/theme': ^1.1.0 || ^2.0.0
+      '@shikijs/themes': ^3.0.0 || ^4.0.0
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+      shiki: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@pierre/theme':
+        optional: true
+      '@shikijs/themes':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      shiki:
+        optional: true
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -992,6 +1025,41 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@shikijs/core@4.4.2':
+    resolution: {integrity: sha512-StyzbAyxg2/tBGf78gwbBkGyeQ73lf8UiJArFaQhTQIDqQOCKPCQFanvrs4/Yv3Yfyc+ONInJM6K+FMIf+P+kA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.4.2':
+    resolution: {integrity: sha512-MnIkeqWdVPUWsxlx8gKLVCJFTsqrQJgpTPBPpQwaFeJ56lOnJxj5aN2LUFnfxUEcvOQuNocmbaMnVrCEln6rkw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.4.2':
+    resolution: {integrity: sha512-GLhowz1+jixjz+wiZ3wMnOn1jTxiFCGl2PkXufivbnwPHKuyw1AYqu5/hbWhZZ2oAb0NP05WUJhYeigY14drnw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.4.2':
+    resolution: {integrity: sha512-8DfeusD+Zdv/eYIDdXyJTUnSMHt+aAWjAOCXV20HNGAHRlInXpG8wh421v6B91WOm9TFwRLN+b/LG5F2NAIojg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.4.2':
+    resolution: {integrity: sha512-l6fQQKsOMlz72n38fztmSgZ76MO6KSWuw8o+GJ+FhmqrpC9pIOJNQNXGgbb5yX2AwpzlEHwsaLPnk/8o4Fm+rA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.4.2':
+    resolution: {integrity: sha512-H0CFoL07ddDC2Dd6EdrPYNkRhUR6YCkJlnuYFceYYUJJA5TIm2b5B33qqiDYryBExgbKMndFJPb2u1gTuqO37g==}
+    engines: {node: '>=20'}
+
+  '@shikijs/transformers@4.4.2':
+    resolution: {integrity: sha512-d81PJ9KkR1tVP95FH/9296HTtDo0mh76wv10u9T1YmsZq/UcXgt0OLdBszfUQ1i+umkRMCjDnFbFZU7/tCODTQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.4.2':
+    resolution: {integrity: sha512-PFYitV4vpDr/iPCIhnHp+Q4ftic5N5VeNJ3KQ1O8gn3h2ar8qgwMAXF7tq4m1CWaMS60fV4VqF6vfnWH4F7vqQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
@@ -1049,14 +1117,23 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -1177,6 +1254,9 @@ packages:
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
   '@valibot/to-json-schema@1.7.1':
     resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
@@ -1330,12 +1410,24 @@ packages:
   capnweb@0.8.0:
     resolution: {integrity: sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
@@ -1408,12 +1500,23 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dunder-proto@1.0.1:
@@ -1606,9 +1709,18 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hono@4.12.34:
     resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -1801,12 +1913,18 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru_map@0.4.1:
+    resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
+
   magic-string@1.1.0:
     resolution: {integrity: sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
   media-typer@1.1.1:
     resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
@@ -1815,6 +1933,21 @@ packages:
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -1925,6 +2058,12 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   openai@6.26.0:
     resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
     hasBin: true
@@ -2006,6 +2145,9 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   protobufjs@7.6.5:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
@@ -2043,6 +2185,11 @@ packages:
   re2js@1.3.3:
     resolution: {integrity: sha512-s/I5zEAo79SUK0Qw4dpZKpiMwbQ6Gz0KU2NRr7eaO4x/p2g7Vvmn3hdeXDg8VsaUjfj/ora+e9oi27LX/C9+mw==}
 
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
+    peerDependencies:
+      react: ^19.2.8
+
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
@@ -2050,6 +2197,15 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -2073,6 +2229,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   seek-bzip@2.0.0:
     resolution: {integrity: sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==}
@@ -2110,6 +2269,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shiki@4.4.2:
+    resolution: {integrity: sha512-P8F/dFhRevaw2uSdeIYlq/5SXZNY85DPtmXQ947gD1Zj2JqO5AkNvVVBar0Me9JkFx3uzVud/qOtP5ek9NEQGA==}
+    engines: {node: '>=20'}
+
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
@@ -2143,6 +2306,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
@@ -2163,6 +2329,9 @@ packages:
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
@@ -2201,6 +2370,9 @@ packages:
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
@@ -2253,6 +2425,21 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -2277,6 +2464,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.2.0:
     resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
@@ -2413,6 +2606,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -3314,6 +3510,30 @@ snapshots:
 
   '@oxc-project/types@0.142.0': {}
 
+  '@pierre/diffs@1.3.4(@shikijs/themes@4.4.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@pierre/theme': 2.0.0
+      '@pierre/theming': 1.0.1(@pierre/theme@2.0.0)(@shikijs/themes@4.4.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.4.2)
+      '@shikijs/transformers': 4.4.2
+      diff: 9.0.0
+      hast-util-to-html: 9.0.5
+      lru_map: 0.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      shiki: 4.4.2
+    transitivePeerDependencies:
+      - '@shikijs/themes'
+
+  '@pierre/theme@2.0.0': {}
+
+  '@pierre/theming@1.0.1(@pierre/theme@2.0.0)(@shikijs/themes@4.4.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.4.2)':
+    optionalDependencies:
+      '@pierre/theme': 2.0.0
+      '@shikijs/themes': 4.4.2
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      shiki: 4.4.2
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -3399,6 +3619,51 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@shikijs/core@4.4.2':
+    dependencies:
+      '@shikijs/primitive': 4.4.2
+      '@shikijs/types': 4.4.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.4.2':
+    dependencies:
+      '@shikijs/types': 4.4.2
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.4.2':
+    dependencies:
+      '@shikijs/types': 4.4.2
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.4.2':
+    dependencies:
+      '@shikijs/types': 4.4.2
+
+  '@shikijs/primitive@4.4.2':
+    dependencies:
+      '@shikijs/types': 4.4.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/themes@4.4.2':
+    dependencies:
+      '@shikijs/types': 4.4.2
+
+  '@shikijs/transformers@4.4.2':
+    dependencies:
+      '@shikijs/core': 4.4.2
+      '@shikijs/types': 4.4.2
+
+  '@shikijs/types@4.4.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@sindresorhus/is@7.2.0': {}
 
   '@smithy/core@3.31.1':
@@ -3467,13 +3732,23 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/node@22.20.1':
     dependencies:
       undici-types: 6.21.0
 
   '@types/retry@0.12.0': {}
+
+  '@types/unist@3.0.3': {}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -3534,6 +3809,8 @@ snapshots:
 
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
+
+  '@ungap/structured-clone@1.3.3': {}
 
   '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@7.0.2))':
     dependencies:
@@ -3681,6 +3958,12 @@ snapshots:
 
   capnweb@0.8.0: {}
 
+  ccount@2.0.1: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
   chownr@1.1.4:
     optional: true
 
@@ -3689,6 +3972,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@6.2.1: {}
 
@@ -3737,9 +4022,17 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
   diff@8.0.4: {}
+
+  diff@9.0.0: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3990,7 +4283,27 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
   hono@4.12.34: {}
+
+  html-void-elements@3.0.0: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -4164,15 +4477,46 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru_map@0.4.1: {}
+
   magic-string@1.1.0:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   media-typer@1.1.1: {}
 
   merge-descriptors@2.0.0: {}
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
 
   mime-db@1.52.0: {}
 
@@ -4272,6 +4616,14 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   openai@6.26.0(ws@8.21.1)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.1
@@ -4342,6 +4694,8 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  property-information@7.2.0: {}
+
   protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -4403,6 +4757,11 @@ snapshots:
 
   re2js@1.3.3: {}
 
+  react-dom@19.2.8(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
   react@19.2.8: {}
 
   readable-stream@3.6.2:
@@ -4411,6 +4770,16 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
     optional: true
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
 
   require-from-string@2.0.2: {}
 
@@ -4449,6 +4818,8 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  scheduler@0.27.0: {}
 
   seek-bzip@2.0.0:
     dependencies:
@@ -4523,6 +4894,17 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shiki@4.4.2:
+    dependencies:
+      '@shikijs/core': 4.4.2
+      '@shikijs/engine-javascript': 4.4.2
+      '@shikijs/engine-oniguruma': 4.4.2
+      '@shikijs/langs': 4.4.2
+      '@shikijs/themes': 4.4.2
+      '@shikijs/types': 4.4.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -4567,6 +4949,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   sprintf-js@1.1.3: {}
 
   sql.js@1.14.1: {}
@@ -4588,6 +4972,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
     optional: true
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-ansi@7.2.0:
     dependencies:
@@ -4635,6 +5024,8 @@ snapshots:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  trim-lines@3.0.1: {}
 
   ts-algebra@2.0.0: {}
 
@@ -4700,6 +5091,29 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   unpipe@1.0.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.7):
@@ -4716,6 +5130,16 @@ snapshots:
       typescript: 7.0.2
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.2.0(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0):
     dependencies:
@@ -4810,3 +5234,5 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
+
+  zwitch@2.0.4: {}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -187,6 +187,7 @@ export interface VerificationRow {
 	status: string;
 	results: string | null;
 	summary: string | null;
+	demo: string | null; // JSON {"video": r2Key, "caption": string}
 	error: string | null;
 	created_at: string;
 }
@@ -225,13 +226,27 @@ export async function createVerification(featureId: number): Promise<number> {
 export async function finishVerification(
 	id: number,
 	status: string,
-	fields: { results?: string; summary?: string; error?: string } = {},
+	fields: { results?: string; summary?: string; error?: string; demo?: string } = {},
 ): Promise<void> {
 	await env.DB.prepare(
-		'UPDATE verifications SET status = ?2, results = ?3, summary = ?4, error = ?5 WHERE id = ?1',
+		'UPDATE verifications SET status = ?2, results = ?3, summary = ?4, error = ?5, demo = ?6 WHERE id = ?1',
 	)
-		.bind(id, status, fields.results ?? null, fields.summary ?? null, fields.error ?? null)
+		.bind(
+			id,
+			status,
+			fields.results ?? null,
+			fields.summary ?? null,
+			fields.error ?? null,
+			fields.demo ?? null,
+		)
 		.run();
+}
+
+// The plan a factory feature came from (null for direct /internal/generate).
+export async function getPlanByFeatureId(featureId: number): Promise<PlanRow | null> {
+	return env.DB.prepare('SELECT * FROM plans WHERE feature_id = ?1 ORDER BY id DESC LIMIT 1')
+		.bind(featureId)
+		.first<PlanRow>();
 }
 
 // --- fix attempts (auto-fix loop bookkeeping + iteration cap) ---
@@ -369,6 +384,7 @@ export interface PlanWithRepo extends PlanRow {
 	pr_number: number | null; // from the linked feature, if generation started
 	verification_status: string | null; // latest verification for the feature
 	verification_results: string | null; // its per-criterion results JSON
+	verification_demo: string | null; // its demo JSON {"video": r2Key}
 }
 
 // Plans across the given installations, newest first, with repo + generated-PR
@@ -381,7 +397,8 @@ export async function listPlansForInstallations(
 	const placeholders = installationIds.map((_, i) => `?${i + 2}`).join(', ');
 	const res = await env.DB.prepare(
 		`SELECT p.*, r.owner, r.name, r.installation_id, f.pr_number AS pr_number,
-		        v.status AS verification_status, v.results AS verification_results
+		        v.status AS verification_status, v.results AS verification_results,
+		        v.demo AS verification_demo
 		 FROM plans p
 		 JOIN repositories r ON r.id = p.repository_id
 		 LEFT JOIN features f ON f.id = p.feature_id

--- a/src/lib/verifier.ts
+++ b/src/lib/verifier.ts
@@ -1,4 +1,4 @@
-import { getSandbox, type Sandbox } from '@cloudflare/sandbox';
+import { collectFile, getSandbox, type Sandbox } from '@cloudflare/sandbox';
 import { env } from 'cloudflare:workers';
 import { gh } from '../tools/github.ts';
 import {
@@ -63,7 +63,20 @@ ${SHOTS_DIR}/ (create it). Write capture scripts as CommonJS (.cjs files using
 require('puppeteer-core')) — ESM import cannot resolve the global install.
 Launch with args ['--no-sandbox', '--disable-dev-shm-usage']. Use descriptive
 kebab-case filenames and reference each screenshot from the matching
-criterion result.`
+criterion result.
+
+## Demo recording
+Also record ONE short screen recording (10–30 seconds) demonstrating the
+feature's happy path end to end. This is what humans watch, so drive it like a
+demo: pause about a second between meaningful steps and let each state change
+be visible before moving on. In a .cjs script, use puppeteer's screencast API:
+
+    const recorder = await page.screencast({ path: '${OUT_DIR}/demo.webm' });
+    // ... drive the flow deliberately ...
+    await recorder.stop();
+
+Write a one-line caption for the recording to ${OUT_DIR}/demo-caption.txt.
+If the app cannot run, skip the recording.`
 		: `## Running the app
 No run command is configured for this repository, so runtime and visual checks
 are unavailable. Verify what can be verified statically from the tree; mark
@@ -113,6 +126,7 @@ export async function runVerification(featureId: number): Promise<void> {
 		await finishVerification(verificationId, outcome.status, {
 			results: JSON.stringify(outcome.results),
 			summary: outcome.summary,
+			demo: outcome.demo ? JSON.stringify({ video: outcome.demo.key, caption: outcome.demo.caption }) : undefined,
 		});
 		console.log(`turbodiff: verification ${outcome.status} for ${label}`);
 	} catch (err) {
@@ -126,7 +140,7 @@ async function verify(
 	feature: FeatureRow,
 	repo: RepositoryRow,
 	criteria: string[],
-): Promise<{ status: string; results: CriterionResult[]; summary?: string }> {
+): Promise<{ status: string; results: CriterionResult[]; summary?: string; demo?: DemoInfo }> {
 	const token = await installationToken(repo.installation_id);
 	const auth = resolveRunnerAuth();
 	// Verifier sandboxes never push: single-repo, contents READ-ONLY token.
@@ -174,9 +188,10 @@ async function verify(
 		const results = await readResults(sandbox, criteria.length);
 		const summary = await readText(sandbox, `${OUT_DIR}/summary.md`);
 		const shots = await uploadScreenshots(sandbox, feature.id, results);
+		const demo = await uploadDemo(sandbox, feature.id);
 
 		const failed = results.filter((r) => r.verdict === 'fail');
-		await postReport(token, repo, feature, criteria, results, shots, summary);
+		await postReport(token, repo, feature, criteria, results, shots, summary, demo);
 		if (failed.length === 0) {
 			await maybeAutoMerge(repo, feature.pr_number!);
 		}
@@ -194,7 +209,7 @@ async function verify(
 					.join('\n\n'),
 			});
 		}
-		return { status: failed.length > 0 ? 'failed' : 'passed', results, summary };
+		return { status: failed.length > 0 ? 'failed' : 'passed', results, summary, demo };
 	} finally {
 		await sandbox
 			.exec(`git -C ${CLONE_DIR} remote set-url origin "https://github.com/${full}.git"`)
@@ -236,8 +251,17 @@ async function readText(sandbox: Sandbox, path: string): Promise<string | undefi
 	}
 }
 
-// Screenshots leave the sandbox base64-encoded (binary-safe over the exec
-// transport) and land in R2 under verify/<featureId>/, served publicly by the
+// Binary-safe read out of the sandbox via the SDK's file streaming.
+async function readBinary(sandbox: Sandbox, path: string): Promise<Uint8Array | null> {
+	try {
+		const { content } = await collectFile(await sandbox.readFileStream(path));
+		return content instanceof Uint8Array ? content : new TextEncoder().encode(content);
+	} catch {
+		return null;
+	}
+}
+
+// Screenshots land in R2 under verify/<featureId>/, served via the signed
 // GET /artifacts/* route so they render inline in the PR comment.
 async function uploadScreenshots(
 	sandbox: Sandbox,
@@ -249,17 +273,39 @@ async function uploadScreenshots(
 	for (const name of wanted) {
 		const safe = name.replace(/[^\w.-]/g, '');
 		if (!safe.endsWith('.png')) continue;
-		const b64 = await sandbox.exec(`base64 < "${SHOTS_DIR}/${safe}" | tr -d '\\n'`, {
-			timeout: 30_000,
-		});
-		if (!b64.success || !b64.stdout.trim()) continue;
-		const bytes = Uint8Array.from(atob(b64.stdout.trim()), (c) => c.charCodeAt(0));
+		const bytes = await readBinary(sandbox, `${SHOTS_DIR}/${safe}`);
+		if (!bytes || bytes.length === 0) continue;
 		const key = `verify/${featureId}/${safe}`;
 		await env.ARTIFACTS.put(key, bytes, { httpMetadata: { contentType: 'image/png' } });
 		const sig = await signArtifactKey(key);
 		urls.set(name, `${env.PUBLIC_BASE_URL}/artifacts/${key}?sig=${sig}`);
 	}
 	return urls;
+}
+
+interface DemoInfo {
+	key: string;
+	url: string;
+	caption?: string;
+}
+
+// The demo recording: WebM to R2; the cockpit plays it natively and the PR
+// comment links it. 40MB guard against runaway recordings.
+async function uploadDemo(sandbox: Sandbox, featureId: number): Promise<DemoInfo | undefined> {
+	const stat = await sandbox.exec(`stat -c %s "${OUT_DIR}/demo.webm"`, { timeout: 15_000 });
+	const size = Number(stat.stdout.trim());
+	if (!stat.success || !Number.isFinite(size) || size === 0) return undefined;
+	if (size > 40 * 1024 * 1024) {
+		console.warn(`turbodiff: demo recording too large (${size} bytes), skipping upload`);
+		return undefined;
+	}
+	const bytes = await readBinary(sandbox, `${OUT_DIR}/demo.webm`);
+	if (!bytes || bytes.length === 0) return undefined;
+	const key = `verify/${featureId}/demo.webm`;
+	await env.ARTIFACTS.put(key, bytes, { httpMetadata: { contentType: 'video/webm' } });
+	const sig = await signArtifactKey(key);
+	const caption = await readText(sandbox, `${OUT_DIR}/demo-caption.txt`);
+	return { key, url: `${env.PUBLIC_BASE_URL}/artifacts/${key}?sig=${sig}`, caption };
 }
 
 const VERDICT_BADGE: Record<CriterionResult['verdict'], string> = {
@@ -276,11 +322,16 @@ async function postReport(
 	results: CriterionResult[],
 	shots: Map<string, string>,
 	summary?: string,
+	demo?: DemoInfo,
 ): Promise<void> {
 	const failed = results.filter((r) => r.verdict === 'fail').length;
+	const cockpit = `${env.PUBLIC_BASE_URL}/factory/features/${feature.id}`;
 	const lines = [
 		`## 🔍 Turbodiff verification — ${failed === 0 ? 'all criteria met' : `${failed} criteria not met`}`,
 		'',
+		...(demo
+			? [`🎬 **[Watch the demo & review this PR in Turbodiff](${cockpit})** — ${demo.caption ?? 'screen recording of the feature in action'} ([raw video](${demo.url}))`, '']
+			: [`🔎 **[Review this PR in Turbodiff](${cockpit})**`, '']),
 		'| | Criterion | Evidence |',
 		'|---|---|---|',
 		...results.map((r) => {

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -1,7 +1,7 @@
 import { env } from 'cloudflare:workers';
 import { Hono, type Context } from 'hono';
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie';
-import { html } from 'hono/html';
+import { html, raw } from 'hono/html';
 import type { HtmlEscapedString } from 'hono/utils/html';
 import {
 	agentUsageForMonth,
@@ -11,6 +11,9 @@ import {
 	createAgentConnection,
 	createPlan,
 	getPlan,
+	getPlanByFeatureId,
+	getFeature,
+	latestVerificationForFeature,
 	listPlansForInstallations,
 	updatePlan,
 	dashboardStats,
@@ -44,7 +47,11 @@ import {
 	type PlanWithRepo,
 	type ReviewActivityRow,
 } from '../lib/db.ts';
+import { parsePatchFiles, wrapCoreCSS } from '@pierre/diffs';
+import { preloadDiffHTML } from '@pierre/diffs/ssr';
 import { approvePlan } from '../lib/planner.ts';
+import { signArtifactKey } from '../lib/crypto.ts';
+import { gh } from '../tools/github.ts';
 import { encryptionConfigured, openToken, sealToken } from '../lib/crypto.ts';
 import { testMcpEndpoint } from '../lib/mcp-test.ts';
 import { DEFAULT_MODEL, RESERVED_AGENT_SLUGS } from '../lib/personas.ts';
@@ -52,6 +59,7 @@ import {
 	exchangeOAuthCode,
 	fetchUser,
 	fetchUserInstallationIds,
+	installationToken,
 	oauthAuthorizeUrl,
 } from '../lib/github-app.ts';
 import {
@@ -298,6 +306,23 @@ const RUNNING_PLAN_STATUSES = new Set(['analyzing', 'refining']);
 // Latest verification for an approved plan's feature, as a compact pill:
 // passed (n/n) / failed (n unmet) / running / error. Full evidence lives in
 // the PR's report comment.
+// Inline pill for the cockpit header, from raw status + results.
+function renderVerificationInline(
+	status: string | null,
+	results: { verdict: string }[],
+): HtmlEscapedString | Promise<HtmlEscapedString> | '' {
+	if (!status) return '';
+	const failed = results.filter((r) => r.verdict === 'fail').length;
+	const detail =
+		status === 'passed'
+			? ` (${results.length}/${results.length})`
+			: status === 'failed'
+				? ` (${failed} unmet)`
+				: '';
+	const cls = status === 'passed' ? 'on' : status === 'running' ? 'running' : 'red';
+	return html` · <span class="pill ${cls}">verify: ${status}${detail}</span>`;
+}
+
 function renderVerification(p: PlanWithRepo): HtmlEscapedString | Promise<HtmlEscapedString> | '' {
 	if (!p.verification_status) return '';
 	let detail = '';
@@ -362,8 +387,9 @@ function renderPlan(p: PlanWithRepo): HtmlEscapedString | Promise<HtmlEscapedStr
 			: ''}
 		${p.status === 'approved' && p.pr_number
 			? html`<p style="margin-top:0.4rem">
-					<a href="https://github.com/${p.owner}/${p.name}/pull/${p.pr_number}"
-						>pull request #${p.pr_number} &rarr;</a
+					<a href="/factory/features/${p.feature_id}"><strong>open in cockpit &rarr;</strong></a>
+					· <a href="https://github.com/${p.owner}/${p.name}/pull/${p.pr_number}"
+						>PR #${p.pr_number}</a
 					>
 					${renderVerification(p)}
 				</p>`
@@ -1363,6 +1389,216 @@ export function createSettingsRoutes() {
 
 		await setRepoEnabled(repo.id, !repo.enabled);
 		return c.redirect('/settings');
+	});
+
+	// --- Factory PR cockpit (v1, server-rendered) ---
+	// One screen for reviewing a factory PR without GitHub: demo video, full
+	// diff (SSR-rendered via @pierre/diffs), acceptance evidence, review
+	// verdicts, and the merge action. GitHub stays the system of record; this
+	// is the review surface. v2 hydrates this markup with @pierre/diffs/react
+	// for inline commenting that feeds the fix loop.
+
+	app.get('/factory/features/:id', async (c) => {
+		const user = await requireUser(c);
+		if (!user) return c.redirect('/auth/login');
+
+		const id = Number(c.req.param('id'));
+		const feature = Number.isInteger(id) ? await getFeature(id) : null;
+		const repo = feature ? await getRepoById(feature.repository_id) : null;
+		if (!feature || !repo || !user.installationIds.includes(repo.installation_id)) {
+			return c.text('unknown feature', 404);
+		}
+		if (!feature.pr_number) {
+			return c.html(
+				page(
+					`Turbodiff — ${feature.title}`,
+					html`${topbar(user.session.login)} ${tabs('factory')}
+						<h2>${feature.title}</h2>
+						<p class="muted">No pull request yet — generation is ${feature.status}.</p>`,
+				),
+			);
+		}
+
+		const [plan, verification, token] = await Promise.all([
+			getPlanByFeatureId(feature.id),
+			latestVerificationForFeature(feature.id),
+			installationToken(repo.installation_id),
+		]);
+		const base = `/repos/${repo.owner}/${repo.name}`;
+		const [prMeta, prFiles, prReviews] = await Promise.all([
+			gh(token, `${base}/pulls/${feature.pr_number}`).then(
+				(r) =>
+					r.json() as Promise<{
+						state: string;
+						merged: boolean;
+						html_url: string;
+						additions: number;
+						deletions: number;
+						changed_files: number;
+					}>,
+			),
+			gh(token, `${base}/pulls/${feature.pr_number}/files?per_page=100`).then(
+				(r) =>
+					r.json() as Promise<
+						{ filename: string; status: string; additions: number; deletions: number; patch?: string }[]
+					>,
+			),
+			gh(token, `${base}/pulls/${feature.pr_number}/reviews?per_page=100`).then(
+				(r) =>
+					r.json() as Promise<{ state: string; body: string; user: { login: string } | null }[]>,
+			),
+		]);
+
+		// SSR-render each file's diff. GitHub's per-file patch lacks git headers,
+		// so wrap it into a minimal single-file patch for the parser.
+		const MAX_FILES = 50;
+		const rendered: { filename: string; status: string; html: string | null }[] = [];
+		for (const f of prFiles.slice(0, MAX_FILES)) {
+			let diffHtml: string | null = null;
+			if (f.patch && f.patch.length < 100_000) {
+				try {
+					const pseudo = `diff --git a/${f.filename} b/${f.filename}\n--- a/${f.filename}\n+++ b/${f.filename}\n${f.patch}\n`;
+					const fileDiff = parsePatchFiles(pseudo)[0]?.files[0];
+					if (fileDiff) {
+						diffHtml = await preloadDiffHTML({ fileDiff, options: { theme: 'pierre-dark' } });
+					}
+				} catch (err) {
+					console.warn(`turbodiff: cockpit diff render failed for ${f.filename}:`, err);
+				}
+			}
+			rendered.push({ filename: f.filename, status: f.status, html: diffHtml });
+		}
+
+		// The library's stylesheet targets :host (web components); rescope it to
+		// a wrapper class for light-DOM embedding.
+		const diffsCss = wrapCoreCSS('').replaceAll(':host', '.diffs-scope');
+
+		const demo = verification?.demo ? (JSON.parse(verification.demo) as { video?: string; caption?: string }) : null;
+		const demoUrl = demo?.video
+			? `/artifacts/${demo.video}?sig=${await signArtifactKey(demo.video)}`
+			: null;
+		const criteria: string[] = feature.acceptance ? JSON.parse(feature.acceptance) : [];
+		const results: { index: number; verdict: string; note: string; screenshot?: string }[] =
+			verification?.results ? JSON.parse(verification.results) : [];
+		const shotUrl = new Map<string, string>();
+		for (const r of results) {
+			if (r.screenshot) {
+				const key = `verify/${feature.id}/${r.screenshot.replace(/[^\w.-]/g, '')}`;
+				shotUrl.set(r.screenshot, `/artifacts/${key}?sig=${await signArtifactKey(key)}`);
+			}
+		}
+		const verdictBadge: Record<string, string> = { pass: '✅', fail: '❌', skip: '⚪' };
+		const prState = prMeta.merged ? 'merged' : prMeta.state;
+
+		return c.html(
+			page(
+				`Turbodiff — ${feature.title}`,
+				html`${topbar(user.session.login)} ${tabs('factory')}
+					<style>
+						${raw(diffsCss)}
+						.diffs-scope { display: block; margin-top: 0.5rem; border: 1px solid #1c2620; border-radius: 8px; overflow: hidden; }
+						.cockpit-video { width: 100%; border: 1px solid #1c2620; border-radius: 8px; margin-top: 0.5rem; background: #000; }
+						.file-label { margin-top: 1.25rem; font-size: 0.8rem; color: #b8c4bc; }
+						details.review-body pre { white-space: pre-wrap; font-size: 0.8rem; }
+					</style>
+					<div class="topbar" style="margin-top:1.5rem">
+						<h1 style="margin:0">${feature.title}</h1>
+						<span class="pill ${prState === 'merged' ? 'on' : prState === 'open' ? 'running' : 'red'}">${prState}</span>
+					</div>
+					<p class="muted">
+						${repo.owner}/${repo.name} · PR
+						<a href="${prMeta.html_url}" target="_blank" rel="noopener">#${feature.pr_number}</a> ·
+						${prMeta.changed_files} files, +${prMeta.additions} −${prMeta.deletions}
+						${renderVerificationInline(verification?.status ?? null, results)}
+					</p>
+					${prState === 'open'
+						? html`<form method="post" action="/factory/features/${feature.id}/merge">
+								<button
+									onclick="return confirm('Merge this pull request?')"
+								>
+									Merge pull request
+								</button>
+							</form>`
+						: ''}
+					${demoUrl
+						? html`<h2>demo</h2>
+								${demo?.caption ? html`<p class="muted">${demo.caption}</p>` : ''}
+								<video class="cockpit-video" controls autoplay muted loop playsinline src="${demoUrl}"></video>`
+						: ''}
+					${criteria.length > 0
+						? html`<h2>acceptance criteria</h2>
+								<table>
+									${criteria.map((crit, i) => {
+										const r = results.find((x) => x.index === i);
+										const shot = r?.screenshot ? shotUrl.get(r.screenshot) : undefined;
+										return html`<tr>
+											<td style="width:1.5rem">${verdictBadge[r?.verdict ?? ''] ?? '⚪'}</td>
+											<td>
+												${crit}
+												${r?.note ? html`<div class="muted">${r.note}</div>` : ''}
+												${shot
+													? html`<div><a href="${shot}" target="_blank" rel="noopener">screenshot →</a></div>`
+													: ''}
+											</td>
+										</tr>`;
+									})}
+								</table>`
+						: ''}
+					${prReviews.length > 0
+						? html`<h2>reviews</h2>
+								${prReviews.map(
+									(r) => html`<details class="review-body">
+										<summary>
+											${r.user?.login ?? 'unknown'} · ${r.state.toLowerCase()}
+										</summary>
+										<pre>${r.body || '(no body)'}</pre>
+									</details>`,
+								)}`
+						: ''}
+					${plan
+						? html`<h2>plan</h2>
+								<details class="review-body">
+									<summary class="muted">implementation plan (approved)</summary>
+									<pre>${plan.plan ?? ''}</pre>
+								</details>`
+						: ''}
+					<h2>diff</h2>
+					${rendered.map(
+						(f) => html`<div class="file-label">${f.filename} <span class="muted">(${f.status})</span></div>
+							${f.html
+								? html`<div class="diffs-scope">${raw(f.html)}</div>`
+								: html`<p class="muted">diff not rendered (binary, renamed, or too large)</p>`}`,
+					)}
+					${prFiles.length > MAX_FILES
+						? html`<p class="muted">…and ${prFiles.length - MAX_FILES} more files — see the PR on GitHub.</p>`
+						: ''}`,
+			),
+		);
+	});
+
+	// Human-initiated merge from the cockpit. Deliberately does not reuse the
+	// auto-merge gates: a signed-in repo admin clicking Merge IS the authority.
+	app.post('/factory/features/:id/merge', async (c) => {
+		const user = await requireUser(c);
+		if (!user) return c.redirect('/auth/login');
+
+		const id = Number(c.req.param('id'));
+		const feature = Number.isInteger(id) ? await getFeature(id) : null;
+		const repo = feature ? await getRepoById(feature.repository_id) : null;
+		if (!feature || !repo || !user.installationIds.includes(repo.installation_id)) {
+			return c.text('unknown feature', 404);
+		}
+		if (!feature.pr_number) return c.redirect(`/factory/features/${id}`);
+		try {
+			const token = await installationToken(repo.installation_id);
+			await gh(token, `/repos/${repo.owner}/${repo.name}/pulls/${feature.pr_number}/merge`, {
+				method: 'PUT',
+				body: JSON.stringify({ merge_method: 'merge' }),
+			});
+		} catch (err) {
+			console.error(`turbodiff: cockpit merge failed for feature ${id}:`, err);
+		}
+		return c.redirect(`/factory/features/${id}`);
 	});
 
 	return app;


### PR DESCRIPTION
The pivot from GitHub-embedded evidence to **turbodiff as the review surface**. GitHub remains git storage, the merge API, and the system of record — but reviewing a factory PR now happens on one turbodiff screen.

## What's in the cockpit (`/factory/features/:id`)
- **🎬 Demo video, natively played.** The verifier records a 10–30s WebM of the feature's happy path (puppeteer `page.screencast()` + ffmpeg, both now in the sandbox image and smoke-tested in-container) and uploads it to R2 (migration 0015). The cockpit plays it in a `<video>` tag — the reason this beats the GIF-in-comments route we abandoned.
- **Full diff, server-rendered** with `@pierre/diffs`' SSR entry: Shiki syntax highlighting, pierre-dark theme, per-file rendering from the GitHub PR files API. Zero client framework — and v2 hydrates this exact markup with `@pierre/diffs/react` for inline comments that feed the fix agent.
- **Acceptance criteria** with verdicts/evidence/screenshot links, **review verdicts**, the **approved plan**, PR state, and a **Merge** button (human-initiated; deliberately separate from the auto-merge gates — the signed-in admin is the authority).
- Verification PR comments link to the cockpit; factory-tab cards get "open in cockpit →".

## Validation
- Screencast smoke inside the rebuilt image: 48KB WebM recorded via puppeteer + ffmpeg 4.4.2.
- Cockpit rendered locally against a real merged PR: highlighted diff, reviews, plan, state pill all present.
- typecheck + lint + build clean (worker bundle fine — Shiki chunks split).

## Deploy
Merge → migration 0015 `--remote` → `pnpm run deploy` (image rebuild: ffmpeg layer). Then the next factory feature gets a recorded demo and a cockpit link in its verification comment.

## v2 (later)
Hydrate with `@pierre/diffs/react`: inline comments → fix agent dispatch, per-hunk accept/reject, `@pierre/trees` file navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)