### PR TITLE
Auto-detect app launch for demos; per-repo demo toggle

### DIFF
--- a/migrations/0021_demo_videos.sql
+++ b/migrations/0021_demo_videos.sql
@@ -1,0 +1,6 @@
+-- Per-repo switch for verification demo videos (and the runtime auto-detect
+-- that powers them). Defaults ON: the verify agent works out how to launch
+-- the app by itself, so there is no config burden — this column exists to
+-- opt OUT for repos where recordings add time without value (API-only,
+-- libraries).
+ALTER TABLE repositories ADD COLUMN demo_videos INTEGER NOT NULL DEFAULT 1;

--- a/src/client/pages/settings.tsx
+++ b/src/client/pages/settings.tsx
@@ -196,6 +196,13 @@ function RepoRow({ repo }: { repo: ApiRepoSettings }) {
 						>
 							&#127981; auto-merge
 						</Chip>
+						<Chip
+							on={repo.demo_videos}
+							title={`${repo.demo_videos ? 'verification records a short demo video of each feature (the verify agent auto-detects how to launch the app)' : 'verification skips demo recordings for this repo'} — click to ${repo.demo_videos ? 'disable' : 'enable'}`}
+							onClick={() => patchRepo.mutate({ demo_videos: !repo.demo_videos })}
+						>
+							&#127909; demos
+						</Chip>
 					</div>
 					<CheckCommandForm repo={repo} />
 				</>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -22,6 +22,7 @@ export interface RepositoryRow {
 	blocking_reviews: number; // P1 → REQUEST_CHANGES, clean → APPROVE
 	auto_fix: number; // dispatch the fix agent when a blocking review lands
 	auto_merge: number; // merge factory PRs when verification + review are clean
+	demo_videos: number; // record a verification demo video (runtime auto-detected)
 	check_command: string | null; // sandbox verification gate before factory pushes
 	run_command: string | null; // how to launch the app for runtime verification
 	app_port: number | null; // port the launched app listens on
@@ -159,6 +160,12 @@ export async function setRepoAutoMerge(id: number, on: boolean): Promise<void> {
 }
 
 // The sandbox verification gate for factory pushes. Empty string clears it.
+export async function setRepoDemoVideos(id: number, on: boolean): Promise<void> {
+	await env.DB.prepare('UPDATE repositories SET demo_videos = ?2 WHERE id = ?1')
+		.bind(id, on ? 1 : 0)
+		.run();
+}
+
 export async function setRepoCheckCommand(id: number, command: string): Promise<void> {
 	const trimmed = command.trim();
 	await env.DB.prepare('UPDATE repositories SET check_command = ?2 WHERE id = ?1')

--- a/src/lib/verifier.ts
+++ b/src/lib/verifier.ts
@@ -8,6 +8,7 @@ import {
 	getRepoById,
 	type FeatureRow,
 	type RepositoryRow,
+	setRepoRunCommand,
 } from './db.ts';
 import { maybeAutoMerge } from './auto-merge.ts';
 import { signArtifactKey } from './crypto.ts';
@@ -41,7 +42,8 @@ interface CriterionResult {
 }
 
 function verifyPrompt(feature: FeatureRow, repo: RepositoryRow, criteria: string[]): string {
-	const runtime = repo.run_command
+	const demos = repo.demo_videos === 1;
+	const launch = repo.run_command
 		? `## Running the app
 The app can be launched with:
 
@@ -52,7 +54,28 @@ Start it in the background (e.g. \`nohup ... > /tmp/app.log 2>&1 &\`), wait for
 the port to accept connections, and verify runtime criteria against it with
 curl or small node scripts. If it fails to start, mark runtime criteria as
 "skip" with a note quoting the relevant log lines — do NOT mark them "fail"
-for infrastructure reasons.
+for infrastructure reasons.`
+		: `## Running the app (work it out yourself)
+No launch command is configured. Determine how to run this app from the
+repository itself: package.json scripts (dev/start/preview), the README,
+framework config, lockfiles. Install dependencies first if needed. Launch in
+the background (\`nohup ... > /tmp/app.log 2>&1 &\`), wait for its port to
+accept connections, and verify runtime criteria against the live app.
+
+If you launch it successfully, record what worked by writing
+${OUT_DIR}/run-command.json:
+
+    {"command": "<one shell command, including any install step>", "port": <number>}
+
+so future verification runs can skip this discovery.
+
+If this repository is NOT a launchable app with a web UI (a library, an
+API-only service, a mobile app), do not force it: verify what you can
+statically, mark runtime-only criteria "skip" with a note, and skip
+screenshots and the recording. If it fails to start after honest attempts,
+mark runtime criteria "skip" quoting the relevant log lines — do NOT mark
+them "fail" for infrastructure reasons.`;
+	const runtime = `${launch}
 
 ## Screenshots
 A headless Chrome binary is installed (its path is in the env var
@@ -65,7 +88,9 @@ Launch with args ['--no-sandbox', '--disable-dev-shm-usage']. Use descriptive
 kebab-case filenames and reference each screenshot from the matching
 criterion result.
 
-## Demo recording
+${
+		demos
+			? `## Demo recording
 Also record ONE short screen recording (10–30 seconds) demonstrating the
 feature's happy path end to end. This is what humans watch, so drive it like a
 demo: pause about a second between meaningful steps and let each state change
@@ -77,10 +102,8 @@ be visible before moving on. In a .cjs script, use puppeteer's screencast API:
 
 Write a one-line caption for the recording to ${OUT_DIR}/demo-caption.txt.
 If the app cannot run, skip the recording.`
-		: `## Running the app
-No run command is configured for this repository, so runtime and visual checks
-are unavailable. Verify what can be verified statically from the tree; mark
-criteria that would need a running app as "skip" with a note saying why.`;
+			: `Demo recordings are disabled for this repository — do not record one.`
+	}`;
 
 	return `You are a verification agent for ${repo.owner}/${repo.name}. You are in a checkout of the pull request branch for "${feature.title}". You may read anything and run the app, but do NOT modify tracked files, commit, or push.
 
@@ -188,7 +211,26 @@ async function verify(
 		const results = await readResults(sandbox, criteria.length);
 		const summary = await readText(sandbox, `${OUT_DIR}/summary.md`);
 		const shots = await uploadScreenshots(sandbox, feature.id, results);
-		const demo = await uploadDemo(sandbox, feature.id);
+		const demo = repo.demo_videos === 1 ? await uploadDemo(sandbox, feature.id) : undefined;
+
+		// Cache the agent's successful launch discovery so future runs (and the
+		// generation check gate) skip it. Same trust domain as running the
+		// repo's own code — the sandbox is the boundary.
+		if (!repo.run_command) {
+			try {
+				const detected = JSON.parse(
+					(await sandbox.readFile(`${OUT_DIR}/run-command.json`)).content,
+				) as { command?: unknown; port?: unknown };
+				const cmd = typeof detected.command === 'string' ? detected.command.trim() : '';
+				const port = Number(detected.port);
+				if (cmd && cmd.length <= 500 && Number.isInteger(port) && port > 0 && port < 65536) {
+					await setRepoRunCommand(repo.id, cmd, port);
+					console.log(`turbodiff: cached auto-detected run command for ${full} (port ${port})`);
+				}
+			} catch {
+				// nothing written — repo isn't launchable or launch failed
+			}
+		}
 
 		const failed = results.filter((r) => r.verdict === 'fail');
 		await postReport(token, repo, feature, criteria, results, shots, summary, demo);

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -38,6 +38,7 @@ import {
 	setRepoAutoMerge,
 	setRepoBlockingReviews,
 	setRepoCheckCommand,
+	setRepoDemoVideos,
 	setRepoEnabled,
 	setRepoReviewOnPush,
 	updateAgent,
@@ -791,6 +792,7 @@ export function createApiRoutes() {
 						blocking_reviews: r.blocking_reviews === 1,
 						auto_fix: r.auto_fix === 1,
 						auto_merge: r.auto_merge === 1,
+						demo_videos: r.demo_videos === 1,
 						check_command: r.check_command,
 						agents: instAgents.map((a) => ({
 							id: a.id,
@@ -815,6 +817,7 @@ export function createApiRoutes() {
 				blocking_reviews?: boolean;
 				auto_fix?: boolean;
 				auto_merge?: boolean;
+				demo_videos?: boolean;
 				check_command?: string;
 			}>()
 			.catch(() => null);
@@ -825,6 +828,7 @@ export function createApiRoutes() {
 			await setRepoBlockingReviews(repo.id, body.blocking_reviews);
 		if (typeof body.auto_fix === 'boolean') await setRepoAutoFix(repo.id, body.auto_fix);
 		if (typeof body.auto_merge === 'boolean') await setRepoAutoMerge(repo.id, body.auto_merge);
+		if (typeof body.demo_videos === 'boolean') await setRepoDemoVideos(repo.id, body.demo_videos);
 		if (typeof body.check_command === 'string') await setRepoCheckCommand(repo.id, body.check_command);
 		return c.json({ ok: true });
 	});

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -194,6 +194,7 @@ export interface ApiRepoSettings {
 	blocking_reviews: boolean;
 	auto_fix: boolean;
 	auto_merge: boolean;
+	demo_videos: boolean;
 	check_command: string | null;
 	agents: { id: number; slug: string; name: string; enabled: boolean }[];
 }


### PR DESCRIPTION
- Verify agent now auto-detects how to launch the app (package.json/README/framework config) when no run command is configured, and caches a successful launch back onto the repo — zero user config
- Non-launchable repos (libraries, API-only) degrade to static verification gracefully
- New per-repo "demos" chip in settings (migration 0021, default ON) to disable recordings where they add no value

Deploy: apply migration 0021 remotely. Typecheck/lint/build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)