### PR TITLE
Mobile and visual polish: fewer borders, no // markers, no iOS zoom

### DIFF
--- a/src/client/components/app-shell.tsx
+++ b/src/client/components/app-shell.tsx
@@ -83,18 +83,18 @@ export function AppShell({ login, children }: { login: string; children: ReactNo
 				<UserBlock login={login} />
 			</aside>
 
-			<div className="sticky top-0 z-40 border-b border-line bg-bg/90 backdrop-blur md:hidden">
-				<div className="flex items-center justify-between px-4 pt-3">
+			<div className="sticky top-0 z-40 border-b border-line/60 bg-bg/95 backdrop-blur md:hidden">
+				<div className="flex items-center justify-between px-4 pt-2.5">
 					<Logo />
 					<UserBlock login={login} />
 				</div>
-				<div className="px-2 py-1.5">
+				<div className="px-2 pt-0.5 pb-1.5">
 					<NavLinks />
 				</div>
 			</div>
 
 			<main className="min-w-0 flex-1">
-				<div className={cn('mx-auto px-4 py-8 md:px-8', wide ? 'max-w-[96rem]' : 'max-w-4xl')}>
+				<div className={cn('mx-auto px-4 py-5 sm:py-8 md:px-8', wide ? 'max-w-[96rem]' : 'max-w-4xl')}>
 					{children}
 				</div>
 			</main>

--- a/src/client/components/section.tsx
+++ b/src/client/components/section.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react';
 import { cn } from '../lib/utils.ts';
 
-// '// heading' section marker — the v1 identity, now a component.
 export function SectionHeading({
 	children,
 	aside,
@@ -12,8 +11,8 @@ export function SectionHeading({
 	className?: string;
 }) {
 	return (
-		<div className={cn('mt-9 mb-2 flex flex-wrap items-baseline justify-between gap-2', className)}>
-			<h2 className="section-mark text-[0.95rem] font-medium text-ink-dim">{children}</h2>
+		<div className={cn('mt-9 mb-3 flex flex-wrap items-baseline justify-between gap-2', className)}>
+			<h2 className="text-xs font-medium tracking-[0.14em] text-mute uppercase">{children}</h2>
 			{aside}
 		</div>
 	);
@@ -21,8 +20,8 @@ export function SectionHeading({
 
 export function PageTitle({ children, aside }: { children: ReactNode; aside?: ReactNode }) {
 	return (
-		<div className="flex flex-wrap items-center justify-between gap-3">
-			<h1 className="text-xl font-medium tracking-wide">{children}</h1>
+		<div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+			<h1 className="text-lg font-medium tracking-wide sm:text-xl">{children}</h1>
 			{aside}
 		</div>
 	);
@@ -30,7 +29,7 @@ export function PageTitle({ children, aside }: { children: ReactNode; aside?: Re
 
 export function EmptyState({ children }: { children: ReactNode }) {
 	return (
-		<p className="rounded-lg border border-dashed border-line-2 px-4 py-6 text-center text-[0.85rem] text-mute">
+		<p className="rounded-xl bg-surface-2/60 px-4 py-8 text-center text-[0.85rem] text-mute">
 			{children}
 		</p>
 	);

--- a/src/client/components/ui/card.tsx
+++ b/src/client/components/ui/card.tsx
@@ -4,7 +4,7 @@ import { cn } from '../../lib/utils.ts';
 export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
 	return (
 		<div
-			className={cn('rounded-lg border border-line bg-surface p-4', className)}
+			className={cn('rounded-xl bg-raised/50 p-4', className)}
 			{...props}
 		/>
 	);

--- a/src/client/components/ui/input.tsx
+++ b/src/client/components/ui/input.tsx
@@ -1,8 +1,10 @@
 import type { InputHTMLAttributes, SelectHTMLAttributes, TextareaHTMLAttributes } from 'react';
 import { cn } from '../../lib/utils.ts';
 
+// text-base below sm is deliberate: iOS Safari auto-zooms any focused field
+// with a font size under 16px.
 const fieldClasses =
-	'w-full rounded-md border border-line-2 bg-surface px-2.5 py-1.5 text-sm text-ink placeholder:text-mute/70 read-only:opacity-60 focus-visible:border-accent/50';
+	'w-full rounded-lg border border-line-2/70 bg-surface px-3 py-2 text-base text-ink placeholder:text-mute/70 read-only:opacity-60 focus-visible:border-accent/50 sm:rounded-md sm:px-2.5 sm:py-1.5 sm:text-sm';
 
 export function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
 	return <input className={cn(fieldClasses, className)} {...props} />;

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -56,7 +56,7 @@ function Pending() {
 function RouteError({ error, reset }: { error: Error; reset: () => void }) {
 	return (
 		<div className="mx-auto mt-16 max-w-md text-center">
-			<p className="section-mark text-ink-dim">something broke</p>
+			<p className="text-ink-dim">something broke</p>
 			<p className="mt-2 text-[0.85rem] text-mute">{error.message}</p>
 			<div className="mt-4">
 				<Button variant="secondary" onClick={reset}>
@@ -70,7 +70,7 @@ function RouteError({ error, reset }: { error: Error; reset: () => void }) {
 function NotFound() {
 	return (
 		<div className="mx-auto mt-16 max-w-md text-center">
-			<p className="section-mark text-ink-dim">404 — no such page</p>
+			<p className="text-ink-dim">404 — no such page</p>
 			<p className="mt-2 text-[0.85rem] text-mute">
 				<a href="/" className="text-accent-bright hover:underline">
 					back to the dashboard &rarr;

--- a/src/client/pages/board.tsx
+++ b/src/client/pages/board.tsx
@@ -44,20 +44,21 @@ function QuickAdd({ board }: { board: ApiBoard }) {
 		if (title.trim()) add.mutate();
 	};
 	return (
-		<form onSubmit={submit} className="flex flex-col gap-1.5">
+		<form onSubmit={submit} className="flex flex-col gap-2 sm:flex-row">
 			<Input
 				value={title}
 				onChange={(e) => setTitle(e.target.value)}
-				placeholder="add a todo… (enter to save)"
+				placeholder="add a todo…"
 				aria-label="New todo title"
 				maxLength={200}
+				className="flex-1"
 			/>
 			{board.installations.length > 1 ? (
 				<Select
 					value={installationId}
 					onChange={(e) => setInstallationId(Number(e.target.value))}
 					aria-label="Installation"
-					className="py-1 text-xs"
+					className="sm:w-44"
 				>
 					{board.installations.map((i) => (
 						<option key={i.id} value={i.id}>
@@ -246,11 +247,15 @@ function Column({
 }) {
 	return (
 		<section className="min-w-0">
-			<h2 className="section-mark mb-2 text-[0.95rem] font-medium text-ink-dim">
-				{title} <Muted className="text-xs">{count}</Muted>
+			<h2 className="mb-2.5 text-xs font-medium tracking-[0.14em] text-mute uppercase">
+				{title} <span className="ml-1 text-mute/60">{count}</span>
 			</h2>
-			<div className="flex flex-col gap-2 rounded-lg border border-line bg-surface/40 p-2">
-				{count === 0 ? <p className="px-2 py-4 text-center text-xs text-mute">{empty}</p> : children}
+			<div className="flex flex-col gap-2.5">
+				{count === 0 ? (
+					<p className="rounded-xl bg-surface-2/60 px-3 py-6 text-center text-xs text-mute">{empty}</p>
+				) : (
+					children
+				)}
 			</div>
 		</section>
 	);
@@ -313,12 +318,12 @@ export function BoardPage() {
 				board
 			</PageTitle>
 
-			<div className="mt-4 max-w-md">
+			<div className="mt-5 lg:max-w-xl">
 				<QuickAdd board={data} />
 			</div>
 
 			{/* Mobile: filter chips instead of three side-by-side columns. */}
-			<div className="mt-4 flex gap-1.5 lg:hidden" role="tablist" aria-label="Filter by status">
+			<div className="mt-5 flex gap-2 overflow-x-auto pb-1 lg:hidden" role="tablist" aria-label="Filter by status">
 				{(
 					[
 						['all', 'all'],
@@ -333,10 +338,10 @@ export function BoardPage() {
 						aria-selected={filter === key}
 						onClick={() => setFilter(key)}
 						className={cn(
-							'cursor-pointer rounded-full border px-3 py-1 text-xs whitespace-nowrap',
+							'cursor-pointer rounded-full px-3.5 py-1.5 text-xs whitespace-nowrap transition-colors',
 							filter === key
-								? 'border-accent/40 bg-raised text-accent-bright'
-								: 'border-line-2 text-mute hover:bg-raised/60',
+								? 'bg-accent/15 font-medium text-accent-bright'
+								: 'bg-raised/60 text-mute hover:text-ink',
 						)}
 					>
 						{label}
@@ -344,8 +349,8 @@ export function BoardPage() {
 				))}
 			</div>
 
-			<div className="mt-4 hidden gap-4 lg:grid lg:grid-cols-3">{columns.map((col) => col.el)}</div>
-			<div className="mt-3 flex flex-col gap-5 lg:hidden">
+			<div className="mt-6 hidden gap-5 lg:grid lg:grid-cols-3">{columns.map((col) => col.el)}</div>
+			<div className="mt-4 flex flex-col gap-7 lg:hidden">
 				{columns.filter((col) => show(col.key)).map((col) => col.el)}
 			</div>
 		</>

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -38,14 +38,6 @@
 	}
 }
 
-@layer components {
-	/* '// heading' — the section marker carried over from v1. */
-	.section-mark::before {
-		content: '// ';
-		color: var(--color-accent);
-	}
-}
-
 @keyframes pulse-dot {
 	0%,
 	100% {


### PR DESCRIPTION
- 16px inputs below sm (kills iOS focus auto-zoom) + comfier touch targets
- Borderless tonal cards/columns/chips; uppercase tracked section labels replace the // prefix
- Tighter mobile chrome and better board spacing

Browser-verified at mobile + desktop viewports; typecheck/lint/build pass. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)