### PR TITLE
Mobile app feel: bottom tab bar, tappable agent rows, tighter screens

### DIFF
--- a/src/client/components/app-shell.tsx
+++ b/src/client/components/app-shell.tsx
@@ -22,15 +22,16 @@ function Logo() {
 	);
 }
 
-function NavLinks({ vertical }: { vertical?: boolean }) {
+function isActive(pathname: string, to: string, exact?: boolean): boolean {
+	return exact ? pathname === to : pathname.startsWith(to);
+}
+
+function SidebarNav() {
 	const pathname = useRouterState({ select: (s) => s.location.pathname });
 	return (
-		<nav
-			aria-label="Main"
-			className={cn('flex gap-1', vertical ? 'flex-col' : 'items-center overflow-x-auto')}
-		>
+		<nav aria-label="Main" className="flex flex-col gap-1">
 			{NAV.map(({ to, label, icon: Icon, ...item }) => {
-				const active = 'exact' in item && item.exact ? pathname === to : pathname.startsWith(to);
+				const active = isActive(pathname, to, 'exact' in item && item.exact);
 				return (
 					<Link
 						key={to}
@@ -46,6 +47,38 @@ function NavLinks({ vertical }: { vertical?: boolean }) {
 					</Link>
 				);
 			})}
+		</nav>
+	);
+}
+
+// Mobile: a fixed bottom tab bar — every destination always visible and
+// thumb-reachable, instead of a horizontally scrolling top row.
+function BottomTabs() {
+	const pathname = useRouterState({ select: (s) => s.location.pathname });
+	return (
+		<nav
+			aria-label="Main"
+			className="fixed inset-x-0 bottom-0 z-40 border-t border-line/60 bg-bg/95 pb-[env(safe-area-inset-bottom)] backdrop-blur md:hidden"
+		>
+			<div className="grid grid-cols-5">
+				{NAV.map(({ to, label, icon: Icon, ...item }) => {
+					const active = isActive(pathname, to, 'exact' in item && item.exact);
+					return (
+						<Link
+							key={to}
+							to={to}
+							aria-current={active ? 'page' : undefined}
+							className={cn(
+								'flex flex-col items-center gap-1 py-2 text-[10px] tracking-wide transition-colors active:scale-95',
+								active ? 'text-accent-bright' : 'text-mute',
+							)}
+						>
+							<Icon className={cn('size-5', active && 'drop-shadow-[0_0_6px_rgba(86,211,100,0.4)]')} aria-hidden />
+							{label}
+						</Link>
+					);
+				})}
+			</div>
 		</nav>
 	);
 }
@@ -78,26 +111,28 @@ export function AppShell({ login, children }: { login: string; children: ReactNo
 			<aside className="sticky top-0 hidden h-dvh w-52 shrink-0 flex-col justify-between border-r border-line bg-surface/50 p-4 md:flex">
 				<div className="space-y-6">
 					<Logo />
-					<NavLinks vertical />
+					<SidebarNav />
 				</div>
 				<UserBlock login={login} />
 			</aside>
 
-			<div className="sticky top-0 z-40 border-b border-line/60 bg-bg/95 backdrop-blur md:hidden">
-				<div className="flex items-center justify-between px-4 pt-2.5">
-					<Logo />
-					<UserBlock login={login} />
-				</div>
-				<div className="px-2 pt-0.5 pb-1.5">
-					<NavLinks />
-				</div>
+			<div className="sticky top-0 z-40 flex items-center justify-between border-b border-line/60 bg-bg/95 px-4 py-2.5 backdrop-blur md:hidden">
+				<Logo />
+				<UserBlock login={login} />
 			</div>
 
 			<main className="min-w-0 flex-1">
-				<div className={cn('mx-auto px-4 py-5 sm:py-8 md:px-8', wide ? 'max-w-[96rem]' : 'max-w-4xl')}>
+				<div
+					className={cn(
+						'mx-auto px-4 py-5 pb-28 sm:py-8 md:px-8 md:pb-8',
+						wide ? 'max-w-[96rem]' : 'max-w-4xl',
+					)}
+				>
 					{children}
 				</div>
 			</main>
+
+			<BottomTabs />
 		</div>
 	);
 }

--- a/src/client/components/ui/button.tsx
+++ b/src/client/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { Loader2 } from 'lucide-react';
 import { cn } from '../../lib/utils.ts';
 
 const buttonVariants = cva(
-	'inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md font-medium whitespace-nowrap transition-colors disabled:pointer-events-none disabled:opacity-50',
+	'inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md font-medium whitespace-nowrap transition-[color,background-color,border-color,transform] active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50',
 	{
 		variants: {
 			variant: {

--- a/src/client/components/ui/input.tsx
+++ b/src/client/components/ui/input.tsx
@@ -1,4 +1,4 @@
-import type { InputHTMLAttributes, SelectHTMLAttributes, TextareaHTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 import { cn } from '../../lib/utils.ts';
 
 // text-base below sm is deliberate: iOS Safari auto-zooms any focused field
@@ -6,17 +6,17 @@ import { cn } from '../../lib/utils.ts';
 const fieldClasses =
 	'w-full rounded-lg border border-line-2/70 bg-surface px-3 py-2 text-base text-ink placeholder:text-mute/70 read-only:opacity-60 focus-visible:border-accent/50 sm:rounded-md sm:px-2.5 sm:py-1.5 sm:text-sm';
 
-export function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
+export function Input({ className, ...props }: ComponentProps<'input'>) {
 	return <input className={cn(fieldClasses, className)} {...props} />;
 }
 
-export function Textarea({ className, ...props }: TextareaHTMLAttributes<HTMLTextAreaElement>) {
+export function Textarea({ className, ...props }: ComponentProps<'textarea'>) {
 	return <textarea className={cn(fieldClasses, 'min-h-40 resize-y leading-relaxed', className)} {...props} />;
 }
 
 // Native select, styled to match — no popover dependency needed for the few
 // pickers in the app.
-export function Select({ className, ...props }: SelectHTMLAttributes<HTMLSelectElement>) {
+export function Select({ className, ...props }: ComponentProps<'select'>) {
 	return <select className={cn(fieldClasses, 'appearance-auto', className)} {...props} />;
 }
 

--- a/src/client/pages/agents.tsx
+++ b/src/client/pages/agents.tsx
@@ -1,9 +1,9 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
+import { ChevronRight } from 'lucide-react';
 import { agentsQuery } from '../lib/queries.ts';
-import { EmptyState, Muted, PageTitle, SectionHeading } from '../components/section.tsx';
+import { EmptyState, PageTitle, SectionHeading } from '../components/section.tsx';
 import { Pill } from '../components/ui/pill.tsx';
-import { Table, Td, Th } from '../components/ui/table.tsx';
 
 export function AgentsPage() {
 	const { data } = useSuspenseQuery(agentsQuery);
@@ -39,41 +39,29 @@ export function AgentsPage() {
 						>
 							{inst.account_login} {inst.suspended ? <Pill tone="red">suspended</Pill> : null}
 						</SectionHeading>
-						<Table>
-							<thead>
-								<tr>
-									<Th>agent</Th>
-									<Th>slug</Th>
-									<Th>model</Th>
-									<Th numeric />
-								</tr>
-							</thead>
-							<tbody>
-								{inst.agents.map((a) => (
-									<tr key={a.id}>
-										<Td>
-											{a.name} {a.is_builtin ? <Pill>built-in</Pill> : null}
-											{a.description ? <div className="text-xs text-mute">{a.description}</div> : null}
-										</Td>
-										<Td>
+						<div className="flex flex-col gap-2.5">
+							{inst.agents.map((a) => (
+								<Link
+									key={a.id}
+									to="/agents/$agentId/edit"
+									params={{ agentId: String(a.id) }}
+									className="flex items-center justify-between gap-3 rounded-xl bg-raised/50 p-3.5 transition-colors hover:bg-raised active:scale-[0.99]"
+								>
+									<div className="min-w-0">
+										<div className="flex flex-wrap items-center gap-2">
+											<span className="text-[0.9rem] font-medium">{a.name}</span>
 											<Pill>{a.slug}</Pill>
-										</Td>
-										<Td>
-											<Muted>{a.model.replace('cloudflare/', '')}</Muted>
-										</Td>
-										<Td numeric>
-											<Link
-												to="/agents/$agentId/edit"
-												params={{ agentId: String(a.id) }}
-												className="text-accent-bright hover:underline"
-											>
-												edit
-											</Link>
-										</Td>
-									</tr>
-								))}
-							</tbody>
-						</Table>
+											{a.is_builtin ? <Pill className="text-mute/70">built-in</Pill> : null}
+										</div>
+										{a.description ? (
+											<p className="mt-1 truncate text-xs text-mute">{a.description}</p>
+										) : null}
+										<p className="mt-0.5 text-xs text-mute/70">{a.model.replace('cloudflare/', '')}</p>
+									</div>
+									<ChevronRight className="size-4 shrink-0 text-mute" aria-hidden />
+								</Link>
+							))}
+						</div>
 					</section>
 				))
 			)}

--- a/src/client/pages/board.tsx
+++ b/src/client/pages/board.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { Archive, Play, Trash2 } from 'lucide-react';
-import { useState, type FormEvent, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type FormEvent, type ReactNode } from 'react';
 import { toast } from 'sonner';
 import type { ApiBoard, ApiPlan, ApiTodo } from '../../shared/api-types.ts';
 import { api, ApiError } from '../lib/api.ts';
@@ -29,8 +29,21 @@ function onApiError(err: unknown) {
 
 function QuickAdd({ board }: { board: ApiBoard }) {
 	const queryClient = useQueryClient();
+	const inputRef = useRef<HTMLInputElement>(null);
 	const [title, setTitle] = useState('');
 	const [installationId, setInstallationId] = useState(board.installations[0]?.id ?? 0);
+	// Power-user affordance: "/" focuses the quick-add from anywhere on the board.
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key !== '/' || e.metaKey || e.ctrlKey || e.altKey) return;
+			const tag = (e.target as HTMLElement | null)?.tagName;
+			if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+			e.preventDefault();
+			inputRef.current?.focus();
+		};
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	}, []);
 	const add = useMutation({
 		mutationFn: () => api.post('/api/todos', { installation_id: installationId, title }),
 		onSuccess: () => {
@@ -46,9 +59,10 @@ function QuickAdd({ board }: { board: ApiBoard }) {
 	return (
 		<form onSubmit={submit} className="flex flex-col gap-2 sm:flex-row">
 			<Input
+				ref={inputRef}
 				value={title}
 				onChange={(e) => setTitle(e.target.value)}
-				placeholder="add a todo…"
+				placeholder="add a todo…  ( / )"
 				aria-label="New todo title"
 				maxLength={200}
 				className="flex-1"

--- a/src/client/pages/integrations.tsx
+++ b/src/client/pages/integrations.tsx
@@ -257,10 +257,12 @@ export function IntegrationsPage() {
 		<>
 			<PageTitle>mcp &amp; integrations</PageTitle>
 			<p className="mt-3 text-[0.85rem] text-mute">
-				Connect remote MCP servers and APIs once, then attach MCP integrations to the review agents
-				that should use their tools. Tokens are encrypted and write-only. Anything a connected server
-				returns is treated as untrusted content, and connected servers see the PR context agents send
-				them — connect only servers you control or trust.
+				Connect MCP servers and APIs once, then attach MCP integrations to the agents that should
+				use their tools.
+			</p>
+			<p className="mt-1.5 text-xs text-mute/70">
+				Tokens are encrypted and write-only. Connected servers see the PR context agents send them
+				and their output is untrusted — connect only servers you control or trust.
 			</p>
 
 			<SectionHeading>connected</SectionHeading>

--- a/src/client/pages/settings.tsx
+++ b/src/client/pages/settings.tsx
@@ -132,11 +132,11 @@ function RepoRow({ repo }: { repo: ApiRepoSettings }) {
 
 	return (
 		<Card className="mt-2">
-			<div className="flex flex-wrap items-center justify-between gap-3">
-				<span className="font-medium">
+			<div className="flex items-center justify-between gap-3">
+				<span className="min-w-0 truncate font-medium" title={`${repo.owner}/${repo.name}`}>
 					{repo.owner}/{repo.name}
 				</span>
-				<label className="flex cursor-pointer items-center gap-2 text-xs text-mute">
+				<label className="flex shrink-0 cursor-pointer items-center gap-2 text-xs text-mute">
 					factory
 					<Switch
 						checked={repo.enabled}


### PR DESCRIPTION
- Fixed bottom tab bar on mobile (all 5 destinations visible, safe-area padded); top bar is just logo + user
- Agents table → tappable rows (was unreadable on narrow screens)
- Settings repo headers truncate; integrations intro condensed
- Press feedback on buttons/cards; "/" focuses quick-add

Browser-verified at mobile viewport; typecheck/lint/build pass. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)