### PR TITLE
Run fix runs as a durable Workflow

### DIFF
--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -7,7 +7,8 @@
 //
 // https://flueframework.com/docs/guide/cloudflare-target/#extending-cloudflarets-entrypoint
 
-import { processFixMessage, type FixQueueMessage } from './lib/fixer.ts';
+import { startFix, FixWorkflow } from './lib/fix-workflow.ts';
+import { type FixQueueMessage } from './lib/fixer.ts';
 import { startGeneration, type GenQueueMessage } from './lib/generation-workflow.ts';
 import { runPlanAnalyze, runPlanRefine, type PlanQueueMessage } from './lib/planner.ts';
 import { startVerification, VerificationWorkflow } from './lib/verification-workflow.ts';
@@ -22,6 +23,7 @@ export { Sandbox } from '@cloudflare/sandbox';
 // retries, no wall-clock kills.
 export { GenerationWorkflow } from './lib/generation-workflow.ts';
 export { VerificationWorkflow };
+export { FixWorkflow };
 
 // Fix and generation runs take minutes, far beyond what a webhook or intake
 // request can wait on, so producers enqueue and these consumers do the work.
@@ -51,7 +53,9 @@ export default {
 					await startVerification(body.featureId);
 					break;
 				default:
-					await processFixMessage(body);
+					// Fix runs get the same no-wall-clock treatment as generation
+					// and verification: the consumer just creates the instance.
+					await startFix(body);
 			}
 			message.ack();
 		}

--- a/src/lib/fix-workflow.ts
+++ b/src/lib/fix-workflow.ts
@@ -1,0 +1,32 @@
+import { env, WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from 'cloudflare:workers';
+import { processFixMessage, type FixQueueMessage } from './fixer.ts';
+
+// Fix runs as a durable Workflow — the last of the three long agent runs
+// (generation, verification, fix) to leave the queue consumer's 15-minute
+// wall clock. processFixMessage records its own outcomes (fix_attempts) and
+// never throws for business reasons; the atomic attempt-cap insert inside it
+// also dedupes concurrent deliveries, so one long-budget step suffices.
+
+export type FixParams = {
+	message: FixQueueMessage;
+};
+
+export class FixWorkflow extends WorkflowEntrypoint<unknown, FixParams> {
+	async run(event: WorkflowEvent<FixParams>, step: WorkflowStep): Promise<string> {
+		await step.do(
+			'run fix',
+			{ retries: { limit: 1, delay: '5 minutes' }, timeout: '40 minutes' },
+			async () => {
+				await processFixMessage(event.payload.message);
+			},
+		);
+		return 'done';
+	}
+}
+
+export async function startFix(message: FixQueueMessage): Promise<void> {
+	await env.FIX_WORKFLOW.create({
+		id: `fix-${message.repoId}-${message.prNumber}-${Date.now()}`,
+		params: { message },
+	});
+}

--- a/src/lib/fixer.ts
+++ b/src/lib/fixer.ts
@@ -46,10 +46,10 @@ export interface FixOutcome {
 const CLONE_DIR = '/workspace/repo';
 const TASK_FILE = '/workspace/fix-task.md';
 const NOTES_FILE = '/workspace/fix-notes.md';
-// Clone (2) + agent (8) + checks (4) + push (1) must fit inside a queue
-// consumer's 15-minute wall clock; typical runs use a fraction of each budget.
-const AGENT_TIMEOUT_MS = 8 * 60_000;
-const TEST_TIMEOUT_MS = 4 * 60_000;
+// Fix runs execute inside a Workflow step (no wall clock — see
+// fix-workflow.ts), so the budgets reflect the work, not a deadline.
+const AGENT_TIMEOUT_MS = 15 * 60_000;
+const TEST_TIMEOUT_MS = 10 * 60_000;
 
 // Fix runs per PR across all triggers. A fix push causes a re-review, which
 // can cause another blocking review and another fix — the cap guarantees the

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -76,6 +76,11 @@
 			"binding": "VERIFY_WORKFLOW",
 			"name": "turbodiff-verification",
 			"class_name": "VerificationWorkflow"
+		},
+		{
+			"binding": "FIX_WORKFLOW",
+			"name": "turbodiff-fix",
+			"class_name": "FixWorkflow"
 		}
 	],
 	// Decouples factory runs (minutes) from the requests that trigger them


### PR DESCRIPTION
Completes the wall-clock elimination: fix runs (the last inline queue execution) move to a FixWorkflow like generation and verification. Attempt-cap insert already dedupes deliveries. Agent budget 8→15m, tests 4→10m. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)