### PR TITLE
Run verification as a durable Workflow; sweep stranded runs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -320,6 +320,18 @@ app.get('/internal/features/:id', async (c) => {
 	return c.json(feature);
 });
 
+// Operator re-verification: enqueue a fresh verify run for a feature.
+app.post('/internal/features/:id/verify', async (c) => {
+	const id = Number(c.req.param('id'));
+	const feature = Number.isInteger(id) ? await getFeature(id) : null;
+	if (!feature) return c.json({ error: 'unknown feature' }, 404);
+	if (!feature.pr_number || !feature.acceptance) {
+		return c.json({ error: 'feature has no PR or no acceptance criteria' }, 409);
+	}
+	await env.FACTORY_QUEUE.send({ kind: 'verify', featureId: id });
+	return c.json({ accepted: true, feature_id: id });
+});
+
 // Operator retry for a failed generation: re-enqueues the SAME feature row,
 // preserving its spec and commit attribution (unlike /internal/generate,
 // which would mint a fresh unattributed feature). An optional

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -10,15 +10,18 @@
 import { processFixMessage, type FixQueueMessage } from './lib/fixer.ts';
 import { startGeneration, type GenQueueMessage } from './lib/generation-workflow.ts';
 import { runPlanAnalyze, runPlanRefine, type PlanQueueMessage } from './lib/planner.ts';
-import { runVerification, type VerifyQueueMessage } from './lib/verifier.ts';
+import { startVerification, VerificationWorkflow } from './lib/verification-workflow.ts';
+import { type VerifyQueueMessage } from './lib/verifier.ts';
 
 // The fixer sandbox container (docs/software-factory-design.md). Declared in
 // wrangler.jsonc under containers/durable_objects with migration tag v2.
 export { Sandbox } from '@cloudflare/sandbox';
 
-// Generation runs as a durable Workflow (binding GEN_WORKFLOW in
-// wrangler.jsonc): memoized steps, bounded retries, no wall-clock kills.
+// Generation and verification run as durable Workflows (bindings
+// GEN_WORKFLOW / VERIFY_WORKFLOW in wrangler.jsonc): memoized steps, bounded
+// retries, no wall-clock kills.
 export { GenerationWorkflow } from './lib/generation-workflow.ts';
+export { VerificationWorkflow };
 
 // Fix and generation runs take minutes, far beyond what a webhook or intake
 // request can wait on, so producers enqueue and these consumers do the work.
