### PR TITLE
Restructure task and cockpit screens for mobile

### DIFF
--- a/src/client/components/section.tsx
+++ b/src/client/components/section.tsx
@@ -18,10 +18,25 @@ export function SectionHeading({
 	);
 }
 
-export function PageTitle({ children, aside }: { children: ReactNode; aside?: ReactNode }) {
+export function PageTitle({
+	children,
+	aside,
+	titleClassName,
+}: {
+	children: ReactNode;
+	aside?: ReactNode;
+	titleClassName?: string;
+}) {
 	return (
-		<div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
-			<h1 className="text-lg font-medium tracking-wide sm:text-xl">{children}</h1>
+		<div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5">
+			<h1
+				className={cn(
+					'min-w-0 text-lg leading-snug font-medium tracking-wide break-words sm:text-xl',
+					titleClassName,
+				)}
+			>
+				{children}
+			</h1>
 			{aside}
 		</div>
 	);

--- a/src/client/components/ui/button.tsx
+++ b/src/client/components/ui/button.tsx
@@ -3,7 +3,7 @@ import type { ButtonHTMLAttributes } from 'react';
 import { Loader2 } from 'lucide-react';
 import { cn } from '../../lib/utils.ts';
 
-const buttonVariants = cva(
+export const buttonVariants = cva(
 	'inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md font-medium whitespace-nowrap transition-[color,background-color,border-color,transform] active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50',
 	{
 		variants: {

--- a/src/client/pages/feature.tsx
+++ b/src/client/pages/feature.tsx
@@ -334,6 +334,7 @@ export default function FeaturePage() {
 		return (
 			<>
 				<PageTitle
+					titleClassName="text-base sm:text-xl"
 					aside={
 						stopped ? <Pill tone="red">{data.feature.status}</Pill> : <Pill tone="running">generating</Pill>
 					}
@@ -379,37 +380,39 @@ export default function FeaturePage() {
 
 	return (
 		<>
-			<PageTitle
-				aside={
-					<Pill tone={prState === 'merged' ? 'on' : prState === 'open' ? 'running' : 'red'}>{prState}</Pill>
-				}
-			>
-				{data.feature.title}
-			</PageTitle>
-			<p className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[0.85rem] text-mute">
-				{data.repo} · PR{' '}
-				<a
-					href={data.pr.html_url}
-					target="_blank"
-					rel="noopener"
-					className="text-accent-bright hover:underline"
-				>
-					#{data.feature.pr_number}
-				</a>{' '}
-				· {data.pr.changed_files} files,{' '}
-				<span className="text-accent-bright">+{data.pr.additions}</span>{' '}
-				<span className="text-danger">−{data.pr.deletions}</span>
+			<h1 className="text-base leading-snug font-medium break-words sm:text-xl">{data.feature.title}</h1>
+			<div className="mt-3 flex flex-wrap items-center gap-2">
+				<Pill tone={prState === 'merged' ? 'on' : prState === 'open' ? 'running' : 'red'}>{prState}</Pill>
 				{v ? (
 					<Pill tone={v.status === 'passed' ? 'on' : v.status === 'running' ? 'running' : 'red'}>
 						verify: {v.status}
 						{v.status === 'passed' ? ` (${v.total}/${v.total})` : v.status === 'failed' ? ` (${v.failed} unmet)` : ''}
 					</Pill>
 				) : null}
+			</div>
+			<p className="mt-2.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-mute sm:text-[0.85rem]">
+				<span className="truncate">{data.repo}</span>
+				<span>·</span>
+				<a
+					href={data.pr.html_url}
+					target="_blank"
+					rel="noopener"
+					className="text-accent-bright hover:underline"
+				>
+					PR #{data.feature.pr_number}
+				</a>
+				<span>·</span>
+				<span>
+					{data.pr.changed_files} files{' '}
+					<span className="text-accent-bright">+{data.pr.additions}</span>{' '}
+					<span className="text-danger">−{data.pr.deletions}</span>
+				</span>
 			</p>
 
 			{prState === 'open' ? (
-				<div className="mt-4">
+				<div className="mt-5">
 					<ConfirmButton
+						className="w-full sm:w-auto"
 						title="Merge pull request?"
 						description={`This merges PR #${data.feature.pr_number} into ${data.repo} on GitHub.`}
 						confirmLabel="Merge"
@@ -438,9 +441,8 @@ export default function FeaturePage() {
 						{data.demo ? (
 							<>
 								<SectionHeading>demo</SectionHeading>
-								{data.demo.caption ? <Muted className="mb-2 block">{data.demo.caption}</Muted> : null}
 								<video
-									className="w-full rounded-lg border border-line bg-black"
+									className="w-full rounded-xl bg-black"
 									controls
 									autoPlay
 									muted
@@ -448,6 +450,9 @@ export default function FeaturePage() {
 									playsInline
 									src={data.demo.url}
 								/>
+								{data.demo.caption ? (
+									<p className="mt-2 text-xs leading-relaxed text-mute">{data.demo.caption}</p>
+								) : null}
 							</>
 						) : null}
 

--- a/src/client/pages/task.tsx
+++ b/src/client/pages/task.tsx
@@ -8,9 +8,10 @@ import { api, ApiError } from '../lib/api.ts';
 import { ago } from '../lib/format.ts';
 import { GENERATION_STOPPED, taskQuery } from '../lib/queries.ts';
 import { taskState } from '../lib/task-state.ts';
+import { cn } from '../lib/utils.ts';
 import { ConfirmButton } from '../components/confirm-button.tsx';
-import { Muted, PageTitle, SectionHeading } from '../components/section.tsx';
-import { Button } from '../components/ui/button.tsx';
+import { SectionHeading } from '../components/section.tsx';
+import { Button, buttonVariants } from '../components/ui/button.tsx';
 import { Field, Input } from '../components/ui/input.tsx';
 import { Pill } from '../components/ui/pill.tsx';
 
@@ -96,16 +97,32 @@ export function TaskPage() {
 
 	return (
 		<>
-			<Link to="/" className="inline-flex items-center gap-1.5 text-xs text-mute hover:text-ink">
+			<Link to="/" className="inline-flex items-center gap-1.5 py-1 text-xs text-mute hover:text-ink">
 				<ArrowLeft className="size-3.5" aria-hidden /> board
 			</Link>
-			<div className="mt-2">
-				<PageTitle aside={<Pill tone={state.tone}>{state.label}</Pill>}>{task.title}</PageTitle>
+			<h1 className="mt-2 text-base leading-snug font-medium break-words sm:text-xl">{task.title}</h1>
+			<div className="mt-3 flex flex-wrap items-center gap-2">
+				<Pill tone={state.tone}>{state.label}</Pill>
+				{task.verification ? (
+					<Pill
+						tone={
+							task.verification.status === 'passed'
+								? 'on'
+								: task.verification.status === 'running'
+									? 'running'
+									: 'red'
+						}
+					>
+						verify: {task.verification.status}
+						{task.verification.status === 'failed' ? ` (${task.verification.failed} unmet)` : ''}
+					</Pill>
+				) : null}
+				{task.archived ? <Pill>archived</Pill> : null}
 			</div>
-			<p className="mt-1 text-[0.85rem] text-mute">
-				{task.repo} · {state.hint} · {ago(task.created_at)}
-				{task.archived ? ' · archived' : ''}
+			<p className="mt-2.5 text-xs text-mute sm:text-[0.85rem]">
+				{task.repo} · {ago(task.created_at)}
 			</p>
+			{state.hint ? <p className="mt-1 text-xs text-mute/70">{state.hint}</p> : null}
 
 			{task.status === 'failed' && task.error ? (
 				<p className="mt-4 text-[0.85rem] text-danger">{task.error}</p>
@@ -154,39 +171,25 @@ export function TaskPage() {
 			) : null}
 
 			{task.status === 'approved' && task.pr_number ? (
-				<p className="mt-4 flex flex-wrap items-center gap-2 text-[0.85rem]">
+				<div className="mt-6 flex flex-col gap-2 sm:flex-row">
 					{task.feature_id !== null ? (
 						<Link
 							to="/factory/features/$featureId"
 							params={{ featureId: String(task.feature_id) }}
-							className="font-medium text-accent-bright hover:underline"
+							className={cn(buttonVariants({ variant: 'default' }), 'w-full sm:w-auto')}
 						>
-							open in cockpit &rarr;
+							Open in cockpit
 						</Link>
 					) : null}
 					<a
 						href={`https://github.com/${task.repo}/pull/${task.pr_number}`}
 						target="_blank"
 						rel="noopener"
-						className="text-accent-bright hover:underline"
+						className={cn(buttonVariants({ variant: 'secondary' }), 'w-full sm:w-auto')}
 					>
 						PR #{task.pr_number} on GitHub
 					</a>
-					{task.verification ? (
-						<Pill
-							tone={
-								task.verification.status === 'passed'
-									? 'on'
-									: task.verification.status === 'running'
-										? 'running'
-										: 'red'
-							}
-						>
-							verify: {task.verification.status}
-							{task.verification.status === 'failed' ? ` (${task.verification.failed} unmet)` : ''}
-						</Pill>
-					) : null}
-				</p>
+				</div>
 			) : null}
 
 			{task.plan && task.status === 'approved' ? (
@@ -199,7 +202,7 @@ export function TaskPage() {
 				</>
 			) : null}
 
-			<div className="mt-8 border-t border-line pt-4">
+			<div className="mt-12 border-t border-line/60 pt-5">
 				{task.archived ? (
 					<Button variant="secondary" onClick={() => archive.mutate(false)} loading={archive.isPending}>
 						Restore to board
@@ -216,7 +219,7 @@ export function TaskPage() {
 						Archive task
 					</ConfirmButton>
 				)}
-				<Muted className="ml-3">started tasks can't be deleted — only archived</Muted>
+				<p className="mt-2.5 text-xs text-mute/70">started tasks can't be deleted — only archived</p>
 			</div>
 		</>
 	);


### PR DESCRIPTION
- Clear hierarchy on both detail screens: compact title → status pills → short meta → hint
- Real action buttons (full-width merge on mobile; cockpit/PR buttons on task page) instead of inline link soup
- Demo video first, caption below; archive footer stacks its helper text

Browser-verified at mobile viewport; typecheck/lint/build pass. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)