### PR TITLE
Surface generation failures on plan cards and add retry

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,7 @@ import {
 	getRepoByFullName,
 	setRepoCheckCommand,
 	setRepoRunCommand,
+	updateFeature,
 	updatePlan,
 	listAgentConnections,
 	recordReview,
@@ -315,6 +316,22 @@ app.get('/internal/features/:id', async (c) => {
 	const feature = Number.isInteger(id) ? await getFeature(id) : null;
 	if (!feature) return c.json({ error: 'unknown feature' }, 404);
 	return c.json(feature);
+});
+
+// Operator retry for a failed generation: re-enqueues the SAME feature row,
+// preserving its spec and commit attribution (unlike /internal/generate,
+// which would mint a fresh unattributed feature).
+app.post('/internal/features/:id/retry', async (c) => {
+	const id = Number(c.req.param('id'));
+	const feature = Number.isInteger(id) ? await getFeature(id) : null;
+	if (!feature) return c.json({ error: 'unknown feature' }, 404);
+	const RETRYABLE = new Set(['failed', 'checks_failed', 'no_changes']);
+	if (!RETRYABLE.has(feature.status)) {
+		return c.json({ error: `feature is ${feature.status}, not retryable` }, 409);
+	}
+	await updateFeature(id, { status: 'generating' });
+	await env.FACTORY_QUEUE.send({ kind: 'generate', featureId: id });
+	return c.json({ accepted: true, feature_id: id, status_url: `/internal/features/${id}` });
 });
 
 app.post('/internal/fix', async (c) => {

--- a/src/client/lib/queries.ts
+++ b/src/client/lib/queries.ts
@@ -48,15 +48,22 @@ export const reviewsQuery = (page: number) =>
 
 const RUNNING_PLAN_STATUSES = new Set(['analyzing', 'refining']);
 
+// Feature states where generation stopped without a PR — terminal until the
+// user retries.
+export const GENERATION_STOPPED = new Set(['failed', 'checks_failed', 'no_changes']);
+
+function planIsLive(p: ApiFactory['plans'][number]): boolean {
+	if (RUNNING_PLAN_STATUSES.has(p.status)) return true;
+	if (p.verification?.status === 'running') return true;
+	// Approved and no PR yet: generation is in flight unless it stopped.
+	return p.status === 'approved' && !p.pr_number && !GENERATION_STOPPED.has(p.feature_status ?? '');
+}
+
 export const factoryQuery = queryOptions({
 	queryKey: ['factory'],
 	queryFn: () => api.get<ApiFactory>('/api/factory'),
 	refetchInterval: (query) =>
-		query.state.data?.plans.some(
-			(p) => RUNNING_PLAN_STATUSES.has(p.status) || p.verification?.status === 'running',
-		)
-			? LIVE_POLL_MS
-			: false,
+		query.state.data?.plans.some(planIsLive) ? LIVE_POLL_MS : false,
 });
 
 export const featureQuery = (id: number) =>
@@ -66,8 +73,10 @@ export const featureQuery = (id: number) =>
 		refetchInterval: (query) => {
 			const d = query.state.data;
 			if (!d) return false;
-			// Poll while generation hasn't opened a PR or verification is running.
-			return !d.pr || d.verification?.status === 'running' ? LIVE_POLL_MS : false;
+			// Poll while generation is in flight (no PR yet, not stopped) or a
+			// verification run is live.
+			if (!d.pr && !GENERATION_STOPPED.has(d.feature.status)) return LIVE_POLL_MS;
+			return d.verification?.status === 'running' ? LIVE_POLL_MS : false;
 		},
 	});
 

--- a/src/client/pages/factory.tsx
+++ b/src/client/pages/factory.tsx
@@ -5,7 +5,7 @@ import { toast } from 'sonner';
 import type { ApiPlan } from '../../shared/api-types.ts';
 import { api, ApiError } from '../lib/api.ts';
 import { ago } from '../lib/format.ts';
-import { factoryQuery } from '../lib/queries.ts';
+import { factoryQuery, GENERATION_STOPPED } from '../lib/queries.ts';
 import { EmptyState, Muted, PageTitle, SectionHeading } from '../components/section.tsx';
 import { Button } from '../components/ui/button.tsx';
 import { Card } from '../components/ui/card.tsx';
@@ -19,6 +19,12 @@ const PLAN_STATUS_HINT: Record<string, string> = {
 	plan_ready: 'review the plan and approve to generate',
 	approved: 'generating — follow the pull request',
 	failed: 'failed — see the error',
+};
+
+const GENERATION_STOPPED_HINT: Record<string, string> = {
+	failed: 'generation failed',
+	checks_failed: 'generated code failed the check command',
+	no_changes: 'the generation agent produced no changes',
 };
 
 const RUNNING_PLAN_STATUSES = new Set(['analyzing', 'refining']);
@@ -146,6 +152,12 @@ function AnswersForm({ plan }: { plan: ApiPlan }) {
 function PlanCard({ plan }: { plan: ApiPlan }) {
 	const queryClient = useQueryClient();
 	const running = RUNNING_PLAN_STATUSES.has(plan.status);
+	// Approved with no PR: generation is either in flight or stopped — the
+	// card reflects the feature's real state instead of an eternal
+	// "generating" (the gap that hid a failed run).
+	const genStopped =
+		plan.status === 'approved' && !plan.pr_number && GENERATION_STOPPED.has(plan.feature_status ?? '');
+	const genRunning = plan.status === 'approved' && !plan.pr_number && !genStopped;
 	const approve = useMutation({
 		mutationFn: () => api.post(`/api/factory/plans/${plan.id}/approve`),
 		onSuccess: () => {
@@ -154,16 +166,48 @@ function PlanCard({ plan }: { plan: ApiPlan }) {
 		},
 		onError: onApiError,
 	});
+	const retry = useMutation({
+		mutationFn: () => api.post(`/api/factory/features/${plan.feature_id}/retry`),
+		onSuccess: () => {
+			toast.success('generation retried — the run is queued');
+			queryClient.invalidateQueries({ queryKey: ['factory'] });
+		},
+		onError: onApiError,
+	});
+
+	const pill = genStopped ? (
+		<Pill tone="red">{GENERATION_STOPPED_HINT[plan.feature_status ?? ''] ?? 'generation stopped'}</Pill>
+	) : (
+		<Pill tone={running || genRunning ? 'running' : plan.status === 'failed' ? 'red' : 'on'}>
+			{genRunning ? 'generating' : plan.status}
+		</Pill>
+	);
+	const hint = genStopped
+		? 'generation stopped — retry below'
+		: (PLAN_STATUS_HINT[plan.status] ?? '');
 
 	return (
 		<Card className="mt-3">
 			<div className="flex flex-wrap items-center justify-between gap-2">
 				<strong className="font-medium">{plan.title}</strong>
-				<Pill tone={running ? 'running' : plan.status === 'failed' ? 'red' : 'on'}>{plan.status}</Pill>
+				{pill}
 			</div>
 			<div className="mt-0.5 text-xs text-mute">
-				{plan.repo} · {PLAN_STATUS_HINT[plan.status] ?? ''} · {ago(plan.created_at)}
+				{plan.repo} · {hint} · {ago(plan.created_at)}
 			</div>
+
+			{genStopped ? (
+				<>
+					{plan.feature_error ? (
+						<p className="mt-3 text-[0.85rem] text-danger">{plan.feature_error}</p>
+					) : null}
+					<div className="mt-3">
+						<Button onClick={() => retry.mutate()} loading={retry.isPending}>
+							Retry generation
+						</Button>
+					</div>
+				</>
+			) : null}
 
 			{plan.status === 'failed' && plan.error ? (
 				<p className="mt-3 text-[0.85rem] text-danger">{plan.error}</p>

--- a/src/client/pages/feature.tsx
+++ b/src/client/pages/feature.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import type { ApiCockpitComment, ApiFeatureDetail } from '../../shared/api-types.ts';
 import { api, ApiError } from '../lib/api.ts';
-import { featureQuery } from '../lib/queries.ts';
+import { featureQuery, GENERATION_STOPPED } from '../lib/queries.ts';
 import { cn } from '../lib/utils.ts';
 import { ConfirmButton } from '../components/confirm-button.tsx';
 import { ensureDiffStyles } from '../components/diff-styles.ts';
@@ -320,14 +320,45 @@ export default function FeaturePage() {
 		},
 		onError: onApiError,
 	});
+	const retryGeneration = useMutation({
+		mutationFn: () => api.post(`/api/factory/features/${id}/retry`),
+		onSuccess: () => {
+			toast.success('generation retried — the run is queued');
+			refresh();
+		},
+		onError: onApiError,
+	});
 
 	if (!data.pr) {
+		const stopped = GENERATION_STOPPED.has(data.feature.status);
 		return (
 			<>
-				<PageTitle>{data.feature.title}</PageTitle>
-				<p className="mt-4">
-					<Muted>No pull request yet — generation is {data.feature.status}.</Muted>
-				</p>
+				<PageTitle
+					aside={
+						stopped ? <Pill tone="red">{data.feature.status}</Pill> : <Pill tone="running">generating</Pill>
+					}
+				>
+					{data.feature.title}
+				</PageTitle>
+				{stopped ? (
+					<>
+						<p className="mt-4">
+							<Muted>Generation stopped without a pull request.</Muted>
+						</p>
+						{data.feature.error ? (
+							<p className="mt-2 text-[0.85rem] text-danger">{data.feature.error}</p>
+						) : null}
+						<div className="mt-4">
+							<Button onClick={() => retryGeneration.mutate()} loading={retryGeneration.isPending}>
+								Retry generation
+							</Button>
+						</div>
+					</>
+				) : (
+					<p className="mt-4">
+						<Muted>No pull request yet — generation is {data.feature.status}.</Muted>
+					</p>
+				)}
 			</>
 		);
 	}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -456,6 +456,8 @@ export interface PlanWithRepo extends PlanRow {
 	name: string;
 	installation_id: number;
 	pr_number: number | null; // from the linked feature, if generation started
+	feature_status: string | null; // the linked feature's lifecycle status
+	feature_error: string | null; // its failure detail, when generation failed
 	verification_status: string | null; // latest verification for the feature
 	verification_results: string | null; // its per-criterion results JSON
 	verification_demo: string | null; // its demo JSON {"video": r2Key}
@@ -471,6 +473,7 @@ export async function listPlansForInstallations(
 	const placeholders = installationIds.map((_, i) => `?${i + 2}`).join(', ');
 	const res = await env.DB.prepare(
 		`SELECT p.*, r.owner, r.name, r.installation_id, f.pr_number AS pr_number,
+		        f.status AS feature_status, f.error AS feature_error,
 		        v.status AS verification_status, v.results AS verification_results,
 		        v.demo AS verification_demo
 		 FROM plans p

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -40,6 +40,7 @@ import {
 	setRepoEnabled,
 	setRepoReviewOnPush,
 	updateAgent,
+	updateFeature,
 	updatePlan,
 	type AgentConnectionRow,
 	type AgentRow,
@@ -140,6 +141,8 @@ function serializePlan(p: PlanWithRepo): ApiPlan {
 		plan: p.plan,
 		feature_id: p.feature_id,
 		pr_number: p.pr_number,
+		feature_status: p.feature_status,
+		feature_error: p.feature_error,
 		verification: verificationSummary(p.verification_status, p.verification_results),
 	};
 }
@@ -387,6 +390,7 @@ export function createApiRoutes() {
 				id: feature.id,
 				title: feature.title,
 				status: feature.status,
+				error: feature.error,
 				pr_number: feature.pr_number,
 			},
 			repo: `${repo.owner}/${repo.name}`,
@@ -537,6 +541,25 @@ export function createApiRoutes() {
 		});
 		await markCockpitCommentDispatched(commentId);
 		return c.json({ ok: true, comment_id: commentId, fix_dispatched: true });
+	});
+
+	// Re-enqueue generation for a failed feature. The feature row (and its
+	// commit attribution) is reused as-is; status flips to 'generating'
+	// immediately so the UI reflects the retry without waiting on the queue.
+	app.post('/factory/features/:id/retry', async (c) => {
+		const id = Number(c.req.param('id'));
+		const feature = Number.isInteger(id) ? await getFeature(id) : null;
+		const repo = feature ? await getRepoById(feature.repository_id) : null;
+		if (!feature || !repo || !c.get('user').installationIds.includes(repo.installation_id)) {
+			return c.json({ error: 'unknown feature' }, 404);
+		}
+		const RETRYABLE = new Set(['failed', 'checks_failed', 'no_changes']);
+		if (!RETRYABLE.has(feature.status)) {
+			return c.json({ error: `feature is ${feature.status}, not retryable` }, 409);
+		}
+		await updateFeature(feature.id, { status: 'generating' });
+		await env.FACTORY_QUEUE.send({ kind: 'generate', featureId: feature.id });
+		return c.json({ ok: true });
 	});
 
 	// Human-initiated merge from the cockpit. Deliberately does not reuse the

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -82,6 +82,10 @@ export interface ApiPlan {
 	plan: string | null;
 	feature_id: number | null;
 	pr_number: number | null;
+	// Lifecycle of the linked feature once the plan is approved: generating /
+	// pr_opened / checks_failed / no_changes / failed (+ its error detail).
+	feature_status: string | null;
+	feature_error: string | null;
 	verification: ApiVerificationSummary | null;
 }
 
@@ -102,7 +106,13 @@ export interface ApiCockpitComment {
 }
 
 export interface ApiFeatureDetail {
-	feature: { id: number; title: string; status: string; pr_number: number | null };
+	feature: {
+		id: number;
+		title: string;
+		status: string;
+		error: string | null;
+		pr_number: number | null;
+	};
 	repo: string; // "owner/name"
 	plan: string | null;
 	// Null while generation hasn't opened a PR yet.


### PR DESCRIPTION
## What

A failed generation run was invisible: the plan card derived its text purely from the plan's status (`approved` → "generating — follow the pull request"), so feature #6's sandbox 500 sat behind an eternal "generating" with no way to retry.

- **Plans API now carries the linked feature's lifecycle** (`feature_status`, `feature_error`). Approved-no-PR cards show a live `generating` pill while the run is in flight, or a red stopped pill (`generation failed` / `checks_failed` / `no_changes`) with the error text.
- **Retry button** on stopped cards (and on the cockpit's no-PR view): `POST /api/factory/features/:id/retry` flips the feature back to `generating` and re-enqueues the **same feature row** — preserving its spec and commit attribution. An operator variant exists at `POST /internal/features/:id/retry`.
- **Polling follows the real state**: the factory page keeps refreshing while generation is in flight and stops on stopped features (previously the cockpit polled failed runs forever).

## Verification

- Browser-tested against the built bundle with a failed-generation fixture: red pill + error + Retry render, the button fires `POST /api/factory/features/6/retry`, and the card flips to live polling on success.
- `vp check --no-fmt`, both typecheck programs, and the full build pass. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)