### PR TITLE
Harden generation against sandbox platform interruptions

### DIFF
--- a/migrations/0018_generation_run_tracking.sql
+++ b/migrations/0018_generation_run_tracking.sql
@@ -1,0 +1,5 @@
+-- When the current generation run (or run attempt) started. Lets the API
+-- lazily sweep features stranded in 'generating' — a queue-consumer
+-- wall-clock kill dies without ever reaching the failure handler, so the row
+-- otherwise sits "generating" forever.
+ALTER TABLE features ADD COLUMN run_started_at TEXT;

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import {
 	connectionSnapshot,
 	createFeature,
 	createPlan,
+	failStrandedGeneration,
 	getFeature,
 	getPlan,
 	getRepoByFullName,
@@ -312,6 +313,7 @@ app.post('/internal/repos/check-command', async (c) => {
 });
 
 app.get('/internal/features/:id', async (c) => {
+	await failStrandedGeneration();
 	const id = Number(c.req.param('id'));
 	const feature = Number.isInteger(id) ? await getFeature(id) : null;
 	if (!feature) return c.json({ error: 'unknown feature' }, 404);
@@ -320,8 +322,12 @@ app.get('/internal/features/:id', async (c) => {
 
 // Operator retry for a failed generation: re-enqueues the SAME feature row,
 // preserving its spec and commit attribution (unlike /internal/generate,
-// which would mint a fresh unattributed feature).
+// which would mint a fresh unattributed feature). An optional
+// {"delay_seconds": n} defers delivery (e.g. to ride out a platform
+// incident); the feature stays in its failed state until the run actually
+// starts, so the strand sweep can't misfire during the wait.
 app.post('/internal/features/:id/retry', async (c) => {
+	await failStrandedGeneration();
 	const id = Number(c.req.param('id'));
 	const feature = Number.isInteger(id) ? await getFeature(id) : null;
 	if (!feature) return c.json({ error: 'unknown feature' }, 404);
@@ -329,9 +335,21 @@ app.post('/internal/features/:id/retry', async (c) => {
 	if (!RETRYABLE.has(feature.status)) {
 		return c.json({ error: `feature is ${feature.status}, not retryable` }, 409);
 	}
-	await updateFeature(id, { status: 'generating' });
-	await env.FACTORY_QUEUE.send({ kind: 'generate', featureId: id });
-	return c.json({ accepted: true, feature_id: id, status_url: `/internal/features/${id}` });
+	const body = await c.req.json<{ delay_seconds?: number }>().catch(() => null);
+	const delay = Math.min(Math.max(Math.floor(body?.delay_seconds ?? 0), 0), 12 * 3600);
+	if (delay > 0) {
+		await updateFeature(id, { error: `retry scheduled in ${Math.round(delay / 60)}m` });
+		await env.FACTORY_QUEUE.send({ kind: 'generate', featureId: id }, { delaySeconds: delay });
+	} else {
+		await updateFeature(id, { status: 'generating', runStartedAt: 'now' });
+		await env.FACTORY_QUEUE.send({ kind: 'generate', featureId: id });
+	}
+	return c.json({
+		accepted: true,
+		feature_id: id,
+		delay_seconds: delay,
+		status_url: `/internal/features/${id}`,
+	});
 });
 
 app.post('/internal/fix', async (c) => {

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -28,7 +28,7 @@ export default {
 			const body = message.body;
 			switch (body.kind) {
 				case 'generate':
-					await runGeneration(body.featureId);
+					await runGeneration(body.featureId, body.attempt ?? 0);
 					break;
 				case 'plan_analyze':
 					await runPlanAnalyze(body.planId);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -352,6 +352,7 @@ export interface FeatureRow {
 	status: string;
 	error: string | null;
 	created_at: string;
+	run_started_at: string | null; // start of the current generation attempt
 	author_login: string | null; // instructing user (plan approver); null = bot
 	author_id: number | null;
 	coauthor_login: string | null; // plan creator when different from author
@@ -394,19 +395,51 @@ export async function getFeature(id: number): Promise<FeatureRow | null> {
 	return env.DB.prepare('SELECT * FROM features WHERE id = ?1').bind(id).first<FeatureRow>();
 }
 
+// A queue-consumer wall-clock kill dies without reaching the failure handler,
+// stranding the feature in 'generating' forever. This lazy sweep (called from
+// the factory read paths) flips any run silent past the wall clock + slack to
+// failed, so the UI shows the truth and the retry button lights up. Legacy
+// rows without run_started_at fall back to created_at.
+const GENERATION_STRAND_MINUTES = 25;
+
+export async function failStrandedGeneration(): Promise<number> {
+	const res = await env.DB.prepare(
+		`UPDATE features SET status = 'failed',
+		   error = 'generation run was killed before finishing (platform wall clock or runtime interruption) — retry'
+		 WHERE status = 'generating'
+		   AND COALESCE(run_started_at, created_at) < datetime('now', '-${GENERATION_STRAND_MINUTES} minutes')`,
+	).run();
+	return res.meta.changes ?? 0;
+}
+
 export async function updateFeature(
 	id: number,
-	fields: { status?: string; branch?: string; prNumber?: number; error?: string },
+	fields: {
+		status?: string;
+		branch?: string;
+		prNumber?: number;
+		error?: string;
+		// 'now' stamps the start of a generation attempt (strand detection).
+		runStartedAt?: 'now';
+	},
 ): Promise<void> {
 	await env.DB.prepare(
 		`UPDATE features SET
 		 status = COALESCE(?2, status),
 		 branch = COALESCE(?3, branch),
 		 pr_number = COALESCE(?4, pr_number),
-		 error = COALESCE(?5, error)
+		 error = COALESCE(?5, error),
+		 run_started_at = CASE WHEN ?6 THEN datetime('now') ELSE run_started_at END
 		 WHERE id = ?1`,
 	)
-		.bind(id, fields.status ?? null, fields.branch ?? null, fields.prNumber ?? null, fields.error ?? null)
+		.bind(
+			id,
+			fields.status ?? null,
+			fields.branch ?? null,
+			fields.prNumber ?? null,
+			fields.error ?? null,
+			fields.runStartedAt === 'now' ? 1 : 0,
+		)
 		.run();
 }
 

--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -23,7 +23,18 @@ const CHECK_TIMEOUT_MS = 4 * 60_000;
 export interface GenQueueMessage {
 	kind: 'generate';
 	featureId: number;
+	// Platform-interruption retry counter (see PLATFORM_INTERRUPTION below);
+	// absent on first delivery.
+	attempt?: number;
 }
+
+// Sandbox infrastructure failures outside our control — a runtime rollout
+// interrupting exec, or the sandbox client's bare 5xx. These are transient:
+// instead of failing the feature, the run re-enqueues itself with a delay so
+// it lands after the platform settles. Bounded by GEN_PLATFORM_RETRIES.
+const PLATFORM_INTERRUPTION = /interrupted while the platform|HTTP error! status: 5\d\d/i;
+const GEN_PLATFORM_RETRIES = 3;
+const GEN_RETRY_DELAY_S = 600;
 
 function branchName(feature: FeatureRow): string {
 	const slug = feature.title
@@ -55,7 +66,7 @@ ${feature.spec}
 `;
 }
 
-export async function runGeneration(featureId: number): Promise<void> {
+export async function runGeneration(featureId: number, attempt = 0): Promise<void> {
 	const feature = await getFeature(featureId);
 	if (!feature) {
 		console.warn(`turbodiff: generation skipped, feature ${featureId} not found`);
@@ -67,7 +78,8 @@ export async function runGeneration(featureId: number): Promise<void> {
 		return;
 	}
 	const label = `${repo.owner}/${repo.name} feature #${featureId}`;
-	await updateFeature(featureId, { status: 'generating' });
+	// runStartedAt restarts the strand-detection clock for this attempt.
+	await updateFeature(featureId, { status: 'generating', runStartedAt: 'now' });
 
 	try {
 		const outcome = await generate(feature, repo);
@@ -80,6 +92,22 @@ export async function runGeneration(featureId: number): Promise<void> {
 		}
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
+		// Transient platform interruption: keep the feature 'generating' and
+		// re-enqueue with a delay so the next attempt lands after the rollout.
+		if (PLATFORM_INTERRUPTION.test(message) && attempt < GEN_PLATFORM_RETRIES) {
+			await updateFeature(featureId, {
+				error: `platform interruption (attempt ${attempt + 1}/${GEN_PLATFORM_RETRIES + 1}), retrying in ${GEN_RETRY_DELAY_S / 60}m: ${message.slice(0, 300)}`,
+			});
+			await env.FACTORY_QUEUE.send(
+				{ kind: 'generate', featureId, attempt: attempt + 1 },
+				{ delaySeconds: GEN_RETRY_DELAY_S },
+			);
+			console.warn(
+				`turbodiff: generation platform-interrupted for ${label} (attempt ${attempt + 1}), re-enqueued with ${GEN_RETRY_DELAY_S}s delay:`,
+				err,
+			);
+			return;
+		}
 		await updateFeature(featureId, { status: 'failed', error: message.slice(0, 500) });
 		console.error(`turbodiff: generation failed for ${label}:`, err);
 	}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -12,6 +12,7 @@ import {
 	deleteAgent,
 	deleteAgentConnection,
 	ensureBuiltinAgents,
+	failStrandedGeneration,
 	getAgentById,
 	getAgentBySlug,
 	getAgentConnection,
@@ -311,6 +312,9 @@ export function createApiRoutes() {
 
 	app.get('/factory', async (c) => {
 		const { installationIds } = c.get('user');
+		// Flip wall-clock-killed runs to failed before reading, so the cards
+		// never show an eternal "generating" for a dead run.
+		await failStrandedGeneration();
 		const [groups, plans] = await Promise.all([
 			listInstallationsWithRepos(installationIds),
 			listPlansForInstallations(installationIds),
@@ -378,6 +382,7 @@ export function createApiRoutes() {
 	// --- Factory PR cockpit ---
 
 	app.get('/factory/features/:id', async (c) => {
+		await failStrandedGeneration();
 		const id = Number(c.req.param('id'));
 		const feature = Number.isInteger(id) ? await getFeature(id) : null;
 		const repo = feature ? await getRepoById(feature.repository_id) : null;
@@ -557,7 +562,7 @@ export function createApiRoutes() {
 		if (!RETRYABLE.has(feature.status)) {
 			return c.json({ error: `feature is ${feature.status}, not retryable` }, 409);
 		}
-		await updateFeature(feature.id, { status: 'generating' });
+		await updateFeature(feature.id, { status: 'generating', runStartedAt: 'now' });
 		await env.FACTORY_QUEUE.send({ kind: 'generate', featureId: feature.id });
 		return c.json({ ok: true });
 	});


### PR DESCRIPTION
## What

Tonight's generation failures were all Cloudflare sandbox platform incidents (exec 500, "interrupted while the platform was updating the sandbox runtime", and a wall-clock kill that stranded the feature in `generating` with no error). Two defenses:

- **Platform-interruption auto-retry**: a run failing on a sandbox-infra signature re-enqueues itself with a 10-minute delivery delay (up to 3 retries) instead of failing the feature — platform rollouts get ridden out invisibly.
- **Strand detection**: features stamp `run_started_at` per attempt (migration 0018); the factory read paths lazily sweep any `generating` row silent past 25 minutes to `failed` with an explicit "run was killed" error, so the UI's retry button appears instead of an eternal "generating". Wall-clock kills never reach the failure handler, so a read-time sweep is the only way to observe them.
- The operator retry endpoint accepts `{"delay_seconds": n}` for scheduled retries; deferred features keep their failed state until the run starts so the sweep can't misfire during the wait.

## Verification

- Sweep SQL exercised against the migrated local schema: a 30-min-old `generating` row flips to failed, a 5-min-old one is untouched.
- `vp check --no-fmt`, both typecheck programs, full build pass.

## Deploy note

⚠️ Apply migration **0018** remotely with the deploy: `pnpm exec wrangler d1 migrations apply turbodiff --remote`

🤖 Generated with [Claude Code](https://claude.com/claude-code)