@@ -43,7 +46,9 @@ export default {
 					await runPlanRefine(body.planId);
 					break;
 				case 'verify':
-					await runVerification(body.featureId);
+					// Just creates a durable workflow instance — verify runs exceed
+					// the consumer wall clock routinely (launch discovery + demos).
+					await startVerification(body.featureId);
 					break;
 				default:
 					await processFixMessage(body);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -269,6 +269,21 @@ export async function latestVerificationForFeature(
 		.first<VerificationRow>();
 }
 
+// Verification runs killed mid-flight (isolate death) never reach their
+// error handler, stranding rows in 'running' and the UI in an endless poll.
+// Lazy sweep from the read paths, like failStrandedGeneration.
+const VERIFICATION_STRAND_MINUTES = 45;
+
+export async function failStrandedVerifications(): Promise<number> {
+	const res = await env.DB.prepare(
+		`UPDATE verifications SET status = 'error',
+		   error = 'verification run was killed before finishing — re-run it from the PR or wait for the next push'
+		 WHERE status = 'running'
+		   AND created_at < datetime('now', '-${VERIFICATION_STRAND_MINUTES} minutes')`,
+	).run();
+	return res.meta.changes ?? 0;
+}
+
 export async function createVerification(featureId: number): Promise<number> {
 	const row = await env.DB.prepare(
 		'INSERT INTO verifications (feature_id) VALUES (?1) RETURNING id',

--- a/src/lib/verification-workflow.ts
+++ b/src/lib/verification-workflow.ts
@@ -1,0 +1,48 @@
+import { env, WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from 'cloudflare:workers';
+import { getFeature, latestVerificationForFeature } from './db.ts';
+import { runVerification } from './verifier.ts';
+
+// Verification as a durable Workflow, for the same reason generation is one:
+// the queue consumer's 15-minute wall clock silently killed long verify runs
+// (launch discovery + screenshots + a recording routinely exceed it),
+// stranding rows in 'running'. runVerification records its own outcomes and
+// never throws for business reasons, so one long-budget step suffices; the
+// retry (limit 1) only fires on infrastructure death, and the stranded-row
+// sweep in db.ts mops up any run the engine itself loses.
+
+export type VerificationParams = {
+	featureId: number;
+};
+
+export class VerificationWorkflow extends WorkflowEntrypoint<unknown, VerificationParams> {
+	async run(event: WorkflowEvent<VerificationParams>, step: WorkflowStep): Promise<string> {
+		const { featureId } = event.payload;
+		await step.do(
+			'run verification',
+			{ retries: { limit: 1, delay: '5 minutes' }, timeout: '40 minutes' },
+			async () => {
+				await runVerification(featureId);
+			},
+		);
+		return 'done';
+	}
+}
+
+// Queue entry point. Dedupe: a fresh 'running' verification for this feature
+// means an instance is already on it (e.g. a queue redelivery) — skip.
+export async function startVerification(featureId: number): Promise<void> {
+	const feature = await getFeature(featureId);
+	if (!feature) return;
+	const latest = await latestVerificationForFeature(featureId);
+	if (latest?.status === 'running') {
+		const startedMs = Date.parse(`${latest.created_at.replace(' ', 'T')}Z`);
+		if (Date.now() - startedMs < 45 * 60_000) {
+			console.log(`turbodiff: verification skipped for feature ${featureId} — a run is in flight`);
+			return;
+		}
+	}
+	await env.VERIFY_WORKFLOW.create({
+		id: `verify-${featureId}-${Date.now()}`,
+		params: { featureId },
+	});
+}

--- a/src/lib/verifier.ts
+++ b/src/lib/verifier.ts
@@ -27,7 +27,9 @@ import { UNTRUSTED_CONTENT_RULES } from './prompt-security.ts';
 const CLONE_DIR = '/workspace/verify-repo';
 const OUT_DIR = '/workspace/verify-out';
 const SHOTS_DIR = `${OUT_DIR}/screenshots`;
-const AGENT_TIMEOUT_MS = 10 * 60_000;
+// Verification runs inside a Workflow step (no wall clock), so the agent can
+// afford launch discovery + screenshots + a recording.
+const AGENT_TIMEOUT_MS = 20 * 60_000;
 
 export interface VerifyQueueMessage {
 	kind: 'verify';
@@ -61,6 +63,11 @@ repository itself: package.json scripts (dev/start/preview), the README,
 framework config, lockfiles. Install dependencies first if needed. Launch in
 the background (\`nohup ... > /tmp/app.log 2>&1 &\`), wait for its port to
 accept connections, and verify runtime criteria against the live app.
+
+Timebox launch discovery to a few minutes. If the app needs Docker,
+containers, cloud bindings (e.g. Cloudflare Workers/D1/R2), a database, or
+other external services to run, treat it as NOT launchable here — do not
+fight it; verify statically instead.
 
 If you launch it successfully, record what worked by writing
 ${OUT_DIR}/run-command.json:

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -15,6 +15,7 @@ import {
 	deleteTodo,
 	ensureBuiltinAgents,
 	failStrandedGeneration,
+	failStrandedVerifications,
 	getAgentById,
 	getAgentBySlug,
 	getConnection,
@@ -326,6 +327,7 @@ export function createApiRoutes() {
 		// Flip wall-clock-killed runs to failed before reading, so the cards
 		// never show an eternal "generating" for a dead run.
 		await failStrandedGeneration();
+		await failStrandedVerifications();
 		const [groups, plans, todos, stats] = await Promise.all([
 			listInstallationsWithRepos(installationIds),
 			listPlansForInstallations(installationIds),
@@ -437,6 +439,7 @@ export function createApiRoutes() {
 	// Task detail for the board's compact cards.
 	app.get('/tasks/:id', async (c) => {
 		await failStrandedGeneration();
+		await failStrandedVerifications();
 		const id = Number(c.req.param('id'));
 		const plan = Number.isInteger(id) ? await getPlanWithRepoById(id) : null;
 		if (!plan || !c.get('user').installationIds.includes(plan.installation_id)) {
@@ -490,6 +493,7 @@ export function createApiRoutes() {
 
 	app.get('/factory/features/:id', async (c) => {
 		await failStrandedGeneration();
+		await failStrandedVerifications();
 		const id = Number(c.req.param('id'));
 		const feature = Number.isInteger(id) ? await getFeature(id) : null;
 		const repo = feature ? await getRepoById(feature.repository_id) : null;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -71,6 +71,11 @@
 			"binding": "GEN_WORKFLOW",
 			"name": "turbodiff-generation",
 			"class_name": "GenerationWorkflow"
+		},
+		{
+			"binding": "VERIFY_WORKFLOW",
+			"name": "turbodiff-verification",
+			"class_name": "VerificationWorkflow"
 		}
 	],
 	// Decouples factory runs (minutes) from the requests that trigger them


### PR DESCRIPTION
Task 11's verify stuck 'running' forever: consumer wall clock killed both deliveries mid-run (rows 15 min apart), and verifications had no strand sweep. Verification now runs as a Workflow (no wall clock, in-flight dedupe, retry limit 1), stranded rows sweep to 'error' after 45m, launch discovery is timeboxed (Docker/cloud-bindings ⇒ not launchable, verify statically), and /internal/features/:id/verify re-runs verification. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)