### PR TITLE
Tiered planning and faster generation runs

### DIFF
--- a/migrations/0020_request_tiers.sql
+++ b/migrations/0020_request_tiers.sql
@@ -1,0 +1,6 @@
+-- Request tiering: a cheap-model classification of each feature request
+-- (trivial = small localized change; standard = everything else) that scales
+-- plan depth, acceptance-criteria count, and the generation agent's budget
+-- to the size of the ask. Null = pre-tiering rows, treated as standard.
+ALTER TABLE plans ADD COLUMN tier TEXT;
+ALTER TABLE features ADD COLUMN tier TEXT;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -353,6 +353,7 @@ export interface FeatureRow {
 	error: string | null;
 	created_at: string;
 	run_started_at: string | null; // start of the current generation attempt
+	tier: string | null; // trivial | standard; scales the agent budget
 	author_login: string | null; // instructing user (plan approver); null = bot
 	author_id: number | null;
 	coauthor_login: string | null; // plan creator when different from author
@@ -371,11 +372,13 @@ export async function createFeature(
 	// Null for operator/API intakes — the generator commits as the bot.
 	author?: { login: string; id: number },
 	coauthor?: { login: string; id: number },
+	// trivial | standard — scales the generation agent's budget and prompt.
+	tier?: string,
 ): Promise<number> {
 	const row = await env.DB.prepare(
 		`INSERT INTO features
-		 (repository_id, title, spec, acceptance, author_login, author_id, coauthor_login, coauthor_id)
-		 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8) RETURNING id`,
+		 (repository_id, title, spec, acceptance, author_login, author_id, coauthor_login, coauthor_id, tier)
+		 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9) RETURNING id`,
 	)
 		.bind(
 			repositoryId,
@@ -386,6 +389,7 @@ export async function createFeature(
 			author?.id ?? null,
 			coauthor?.login ?? null,
 			coauthor?.id ?? null,
+			tier ?? null,
 		)
 		.first<{ id: number }>();
 	return row!.id;
@@ -462,6 +466,7 @@ export interface PlanRow {
 	created_at: string;
 	created_by_login: string | null; // signed-in submitter; null = operator/API
 	created_by_id: number | null;
+	tier: string | null; // trivial | standard; null = pre-tiering (standard)
 }
 
 export async function createPlan(
@@ -535,6 +540,7 @@ export async function updatePlan(
 		acceptance?: string;
 		featureId?: number;
 		error?: string;
+		tier?: string;
 	},
 ): Promise<void> {
 	await env.DB.prepare(
@@ -546,7 +552,8 @@ export async function updatePlan(
 		 plan = COALESCE(?6, plan),
 		 acceptance = COALESCE(?7, acceptance),
 		 feature_id = COALESCE(?8, feature_id),
-		 error = COALESCE(?9, error)
+		 error = COALESCE(?9, error),
+		 tier = COALESCE(?10, tier)
 		 WHERE id = ?1`,
 	)
 		.bind(
@@ -559,6 +566,7 @@ export async function updatePlan(
 			fields.acceptance ?? null,
 			fields.featureId ?? null,
 			fields.error ?? null,
+			fields.tier ?? null,
 		)
 		.run();
 }

--- a/src/lib/generation-workflow.ts
+++ b/src/lib/generation-workflow.ts
@@ -3,7 +3,7 @@ import { env, WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from '
 import { NonRetryableError } from 'cloudflare:workflows';
 import { gh } from '../tools/github.ts';
 import { coauthorTrailer, gitAuthorEnv } from './attribution.ts';
-import { getFeature, getRepoById, updateFeature, type FeatureRow, type RepositoryRow } from './db.ts';
+import { getFeature, getRepoById, updateFeature, type FeatureRow } from './db.ts';
 import { resolveRunnerAuth } from './fixer.ts';
 import { installationToken, sandboxGitToken } from './github-app.ts';
 import { UNTRUSTED_CONTENT_RULES } from './prompt-security.ts';
@@ -28,12 +28,23 @@ import { mintUserToken } from './user-tokens.ts';
 // Step return values are persisted by the engine: never return tokens or
 // other secrets from a step — mint them inside the step that uses them.
 
-const CLONE_DIR = '/workspace/gen';
-const SPEC_FILE = '/workspace/gen-spec.md';
-// The agent's exec budget — the point of the workflow move. The step timeout
-// is set slightly above it so the exec timeout (a clean, attributable
-// failure) fires before the step timeout does.
-const AGENT_TIMEOUT_MS = 25 * 60_000;
+// The sandbox is per-REPO (warm across features): a shared git cache gets
+// fetched instead of re-cloned, and shared package caches make any install
+// the agent does run cache-hot. Each feature works in its own directory for
+// isolation; only the caches are shared.
+const CACHE_DIR = '/workspace/repo-cache';
+const NPM_CACHE_ENV = {
+	npm_config_cache: '/workspace/.npm-cache',
+	npm_config_store_dir: '/workspace/.pnpm-store',
+};
+const workDir = (featureId: number) => `/workspace/gen-${featureId}`;
+const specFile = (featureId: number) => `/workspace/gen-spec-${featureId}.md`;
+const prFile = (featureId: number) => `/workspace/gen-pr-${featureId}.md`;
+// Agent exec budgets by tier — trivial requests don't get to burn a
+// feature-sized window. Step timeouts sit slightly above so the exec timeout
+// (a clean, attributable failure) fires before the step timeout does.
+const AGENT_TIMEOUT_MS = { trivial: 8 * 60_000, standard: 25 * 60_000 };
+const AGENT_STEP_TIMEOUT = { trivial: '10 minutes', standard: '28 minutes' } as const;
 const CHECK_TIMEOUT_MS = 12 * 60_000;
 
 export interface GenQueueMessage {
@@ -56,31 +67,38 @@ function branchName(feature: FeatureRow): string {
 	return `turbodiff/feat-${feature.id}-${slug}`;
 }
 
-function generationPrompt(feature: FeatureRow, repo: RepositoryRow): string {
-	return `You are an automated implementation agent working in a fresh checkout of ${repo.owner}/${repo.name}.
+function generationPrompt(ctx: RunContext): string {
+	const trivial = ctx.tier === 'trivial';
+	return `You are an automated implementation agent working in a fresh checkout of ${ctx.owner}/${ctx.name}.
 
 Implement the feature specified below. Rules:
 - Implement exactly what the spec describes — no scope creep, no drive-by refactors.
 - Match the repository's existing conventions: style, structure, naming, idioms.
-- If the repository has an established testing pattern, add or update tests for
-  the new behavior in that same pattern.
+${trivial ? '- This is a small, localized change: make the edits, verify them by reading, and stop.' : `- If the repository has an established testing pattern, add or update tests for
+  the new behavior in that same pattern.`}
+- Do NOT run dependency installs, builds, or test suites unless the change itself
+  requires it — the harness runs the repository's check command after you finish,
+  and a separate verification phase checks the acceptance criteria empirically.
 - Do NOT run git commit or git push; the harness handles git.
 - If part of the spec is ambiguous, choose the most conventional interpretation
   and note the choice in a "## Implementation notes" section you append to
-  ${SPEC_FILE}.
+  ${specFile(ctx.featureId)}.
+- When done, write ${prFile(ctx.featureId)}: a concise pull-request description —
+  ${trivial ? '1-3' : '3-6'} bullet points covering what changed and why. No spec restatement, no
+  process narration; just what a reviewer needs.
 
 ${UNTRUSTED_CONTENT_RULES}
 
-## Feature: ${feature.title}
+## Feature: ${ctx.title}
 
-${feature.spec}
+${ctx.spec}
 `;
 }
 
-function sandboxFor(repo: { owner: string; name: string }, featureId: number): Sandbox {
+function sandboxFor(repo: { owner: string; name: string }): Sandbox {
 	return getSandbox(
 		env.Sandbox as unknown as DurableObjectNamespace<Sandbox>,
-		`gen--${repo.owner}--${repo.name}--${featureId}`.toLowerCase(),
+		`gen--${repo.owner}--${repo.name}`.toLowerCase(),
 		{ sleepAfter: '45m' },
 	) as unknown as Sandbox;
 }
@@ -102,6 +120,7 @@ type RunContext = {
 	coauthorLogin: string | null;
 	coauthorId: number | null;
 	acceptance: boolean;
+	tier: 'trivial' | 'standard';
 };
 
 const QUICK = {
@@ -145,31 +164,45 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
 					coauthorLogin: feature.coauthor_login,
 					coauthorId: feature.coauthor_id,
 					acceptance: feature.acceptance !== null,
+					tier: feature.tier === 'trivial' ? 'trivial' : 'standard',
 				};
 			});
 			if (!ctx) return 'skipped';
 			const full = `${ctx.owner}/${ctx.name}`;
 			const label = `${full} feature #${featureId}`;
 
-			await step.do('clone into sandbox', { retries: { limit: 3, delay: '1 minute', backoff: 'exponential' }, timeout: '8 minutes' }, async () => {
+			const WORK = workDir(featureId);
+			await step.do('prepare working copy', { retries: { limit: 3, delay: '1 minute', backoff: 'exponential' }, timeout: '8 minutes' }, async () => {
 				await updateFeature(featureId, { runStartedAt: 'now' }); // heartbeat for the strand sweep
 				const gitToken = await sandboxGitToken(ctx.installationId, ctx.name, 'write');
-				const sandbox = sandboxFor(ctx, featureId);
-				await sandbox.exec(`rm -rf ${CLONE_DIR}`);
-				const clone = await sandbox.exec(
-					`git clone --depth 50 --single-branch --branch "$GEN_BASE" ` +
-						`"https://x-access-token:$GIT_TOKEN@github.com/${full}.git" ${CLONE_DIR} && ` +
-						`git -C ${CLONE_DIR} checkout -b "$GEN_BRANCH" && ` +
-						`git -C ${CLONE_DIR} config user.name "turbodiff[bot]" && ` +
-						`git -C ${CLONE_DIR} config user.email "turbodiff[bot]@users.noreply.github.com"`,
-					{ env: { GIT_TOKEN: gitToken, GEN_BASE: ctx.base, GEN_BRANCH: ctx.branch }, timeout: 5 * 60_000 },
+				const sandbox = sandboxFor(ctx);
+				// Warm path: update the shared per-repo cache (fetch, seconds) or
+				// cold-clone it once; then a local hardlink clone into this
+				// feature's own directory. Credentials only ever travel via env to
+				// explicit-URL commands — nothing credentialed persists on disk.
+				const sync = await sandbox.exec(
+					`if [ -d ${CACHE_DIR}/.git ]; then ` +
+						`git -C ${CACHE_DIR} fetch --depth 50 "https://x-access-token:$GIT_TOKEN@github.com/${full}.git" "$GEN_BASE" && ` +
+						`git -C ${CACHE_DIR} checkout -q -B "$GEN_BASE" FETCH_HEAD; ` +
+						`else git clone --depth 50 --single-branch --branch "$GEN_BASE" ` +
+						`"https://x-access-token:$GIT_TOKEN@github.com/${full}.git" ${CACHE_DIR} && ` +
+						`git -C ${CACHE_DIR} remote set-url origin "https://github.com/${full}.git"; fi`,
+					{ env: { GIT_TOKEN: gitToken, GEN_BASE: ctx.base }, timeout: 5 * 60_000 },
 				);
-				// Never leave the credentialed remote behind, even on failure paths.
-				await sandbox
-					.exec(`git -C ${CLONE_DIR} remote set-url origin "https://github.com/${full}.git"`)
-					.catch(() => {});
+				if (!sync.success) {
+					// A corrupted cache must never wedge the repo — drop it for next time.
+					await sandbox.exec(`rm -rf ${CACHE_DIR}`).catch(() => {});
+					throw new Error(`repo cache sync failed: ${sync.stderr.replaceAll(gitToken, '***').slice(0, 500)}`);
+				}
+				const clone = await sandbox.exec(
+					`rm -rf ${WORK} && git clone --local ${CACHE_DIR} ${WORK} && ` +
+						`git -C ${WORK} checkout -q -b "$GEN_BRANCH" && ` +
+						`git -C ${WORK} config user.name "turbodiff[bot]" && ` +
+						`git -C ${WORK} config user.email "turbodiff[bot]@users.noreply.github.com"`,
+					{ env: { GEN_BRANCH: ctx.branch }, timeout: 2 * 60_000 },
+				);
 				if (!clone.success) {
-					throw new Error(`git clone failed: ${clone.stderr.replaceAll(gitToken, '***').slice(0, 500)}`);
+					throw new Error(`working-copy clone failed: ${clone.stderr.slice(0, 500)}`);
 				}
 			});
 
@@ -177,21 +210,20 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
 			// instance, ever. Memoization means success is never re-bought.
 			const agentRan = await step.do(
 				'run coding agent',
-				{ retries: { limit: 1, delay: '5 minutes' }, timeout: '28 minutes' },
+				{ retries: { limit: 1, delay: '5 minutes' }, timeout: AGENT_STEP_TIMEOUT[ctx.tier] },
 				async (): Promise<{ changed: boolean }> => {
 					await updateFeature(featureId, { runStartedAt: 'now' });
 					const auth = resolveRunnerAuth();
-					const sandbox = sandboxFor(ctx, featureId);
-					const feature = { title: ctx.title, spec: ctx.spec } as FeatureRow;
-					const repo = { owner: ctx.owner, name: ctx.name } as RepositoryRow;
-					await sandbox.writeFile(SPEC_FILE, generationPrompt(feature, repo));
+					const sandbox = sandboxFor(ctx);
+					await sandbox.writeFile(specFile(featureId), generationPrompt(ctx));
 					const agent = await sandbox.exec(
-						`claude -p --dangerously-skip-permissions --output-format text < ${SPEC_FILE}`,
+						`claude -p --dangerously-skip-permissions --output-format text < ${specFile(featureId)}`,
 						{
-							cwd: CLONE_DIR,
-							timeout: AGENT_TIMEOUT_MS,
+							cwd: WORK,
+							timeout: AGENT_TIMEOUT_MS[ctx.tier],
 							env: {
 								...auth.vars,
+								...NPM_CACHE_ENV,
 								IS_SANDBOX: '1',
 								DISABLE_AUTOUPDATER: '1',
 								CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
@@ -203,7 +235,7 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
 							`generation agent exited ${agent.exitCode}: ${`${agent.stdout}\n${agent.stderr}`.trim().slice(-1_000)}`,
 						);
 					}
-					const status = await sandbox.exec(`git -C ${CLONE_DIR} status --porcelain`);
+					const status = await sandbox.exec(`git -C ${WORK} status --porcelain`);
 					return { changed: Boolean(status.stdout.trim()) };
 				},
 			);
@@ -225,9 +257,9 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
 					ctx.coauthorLogin && ctx.coauthorId !== null
 						? { login: ctx.coauthorLogin, id: ctx.coauthorId }
 						: null;
-				const sandbox = sandboxFor(ctx, featureId);
+				const sandbox = sandboxFor(ctx);
 				const commit = await sandbox.exec(
-					`git -C ${CLONE_DIR} add -A && git -C ${CLONE_DIR} commit -m "$COMMIT_MSG"`,
+					`git -C ${WORK} add -A && git -C ${WORK} commit -m "$COMMIT_MSG"`,
 					{
 						env: {
 							COMMIT_MSG:
@@ -246,8 +278,12 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
 					{ retries: { limit: 1, delay: '1 minute' }, timeout: '15 minutes' },
 					async (): Promise<{ ok: boolean; output: string }> => {
 						await updateFeature(featureId, { runStartedAt: 'now' });
-						const sandbox = sandboxFor(ctx, featureId);
-						const res = await sandbox.exec(ctx.checkCommand!, { cwd: CLONE_DIR, timeout: CHECK_TIMEOUT_MS });
+						const sandbox = sandboxFor(ctx);
+						const res = await sandbox.exec(ctx.checkCommand!, {
+							cwd: WORK,
+							timeout: CHECK_TIMEOUT_MS,
+							env: NPM_CACHE_ENV,
+						});
 						// A failing check command is a business outcome, not an infra
 						// error — return it so the step is never retried for it.
 						return { ok: res.success, output: `${res.stdout}\n${res.stderr}`.trim().slice(-500) };
@@ -263,9 +299,9 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
 
 			await step.do('push branch', QUICK, async () => {
 				const gitToken = await sandboxGitToken(ctx.installationId, ctx.name, 'write');
-				const sandbox = sandboxFor(ctx, featureId);
+				const sandbox = sandboxFor(ctx);
 				const push = await sandbox.exec(
-					`git -C ${CLONE_DIR} push "https://x-access-token:$GIT_TOKEN@github.com/${full}.git" HEAD:"$GEN_BRANCH"`,
+					`git -C ${WORK} push "https://x-access-token:$GIT_TOKEN@github.com/${full}.git" HEAD:"$GEN_BRANCH"`,
 					{ env: { GIT_TOKEN: gitToken, GEN_BRANCH: ctx.branch }, timeout: 3 * 60_000 },
 				);
 				if (!push.success) {
@@ -274,10 +310,16 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
 			});
 
 			const prNumber = await step.do('open pull request', QUICK, async (): Promise<number> => {
-				const sandbox = sandboxFor(ctx, featureId);
-				// The agent may have appended implementation notes to the spec file.
+				const sandbox = sandboxFor(ctx);
+				// Concise PR body: the agent's own summary (what changed and why),
+				// not a spec dump. Implementation notes ride along only when the
+				// agent recorded a judgment call worth surfacing.
+				const summary = await sandbox
+					.readFile(prFile(featureId))
+					.then((f) => f.content.trim() || undefined)
+					.catch(() => undefined);
 				const notes = await sandbox
-					.readFile(SPEC_FILE)
+					.readFile(specFile(featureId))
 					.then((f) => f.content.split('## Implementation notes')[1]?.trim())
 					.catch(() => undefined);
 				const createPr = async (authToken: string) =>
@@ -289,9 +331,9 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
 								head: ctx.branch,
 								base: ctx.base,
 								body:
-									`Generated by the turbodiff software factory (feature #${featureId}).\n\n` +
-									`## Spec\n\n${ctx.spec}` +
-									(notes ? `\n\n## Implementation notes\n\n${notes}` : ''),
+									(summary ?? `${ctx.title} — generated change; see the diff.`) +
+									(notes ? `\n\n<details><summary>Implementation notes</summary>\n\n${notes}\n\n</details>` : '') +
+									`\n\n---\n_turbodiff factory · feature #${featureId}_`,
 							}),
 						})
 					).json()) as { number: number };
@@ -319,6 +361,14 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
 				// Phase 4: acceptance criteria get an empirical verification run.
 				if (ctx.acceptance) await env.FACTORY_QUEUE.send({ kind: 'verify', featureId });
 				return pr.number;
+			});
+
+			await step.do('clean workspace', { retries: { limit: 1, delay: '10 seconds' }, timeout: '2 minutes' }, async () => {
+				// Bound the warm container's disk: drop this feature's working copy
+				// and prompt files; the shared repo/package caches stay.
+				await sandboxFor(ctx)
+					.exec(`rm -rf ${WORK} ${specFile(featureId)} ${prFile(featureId)}`)
+					.catch(() => {});
 			});
 
 			console.log(`turbodiff: generation pr_opened for ${label} (PR #${prNumber})`);

--- a/src/lib/planner.ts
+++ b/src/lib/planner.ts
@@ -94,13 +94,49 @@ async function runAgent(
 	}
 }
 
-function analyzePrompt(plan: PlanRow, repo: RepositoryRow): string {
-	return `You are a planning agent for ${repo.owner}/${repo.name}. You are in a read-only checkout — study the code but do NOT modify it.
+// Cheap-model triage: is this request a small localized change or real
+// feature work? Drives plan depth, criteria count, and the generation
+// agent's budget. Fails open to 'standard' — misclassifying big work as
+// trivial is the only harmful direction.
+async function classifyTier(
+	sandbox: Sandbox,
+	plan: PlanRow,
+	repo: RepositoryRow,
+): Promise<'trivial' | 'standard'> {
+	const auth = resolveRunnerAuth();
+	const prompt = `Classify this feature request for ${repo.owner}/${repo.name}. Reply with EXACTLY one word: trivial or standard.
 
+trivial = a small, localized change: cosmetic/styling tweaks, copy changes, a config value, a small fix confined to a handful of files, no new subsystem, no schema or API changes.
+standard = everything else.
+
+## Request: ${plan.title}
+
+${plan.requirements}
+`;
+	try {
+		await sandbox.writeFile(`${OUT_DIR}/classify.md`, prompt);
+		const res = await sandbox.exec(
+			`claude -p --model haiku --output-format text < ${OUT_DIR}/classify.md`,
+			{
+				cwd: CLONE_DIR,
+				timeout: 2 * 60_000,
+				env: { ...auth.vars, IS_SANDBOX: '1', DISABLE_AUTOUPDATER: '1' },
+			},
+		);
+		return res.success && /\btrivial\b/i.test(res.stdout) ? 'trivial' : 'standard';
+	} catch {
+		return 'standard';
+	}
+}
+
+function analyzePrompt(plan: PlanRow, repo: RepositoryRow, tier: string): string {
+	const trivial = tier === 'trivial';
+	return `You are a planning agent for ${repo.owner}/${repo.name}. You are in a read-only checkout — study the code but do NOT modify it.
+${trivial ? '\nThis request is classified TRIVIAL: a small, localized change. Keep everything proportionate — a short analysis, and questions only for a genuine blocker.\n' : ''}
 Analyze the feature requirements below against the actual codebase, then write these files (create the directory if needed):
 
-1. ${OUT_DIR}/analysis.md — a short grounding analysis: which files/modules this touches, how it fits existing conventions, and any risks.
-2. ${OUT_DIR}/questions.json — a JSON array of clarifying questions (strings). Include ONLY genuine ambiguities or decisions the requirements leave open and that would change the implementation. If the requirements are clear enough to implement well, write an empty array [].
+1. ${OUT_DIR}/analysis.md — a ${trivial ? 'brief (≤10 lines)' : 'short'} grounding analysis: which files/modules this touches, how it fits existing conventions, and any risks.
+2. ${OUT_DIR}/questions.json — a JSON array of clarifying questions (strings). Include ONLY genuine ambiguities or decisions the requirements leave open and that would change the implementation. If the requirements are clear enough to implement well, write an empty array [].${trivial ? ' For a trivial request the answer is almost always [].' : ''}
 
 ${UNTRUSTED_CONTENT_RULES}
 
@@ -111,13 +147,17 @@ ${plan.requirements}
 `;
 }
 
-function planPrompt(plan: PlanRow, repo: RepositoryRow, qa: string): string {
+function planPrompt(plan: PlanRow, repo: RepositoryRow, qa: string, tier: string): string {
+	const trivial = tier === 'trivial';
 	return `You are a planning agent for ${repo.owner}/${repo.name}. You are in a read-only checkout — study the code but do NOT modify it.
-
+${trivial ? '\nThis request is classified TRIVIAL: a small, localized change. The plan must be proportionate — a reader should grasp it in seconds.\n' : ''}
 Produce an implementation plan for the feature below, grounded in the real code, then write these files:
 
-1. ${OUT_DIR}/plan.md — a file-level implementation plan: what changes in which files, in what order, and why. Concrete enough for an implementation agent to follow without further questions.
-2. ${OUT_DIR}/acceptance.json — a JSON array of machine-checkable acceptance criteria (strings). Each must be objectively verifiable (a specific response shape, a test that would pass, an observable behavior) — not vague ("works well"). These gate whether the generated code satisfies the request.
+1. ${OUT_DIR}/plan.md — ${trivial ? 'a brief plan (≤15 lines): the exact files to edit and what changes in each. No background essays, no scope-decision narratives.' : 'a file-level implementation plan: what changes in which files, in what order, and why. Concrete enough for an implementation agent to follow without further questions.'}
+2. ${OUT_DIR}/acceptance.json — a JSON array of at most ${trivial ? 4 : 8} machine-checkable acceptance criteria (strings), each about the observable behavior of the change itself. Rules:
+   - NEVER include build/typecheck/test-suite-passes criteria — the harness runs the repository's check command as its own gate.
+   - NEVER include "file X is unchanged" criteria — the diff itself shows that.
+   - Not vague ("works well"); each must be objectively verifiable.
 
 ${UNTRUSTED_CONTENT_RULES}
 
@@ -147,13 +187,16 @@ export async function runPlanAnalyze(planId: number): Promise<void> {
 	try {
 		const booted = await clonePlanRepo(repo, planId);
 		sandbox = booted.sandbox;
-		await runAgent(sandbox, analyzePrompt(plan, repo), booted.scrub);
+		// Cheap-model triage first: trivial requests get proportionate plans.
+		const tier = await classifyTier(sandbox, plan, repo);
+		await updatePlan(planId, { tier });
+		await runAgent(sandbox, analyzePrompt(plan, repo, tier), booted.scrub);
 		const analysis = await readText(sandbox, `${OUT_DIR}/analysis.md`);
 		const questions = await readJsonArray(sandbox, `${OUT_DIR}/questions.json`);
 
 		if (questions.length === 0) {
 			// No ambiguities — plan immediately in the same run.
-			await runAgent(sandbox, planPrompt({ ...plan, analysis: analysis ?? null }, repo, ''), booted.scrub);
+			await runAgent(sandbox, planPrompt({ ...plan, analysis: analysis ?? null }, repo, '', tier), booted.scrub);
 			const planMd = await readText(sandbox, `${OUT_DIR}/plan.md`);
 			const acceptance = await readJsonArray(sandbox, `${OUT_DIR}/acceptance.json`);
 			await updatePlan(planId, {
@@ -205,7 +248,7 @@ export async function runPlanRefine(planId: number): Promise<void> {
 	try {
 		const booted = await clonePlanRepo(repo, planId);
 		sandbox = booted.sandbox;
-		await runAgent(sandbox, planPrompt(plan, repo, qa), booted.scrub);
+		await runAgent(sandbox, planPrompt(plan, repo, qa, plan.tier ?? 'standard'), booted.scrub);
 		const planMd = await readText(sandbox, `${OUT_DIR}/plan.md`);
 		const acceptance = await readJsonArray(sandbox, `${OUT_DIR}/acceptance.json`);
 		await updatePlan(planId, {
@@ -260,6 +303,7 @@ export async function approvePlan(
 		plan.acceptance ?? undefined,
 		author,
 		coauthor,
+		plan.tier ?? undefined,
 	);
 	await updatePlan(planId, { status: 'approved', featureId });
 	return featureId;


### PR DESCRIPTION
- Cheap-model (haiku) triage at plan intake: trivial vs standard (migration 0020)
- Trivial: short plan, ≤4 criteria, no questions unless blocking, 8-min agent budget; standard: ≤8 criteria
- Banned criteria: build/typecheck/test-passes and "file unchanged" — the harness gates those
- Agent no longer installs/builds unless required; PR bodies are the agent's concise summary, not a spec dump
- Warm per-repo sandbox: git cache + hardlink clones + shared npm/pnpm caches; workspace cleaned after PR opens

Deploy: apply migration 0020 remotely. Typecheck/lint/build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)