### PR TITLE
Attribute factory commits to the instructing user

### DIFF
--- a/migrations/0017_commit_attribution.sql
+++ b/migrations/0017_commit_attribution.sql
@@ -1,0 +1,15 @@
+-- Commit attribution: record which signed-in user instructed each factory
+-- action so sandbox commits can carry them as the git author (the bot stays
+-- the committer). All columns are nullable — operator/API and auto-triggered
+-- runs have no human to attribute.
+ALTER TABLE plans ADD COLUMN created_by_login TEXT;
+ALTER TABLE plans ADD COLUMN created_by_id INTEGER;
+-- Feature author = the plan approver; coauthor = the plan creator when they
+-- differ (rides the commit message as a Co-authored-by trailer).
+ALTER TABLE features ADD COLUMN author_login TEXT;
+ALTER TABLE features ADD COLUMN author_id INTEGER;
+ALTER TABLE features ADD COLUMN coauthor_login TEXT;
+ALTER TABLE features ADD COLUMN coauthor_id INTEGER;
+-- cockpit_comments.author (login) predates this; the id completes the noreply
+-- identity for fix commits dispatched from a comment.
+ALTER TABLE cockpit_comments ADD COLUMN author_id INTEGER;

--- a/src/lib/attribution.ts
+++ b/src/lib/attribution.ts
@@ -1,0 +1,31 @@
+// Attribution of factory commits to the instructing user. The sandbox always
+// commits as turbodiff[bot] (the committer — honest: the bot recorded it),
+// but when a signed-in human instructed the run, they become the git AUTHOR
+// via GIT_AUTHOR_* env on the commit command. GitHub links the
+// `<id>+<login>@users.noreply.github.com` form to the account regardless of
+// its email-privacy settings, so authored commits show the user's avatar and
+// count toward their contribution graph once merged.
+
+export interface GitIdentity {
+	login: string;
+	id: number;
+}
+
+export function noreplyEmail(user: GitIdentity): string {
+	return `${user.id}+${user.login}@users.noreply.github.com`;
+}
+
+// Env vars for `git commit`. Empty when no human instructed the run — git
+// then falls back to the repo-config bot identity for the author too.
+export function gitAuthorEnv(user: GitIdentity | null | undefined): Record<string, string> {
+	if (!user) return {};
+	return { GIT_AUTHOR_NAME: user.login, GIT_AUTHOR_EMAIL: noreplyEmail(user) };
+}
+
+// Trailer crediting a second instructing user (e.g. the plan creator when a
+// different user approved). Must be separated from the subject by a blank
+// line to parse as a git trailer.
+export function coauthorTrailer(user: GitIdentity | null | undefined): string {
+	if (!user) return '';
+	return `\n\nCo-authored-by: ${user.login} <${noreplyEmail(user)}>`;
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -200,6 +200,7 @@ export interface CockpitCommentRow {
 	side: string;
 	body: string;
 	author: string;
+	author_id: number | null; // null on rows predating attribution
 	status: string;
 	created_at: string;
 }
@@ -211,12 +212,15 @@ export async function createCockpitComment(
 	side: string,
 	body: string,
 	author: string,
+	// GitHub user id completing the commenter's noreply identity, so the fix
+	// commit this comment dispatches can carry them as git author.
+	authorId?: number,
 ): Promise<number> {
 	const row = await env.DB.prepare(
-		`INSERT INTO cockpit_comments (feature_id, path, line, side, body, author)
-		 VALUES (?1, ?2, ?3, ?4, ?5, ?6) RETURNING id`,
+		`INSERT INTO cockpit_comments (feature_id, path, line, side, body, author, author_id)
+		 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) RETURNING id`,
 	)
-		.bind(featureId, path, line, side, body, author)
+		.bind(featureId, path, line, side, body, author, authorId ?? null)
 		.first<{ id: number }>();
 	return row!.id;
 }
@@ -348,6 +352,10 @@ export interface FeatureRow {
 	status: string;
 	error: string | null;
 	created_at: string;
+	author_login: string | null; // instructing user (plan approver); null = bot
+	author_id: number | null;
+	coauthor_login: string | null; // plan creator when different from author
+	coauthor_id: number | null;
 }
 
 export async function createFeature(
@@ -357,11 +365,27 @@ export async function createFeature(
 	// JSON array of acceptance criteria strings; the verify step checks these
 	// empirically against the generated branch.
 	acceptance?: string,
+	// Commit attribution (src/lib/attribution.ts): author = the instructing
+	// user (plan approver), coauthor = the plan creator when they differ.
+	// Null for operator/API intakes — the generator commits as the bot.
+	author?: { login: string; id: number },
+	coauthor?: { login: string; id: number },
 ): Promise<number> {
 	const row = await env.DB.prepare(
-		'INSERT INTO features (repository_id, title, spec, acceptance) VALUES (?1, ?2, ?3, ?4) RETURNING id',
+		`INSERT INTO features
+		 (repository_id, title, spec, acceptance, author_login, author_id, coauthor_login, coauthor_id)
+		 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8) RETURNING id`,
 	)
-		.bind(repositoryId, title, spec, acceptance ?? null)
+		.bind(
+			repositoryId,
+			title,
+			spec,
+			acceptance ?? null,
+			author?.login ?? null,
+			author?.id ?? null,
+			coauthor?.login ?? null,
+			coauthor?.id ?? null,
+		)
 		.first<{ id: number }>();
 	return row!.id;
 }
@@ -402,17 +426,23 @@ export interface PlanRow {
 	status: string;
 	error: string | null;
 	created_at: string;
+	created_by_login: string | null; // signed-in submitter; null = operator/API
+	created_by_id: number | null;
 }
 
 export async function createPlan(
 	repositoryId: number,
 	title: string,
 	requirements: string,
+	// The signed-in user who submitted the requirements; null for operator/API
+	// intakes. Carried onto the feature at approval for commit attribution.
+	createdBy?: { login: string; id: number },
 ): Promise<number> {
 	const row = await env.DB.prepare(
-		'INSERT INTO plans (repository_id, title, requirements) VALUES (?1, ?2, ?3) RETURNING id',
+		`INSERT INTO plans (repository_id, title, requirements, created_by_login, created_by_id)
+		 VALUES (?1, ?2, ?3, ?4, ?5) RETURNING id`,
 	)
-		.bind(repositoryId, title, requirements)
+		.bind(repositoryId, title, requirements, createdBy?.login ?? null, createdBy?.id ?? null)
 		.first<{ id: number }>();
 	return row!.id;
 }

--- a/src/lib/fixer.ts
+++ b/src/lib/fixer.ts
@@ -1,6 +1,7 @@
 import { getSandbox, type Sandbox } from '@cloudflare/sandbox';
 import { env } from 'cloudflare:workers';
 import { gh } from '../tools/github.ts';
+import { gitAuthorEnv } from './attribution.ts';
 import { finishFixAttempt, getFeatureByRepoPr, getRepoById, tryRecordFixAttempt } from './db.ts';
 import { installationToken, sandboxGitToken } from './github-app.ts';
 import { UNTRUSTED_CONTENT_RULES } from './prompt-security.ts';
@@ -26,6 +27,9 @@ export interface FixParams {
 	authMode?: FixAuthMode;
 	// e.g. "npm test". When set, a failing run blocks the push.
 	testCommand?: string;
+	// The instructing user (e.g. a cockpit commenter) — becomes the git author
+	// of the fix commit; the bot stays committer. Absent on auto-triggered runs.
+	author?: { login: string; id: number };
 }
 
 export interface FixOutcome {
@@ -276,7 +280,7 @@ export async function runFix(params: FixParams): Promise<FixOutcome> {
 		const committed = await sandbox.exec(
 			`git -C ${CLONE_DIR} add -A && ` +
 				`git -C ${CLONE_DIR} commit -m "Address review findings on #${prNumber} (turbodiff fix agent)"`,
-			{ timeout: 60_000 },
+			{ env: gitAuthorEnv(params.author), timeout: 60_000 },
 		);
 		if (!committed.success) {
 			throw new Error(`git commit failed: ${scrub(committed.stderr).slice(0, 500)}`);
@@ -337,6 +341,9 @@ export interface FixQueueMessage {
 	// Explicit work order (e.g. unmet acceptance criteria from a verification
 	// run). When absent, the latest blocking bot review on the PR is used.
 	findings?: string;
+	// Instructing user for commit attribution (cockpit comments); absent on
+	// auto-triggered fixes.
+	author?: { login: string; id: number };
 }
 
 // Queue consumer body: re-validate against current state (the toggle may have
@@ -378,6 +385,7 @@ export async function processFixMessage(msg: FixQueueMessage): Promise<void> {
 			installationId: repo.installation_id,
 			findings: msg.findings,
 			testCommand: repo.check_command ?? undefined,
+			author: msg.author,
 		});
 		await finishFixAttempt(attemptId, outcome.status, outcome.commit);
 		console.log(`turbodiff: fix ${outcome.status} for ${label} (attempt ${attemptId})`);

--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -1,6 +1,7 @@
 import { getSandbox, type Sandbox } from '@cloudflare/sandbox';
 import { env } from 'cloudflare:workers';
 import { gh } from '../tools/github.ts';
+import { coauthorTrailer, gitAuthorEnv } from './attribution.ts';
 import { getFeature, getRepoById, updateFeature, type FeatureRow, type RepositoryRow } from './db.ts';
 import { resolveRunnerAuth } from './fixer.ts';
 import { installationToken, sandboxGitToken } from './github-app.ts';
@@ -152,11 +153,26 @@ async function generate(
 		// mutations must never end up in the pushed commit. The commit is local
 		// only until the check passes and we push.
 		// The title is user input: it travels via env so shell metacharacters in
-		// it are data, never code.
+		// it are data, never code. When a signed-in user instructed this feature
+		// they become the git author (the bot stays committer); a differing plan
+		// creator rides the message as a Co-authored-by trailer.
+		const author =
+			feature.author_login && feature.author_id !== null
+				? { login: feature.author_login, id: feature.author_id }
+				: null;
+		const coauthor =
+			feature.coauthor_login && feature.coauthor_id !== null
+				? { login: feature.coauthor_login, id: feature.coauthor_id }
+				: null;
 		const commit = await sandbox.exec(
 			`git -C ${CLONE_DIR} add -A && git -C ${CLONE_DIR} commit -m "$COMMIT_MSG"`,
 			{
-				env: { COMMIT_MSG: `${feature.title} (turbodiff generator, feature #${feature.id})` },
+				env: {
+					COMMIT_MSG:
+						`${feature.title} (turbodiff generator, feature #${feature.id})` +
+						coauthorTrailer(coauthor),
+					...gitAuthorEnv(author),
+				},
 				timeout: 60_000,
 			},
 		);

--- a/src/lib/planner.ts
+++ b/src/lib/planner.ts
@@ -230,7 +230,12 @@ export async function runPlanRefine(planId: number): Promise<void> {
 // Approval turns a ready plan into a generation feature: the spec is the plan
 // plus its acceptance criteria, so the generated code is built against them.
 // Returns the new feature id, or null if the plan isn't ready.
-export async function approvePlan(planId: number): Promise<number | null> {
+// The approver becomes the feature's commit author; the plan creator rides
+// along as coauthor when a different user approved (see src/lib/attribution.ts).
+export async function approvePlan(
+	planId: number,
+	approver?: { login: string; id: number },
+): Promise<number | null> {
 	const plan = await getPlan(planId);
 	if (!plan || plan.status !== 'plan_ready' || !plan.plan) return null;
 	const acceptance: string[] = plan.acceptance ? JSON.parse(plan.acceptance) : [];
@@ -240,6 +245,12 @@ export async function approvePlan(planId: number): Promise<number | null> {
 			? acceptance.map((c) => `- ${c}`).join('\n')
 			: '(none specified)') +
 		`\n\nImplement the plan above so that every acceptance criterion holds.`;
+	const creator =
+		plan.created_by_login && plan.created_by_id !== null
+			? { login: plan.created_by_login, id: plan.created_by_id }
+			: undefined;
+	const author = approver ?? creator;
+	const coauthor = creator && author && creator.login !== author.login ? creator : undefined;
 	// Criteria travel structured (not only embedded in the spec text) so the
 	// verify step can check them one by one after generation.
 	const featureId = await createFeature(
@@ -247,6 +258,8 @@ export async function approvePlan(planId: number): Promise<number | null> {
 		plan.title,
 		spec,
 		plan.acceptance ?? undefined,
+		author,
+		coauthor,
 	);
 	await updatePlan(planId, { status: 'approved', featureId });
 	return featureId;

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -334,7 +334,11 @@ export function createApiRoutes() {
 		if (!row || !c.get('user').installationIds.includes(row.installation_id)) {
 			return c.json({ error: 'unknown repository' }, 404);
 		}
-		const planId = await createPlan(row.id, title, requirements);
+		const { session } = c.get('user');
+		const planId = await createPlan(row.id, title, requirements, {
+			login: session.login,
+			id: session.userId,
+		});
 		await env.FACTORY_QUEUE.send({ kind: 'plan_analyze', planId });
 		return c.json({ ok: true, plan_id: planId });
 	});
@@ -360,7 +364,9 @@ export function createApiRoutes() {
 	app.post('/factory/plans/:id/approve', async (c) => {
 		const plan = await authorizedPlan(c);
 		if (!plan) return c.json({ error: 'unknown plan' }, 404);
-		const featureId = await approvePlan(plan.id);
+		const { session } = c.get('user');
+		// The approver authors the generated commit (src/lib/attribution.ts).
+		const featureId = await approvePlan(plan.id, { login: session.login, id: session.userId });
 		if (featureId === null) return c.json({ error: 'plan is not ready for approval' }, 409);
 		await env.FACTORY_QUEUE.send({ kind: 'generate', featureId });
 		return c.json({ ok: true, feature_id: featureId });
@@ -504,7 +510,8 @@ export function createApiRoutes() {
 		if (!payload?.path || !Number.isInteger(payload.line) || !payload.body?.trim() || !feature.pr_number) {
 			return c.json({ error: 'body must be {path, line, side?, body}' }, 400);
 		}
-		const login = c.get('user').session.login;
+		const { session } = c.get('user');
+		const login = session.login;
 		const side = payload.side === 'deletions' ? 'deletions' : 'additions';
 		const commentId = await createCockpitComment(
 			feature.id,
@@ -513,14 +520,17 @@ export function createApiRoutes() {
 			side,
 			payload.body.trim(),
 			login,
+			session.userId,
 		);
 		// The comment IS the work order: dispatch the fixer with it verbatim.
 		// The consumer re-validates the auto_fix toggle and the attempt cap.
+		// The commenter rides along as the fix commit's git author.
 		await env.FACTORY_QUEUE.send({
 			kind: 'fix',
 			repoId: repo.id,
 			prNumber: feature.pr_number,
 			trigger: 'cockpit_comment',
+			author: { login, id: session.userId },
 			findings:
 				`**P1** — Reviewer comment on \`${payload.path}:${payload.line}\` ` +
 				`(from @${login} in the Turbodiff cockpit):\n\n${payload.body.trim()}`,
@@ -531,6 +541,10 @@ export function createApiRoutes() {
 
 	// Human-initiated merge from the cockpit. Deliberately does not reuse the
 	// auto-merge gates: a signed-in repo admin clicking Merge IS the authority.
+	// Merged with the clicking user's own OAuth token when possible so GitHub
+	// attributes the merge to them, not turbodiff[bot]; falls back to the App
+	// installation token when the user token can't merge (missing push
+	// permission, SSO enforcement, or the empty dev-fake session token).
 	app.post('/factory/features/:id/merge', async (c) => {
 		const id = Number(c.req.param('id'));
 		const feature = Number.isInteger(id) ? await getFeature(id) : null;
@@ -539,15 +553,23 @@ export function createApiRoutes() {
 			return c.json({ error: 'unknown feature' }, 404);
 		}
 		if (!feature.pr_number) return c.json({ error: 'no pull request yet' }, 409);
+		const mergePath = `/repos/${repo.owner}/${repo.name}/pulls/${feature.pr_number}/merge`;
+		const mergeBody = { method: 'PUT' as const, body: JSON.stringify({ merge_method: 'merge' }) };
+		const userToken = c.get('user').session.ghToken;
 		try {
-			const token = await installationToken(repo.installation_id);
-			await gh(token, `/repos/${repo.owner}/${repo.name}/pulls/${feature.pr_number}/merge`, {
-				method: 'PUT',
-				body: JSON.stringify({ merge_method: 'merge' }),
-			});
+			await gh(userToken || (await installationToken(repo.installation_id)), mergePath, mergeBody);
 		} catch (err) {
-			console.error(`turbodiff: cockpit merge failed for feature ${id}:`, err);
-			return c.json({ error: 'merge failed — check the PR on GitHub' }, 502);
+			if (!userToken) {
+				console.error(`turbodiff: cockpit merge failed for feature ${id}:`, err);
+				return c.json({ error: 'merge failed — check the PR on GitHub' }, 502);
+			}
+			console.warn(`turbodiff: user-token merge failed for feature ${id}, retrying as app:`, err);
+			try {
+				await gh(await installationToken(repo.installation_id), mergePath, mergeBody);
+			} catch (appErr) {
+				console.error(`turbodiff: cockpit merge failed for feature ${id}:`, appErr);
+				return c.json({ error: 'merge failed — check the PR on GitHub' }, 502);
+			}
 		}
 		return c.json({ ok: true });
 	});


### PR DESCRIPTION
## What

Factory commits (generator + fix agent) were authored **and** committed as `turbodiff[bot]`, so the human who instructed the work never appeared on GitHub. This implements author/committer split attribution:

- **Git author = the instructing user, committer stays `turbodiff[bot]`.** The sandbox commit commands now set `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` to the user's `<id>+<login>@users.noreply.github.com` identity — GitHub links that form to the account regardless of email-privacy settings, so commits show the user's avatar and count toward their contribution graph once merged. The bot remains the committer, keeping provenance honest.
- **Plans record their submitter** (`created_by_login/_id`); **approval stamps the feature** with the approver as author and the plan creator as `Co-authored-by:` trailer when they differ.
- **Cockpit comments record the commenter's user id**; the fix run they dispatch carries them as git author (threaded through the fix queue message).
- **Auto-triggered fixes and `/internal/*` operator intakes stay pure bot** — no human instructed them, so no attribution is invented.
- **Cockpit Merge now uses the clicking user's own OAuth token** (their session token is live at click time), so the merge shows "merged by *user*". Falls back to the installation token when the user token can't merge (missing push permission, SSO enforcement, or the dev-fake session).

## Verification

- Reproduced the exact sandbox commit mechanics locally (`sh -c` with the same env threading): author resolves to the user's noreply identity, committer stays `turbodiff[bot]`, and the `Co-authored-by:` trailer parses via `git interpret-trailers`.
- Exercised all three new INSERT statements against the migrated local D1 schema.
- `vp check --no-fmt`, both typecheck programs, and the full build pass; migration 0017 applied cleanly locally.

## Deploy note

⚠️ Migration **0017** must be applied to the remote database before/with this deploy:

```
pnpm exec wrangler d1 migrations apply turbodiff --remote
```

(Columns are nullable and the old code never references them, so applying the migration ahead of the deploy is safe.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)