### PR TITLE
Cache launch verdicts and warm the verify sandbox

### DIFF
--- a/migrations/0024_repo_launchable.sql
+++ b/migrations/0024_repo_launchable.sql
@@ -1,0 +1,5 @@
+-- Cached launch-detection verdict per repo: null = never checked,
+-- 1 = launchable (run_command/app_port hold the recipe), 0 = verified NOT
+-- launchable in the sandbox (needs Docker/cloud bindings/etc.) — future
+-- verification runs skip discovery instead of rediscovering it every time.
+ALTER TABLE repositories ADD COLUMN launchable INTEGER;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -23,6 +23,7 @@ export interface RepositoryRow {
 	auto_fix: number; // dispatch the fix agent when a blocking review lands
 	auto_merge: number; // merge factory PRs when verification + review are clean
 	demo_videos: number; // record a verification demo video (runtime auto-detected)
+	launchable: number | null; // cached detection: null unknown, 1 yes, 0 no
 	check_command: string | null; // sandbox verification gate before factory pushes
 	run_command: string | null; // how to launch the app for runtime verification
 	app_port: number | null; // port the launched app listens on
@@ -160,6 +161,12 @@ export async function setRepoAutoMerge(id: number, on: boolean): Promise<void> {
 }
 
 // The sandbox verification gate for factory pushes. Empty string clears it.
+export async function setRepoLaunchable(id: number, launchable: boolean): Promise<void> {
+	await env.DB.prepare('UPDATE repositories SET launchable = ?2 WHERE id = ?1')
+		.bind(id, launchable ? 1 : 0)
+		.run();
+}
+
 export async function setRepoDemoVideos(id: number, on: boolean): Promise<void> {
 	await env.DB.prepare('UPDATE repositories SET demo_videos = ?2 WHERE id = ?1')
 		.bind(id, on ? 1 : 0)

--- a/src/lib/generation-workflow.ts
+++ b/src/lib/generation-workflow.ts
@@ -33,7 +33,7 @@ import { mintUserToken } from './user-tokens.ts';
 // the agent does run cache-hot. Each feature works in its own directory for
 // isolation; only the caches are shared.
 const CACHE_DIR = '/workspace/repo-cache';
-const NPM_CACHE_ENV = {
+export const NPM_CACHE_ENV = {
 	npm_config_cache: '/workspace/.npm-cache',
 	npm_config_store_dir: '/workspace/.pnpm-store',
 };

--- a/src/lib/verifier.ts
+++ b/src/lib/verifier.ts
@@ -9,11 +9,13 @@ import {
 	type FeatureRow,
 	type RepositoryRow,
 	setRepoRunCommand,
+	setRepoLaunchable,
 } from './db.ts';
 import { maybeAutoMerge } from './auto-merge.ts';
 import { signArtifactKey } from './crypto.ts';
 import { resolveRunnerAuth } from './fixer.ts';
 import { installationToken, sandboxGitToken } from './github-app.ts';
+import { NPM_CACHE_ENV } from './generation-workflow.ts';
 import { UNTRUSTED_CONTENT_RULES } from './prompt-security.ts';
 
 // Phase 4 (docs/software-factory-design.md): empirical verification of factory
@@ -24,9 +26,14 @@ import { UNTRUSTED_CONTENT_RULES } from './prompt-security.ts';
 // capturing screenshots. The evidence lands on the PR as a report comment;
 // failed criteria feed the existing auto-fix loop.
 
-const CLONE_DIR = '/workspace/verify-repo';
-const OUT_DIR = '/workspace/verify-out';
-const SHOTS_DIR = `${OUT_DIR}/screenshots`;
+// Verification shares GENERATION's per-repo container (same sandbox id), so
+// a verify that follows a generation lands on a hot container with the repo
+// git cache and package caches already warm. Work/output dirs are
+// per-feature for isolation; only the caches are shared.
+const CACHE_DIR = '/workspace/repo-cache';
+const cloneDir = (featureId: number) => `/workspace/verify-${featureId}`;
+const outDir = (featureId: number) => `/workspace/verify-out-${featureId}`;
+const shotsDir = (featureId: number) => `${outDir(featureId)}/screenshots`;
 // Verification runs inside a Workflow step (no wall clock), so the agent can
 // afford launch discovery + screenshots + a recording.
 const AGENT_TIMEOUT_MS = 20 * 60_000;
@@ -44,7 +51,13 @@ interface CriterionResult {
 }
 
 function verifyPrompt(feature: FeatureRow, repo: RepositoryRow, criteria: string[]): string {
+	const OUT_DIR = outDir(feature.id);
+	const SHOTS_DIR = shotsDir(feature.id);
 	const demos = repo.demo_videos === 1;
+	// launchable is the cached detection verdict: 0 means a previous run
+	// proved this repo can't launch in the sandbox — skip discovery entirely.
+	const detect = !repo.run_command && demos && repo.launchable !== 0;
+	const demosPossible = demos && (repo.run_command !== null || detect);
 	const launch = repo.run_command
 		? `## Running the app
 The app can be launched with:
@@ -57,7 +70,8 @@ the port to accept connections, and verify runtime criteria against it with
 curl or small node scripts. If it fails to start, mark runtime criteria as
 "skip" with a note quoting the relevant log lines — do NOT mark them "fail"
 for infrastructure reasons.`
-		: `## Running the app (work it out yourself)
+		: detect
+			? `## Running the app (work it out yourself)
 No launch command is configured. Determine how to run this app from the
 repository itself: package.json scripts (dev/start/preview), the README,
 framework config, lockfiles. Install dependencies first if needed. Launch in
@@ -69,19 +83,21 @@ containers, cloud bindings (e.g. Cloudflare Workers/D1/R2), a database, or
 other external services to run, treat it as NOT launchable here — do not
 fight it; verify statically instead.
 
-If you launch it successfully, record what worked by writing
-${OUT_DIR}/run-command.json:
-
-    {"command": "<one shell command, including any install step>", "port": <number>}
-
-so future verification runs can skip this discovery.
+Record your conclusion either way by writing ${OUT_DIR}/run-command.json:
+- launched successfully: {"command": "<one shell command, including any install step>", "port": <number>}
+- not launchable here: {"launchable": false, "reason": "<one line why>"}
+so future verification runs skip this discovery entirely.
 
 If this repository is NOT a launchable app with a web UI (a library, an
 API-only service, a mobile app), do not force it: verify what you can
 statically, mark runtime-only criteria "skip" with a note, and skip
 screenshots and the recording. If it fails to start after honest attempts,
 mark runtime criteria "skip" quoting the relevant log lines — do NOT mark
-them "fail" for infrastructure reasons.`;
+them "fail" for infrastructure reasons.`
+			: `## Running the app
+This repository is known not to be launchable in this sandbox (cached from a
+previous run). Verify what can be verified statically from the tree; mark
+criteria that would need a running app as "skip" with a note saying why.`;
 	const runtime = `${launch}
 
 ## Screenshots
@@ -96,7 +112,7 @@ kebab-case filenames and reference each screenshot from the matching
 criterion result.
 
 ${
-		demos
+		demosPossible
 			? `## Demo recording
 Also record ONE short screen recording (10–30 seconds) demonstrating the
 feature's happy path end to end. This is what humans watch, so drive it like a
@@ -109,7 +125,7 @@ be visible before moving on. In a .cjs script, use puppeteer's screencast API:
 
 Write a one-line caption for the recording to ${OUT_DIR}/demo-caption.txt.
 If the app cannot run, skip the recording.`
-			: `Demo recordings are disabled for this repository — do not record one.`
+			: `Do not record a demo for this repository.`
 	}`;
 
 	return `You are a verification agent for ${repo.owner}/${repo.name}. You are in a checkout of the pull request branch for "${feature.title}". You may read anything and run the app, but do NOT modify tracked files, commit, or push.
@@ -178,31 +194,52 @@ async function verify(
 	const scrub = (s: string) => s.replaceAll(token, '***').replaceAll(gitToken, '***');
 	const full = `${repo.owner}/${repo.name}`;
 
+	// Same container id as generation: verify usually follows a generation on
+	// the same repo, so the container, repo cache, and package caches are warm.
 	const sandbox = getSandbox(
 		env.Sandbox as unknown as DurableObjectNamespace<Sandbox>,
-		`verify--${repo.owner}--${repo.name}--${feature.id}`.toLowerCase(),
-		{ sleepAfter: '15m' },
+		`gen--${repo.owner}--${repo.name}`.toLowerCase(),
+		{ sleepAfter: '45m' },
 	);
+	const WORK = cloneDir(feature.id);
+	const OUT = outDir(feature.id);
 
 	try {
-		await sandbox.exec(`rm -rf ${CLONE_DIR} ${OUT_DIR} && mkdir -p ${SHOTS_DIR}`);
-		const clone = await sandbox.exec(
-			`git clone --depth 50 --single-branch --branch "$VERIFY_BRANCH" ` +
-				`"https://x-access-token:$GIT_TOKEN@github.com/${full}.git" ${CLONE_DIR}`,
+		await sandbox.exec(`rm -rf ${WORK} ${OUT} && mkdir -p ${shotsDir(feature.id)}`);
+		// Warm path: force-fetch the PR branch into the shared repo cache, then
+		// hardlink-clone it into this feature's own working dir. Cold path
+		// bootstraps the cache. Credentials only ever travel via env to
+		// explicit-URL commands.
+		const sync = await sandbox.exec(
+			`if [ -d ${CACHE_DIR}/.git ]; then ` +
+				`git -C ${CACHE_DIR} fetch --depth 50 "https://x-access-token:$GIT_TOKEN@github.com/${full}.git" "+refs/heads/$VERIFY_BRANCH:refs/heads/$VERIFY_BRANCH"; ` +
+				`else git clone --depth 50 --single-branch --branch "$VERIFY_BRANCH" ` +
+				`"https://x-access-token:$GIT_TOKEN@github.com/${full}.git" ${CACHE_DIR} && ` +
+				`git -C ${CACHE_DIR} remote set-url origin "https://github.com/${full}.git"; fi`,
 			{ env: { GIT_TOKEN: gitToken, VERIFY_BRANCH: feature.branch! }, timeout: 3 * 60_000 },
 		);
+		if (!sync.success) {
+			// A corrupted cache must never wedge the repo — drop it for next time.
+			await sandbox.exec(`rm -rf ${CACHE_DIR}`).catch(() => {});
+			throw new Error(`repo cache sync failed: ${scrub(sync.stderr).slice(0, 500)}`);
+		}
+		const clone = await sandbox.exec(
+			`git clone --local ${CACHE_DIR} ${WORK} -b "$VERIFY_BRANCH"`,
+			{ env: { VERIFY_BRANCH: feature.branch! }, timeout: 2 * 60_000 },
+		);
 		if (!clone.success) {
-			throw new Error(`git clone failed: ${scrub(clone.stderr).slice(0, 500)}`);
+			throw new Error(`working-copy clone failed: ${scrub(clone.stderr).slice(0, 500)}`);
 		}
 
-		await sandbox.writeFile(`${OUT_DIR}/task.md`, verifyPrompt(feature, repo, criteria));
+		await sandbox.writeFile(`${OUT}/task.md`, verifyPrompt(feature, repo, criteria));
 		const agent = await sandbox.exec(
-			`claude -p --dangerously-skip-permissions --output-format text < ${OUT_DIR}/task.md`,
+			`claude -p --dangerously-skip-permissions --output-format text < ${OUT}/task.md`,
 			{
-				cwd: CLONE_DIR,
+				cwd: WORK,
 				timeout: AGENT_TIMEOUT_MS,
 				env: {
 					...auth.vars,
+					...NPM_CACHE_ENV,
 					IS_SANDBOX: '1',
 					DISABLE_AUTOUPDATER: '1',
 					CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
@@ -215,27 +252,35 @@ async function verify(
 			);
 		}
 
-		const results = await readResults(sandbox, criteria.length);
-		const summary = await readText(sandbox, `${OUT_DIR}/summary.md`);
+		const results = await readResults(sandbox, OUT, criteria.length);
+		const summary = await readText(sandbox, `${OUT}/summary.md`);
 		const shots = await uploadScreenshots(sandbox, feature.id, results);
 		const demo = repo.demo_videos === 1 ? await uploadDemo(sandbox, feature.id) : undefined;
 
-		// Cache the agent's successful launch discovery so future runs (and the
-		// generation check gate) skip it. Same trust domain as running the
-		// repo's own code — the sandbox is the boundary.
-		if (!repo.run_command) {
+		// Cache the agent's discovery verdict — positive OR negative — so future
+		// runs skip it entirely. Same trust domain as running the repo's own
+		// code; the sandbox is the boundary.
+		if (!repo.run_command && repo.launchable !== 0) {
 			try {
 				const detected = JSON.parse(
-					(await sandbox.readFile(`${OUT_DIR}/run-command.json`)).content,
-				) as { command?: unknown; port?: unknown };
-				const cmd = typeof detected.command === 'string' ? detected.command.trim() : '';
-				const port = Number(detected.port);
-				if (cmd && cmd.length <= 500 && Number.isInteger(port) && port > 0 && port < 65536) {
-					await setRepoRunCommand(repo.id, cmd, port);
-					console.log(`turbodiff: cached auto-detected run command for ${full} (port ${port})`);
+					(await sandbox.readFile(`${OUT}/run-command.json`)).content,
+				) as { command?: unknown; port?: unknown; launchable?: unknown; reason?: unknown };
+				if (detected.launchable === false) {
+					await setRepoLaunchable(repo.id, false);
+					console.log(
+						`turbodiff: cached NOT-launchable verdict for ${full}: ${String(detected.reason ?? '').slice(0, 120)}`,
+					);
+				} else {
+					const cmd = typeof detected.command === 'string' ? detected.command.trim() : '';
+					const port = Number(detected.port);
+					if (cmd && cmd.length <= 500 && Number.isInteger(port) && port > 0 && port < 65536) {
+						await setRepoRunCommand(repo.id, cmd, port);
+						await setRepoLaunchable(repo.id, true);
+						console.log(`turbodiff: cached auto-detected run command for ${full} (port ${port})`);
+					}
 				}
 			} catch {
-				// nothing written — repo isn't launchable or launch failed
+				// nothing written — discovery inconclusive; try again next run
 			}
 		}
 
@@ -260,16 +305,16 @@ async function verify(
 		}
 		return { status: failed.length > 0 ? 'failed' : 'passed', results, summary, demo };
 	} finally {
-		await sandbox
-			.exec(`git -C ${CLONE_DIR} remote set-url origin "https://github.com/${full}.git"`)
-			.catch(() => {});
+		// The working copy's origin is the local cache path (no credentials);
+		// drop this feature's dirs to bound the warm container's disk.
+		await sandbox.exec(`rm -rf ${WORK} ${OUT}`).catch(() => {});
 	}
 }
 
-async function readResults(sandbox: Sandbox, count: number): Promise<CriterionResult[]> {
+async function readResults(sandbox: Sandbox, out: string, count: number): Promise<CriterionResult[]> {
 	let parsed: unknown;
 	try {
-		parsed = JSON.parse((await sandbox.readFile(`${OUT_DIR}/results.json`)).content);
+		parsed = JSON.parse((await sandbox.readFile(`${out}/results.json`)).content);
 	} catch {
 		throw new Error('verifier agent did not produce a parseable results.json');
 	}
@@ -322,7 +367,7 @@ async function uploadScreenshots(
 	for (const name of wanted) {
 		const safe = name.replace(/[^\w.-]/g, '');
 		if (!safe.endsWith('.png')) continue;
-		const bytes = await readBinary(sandbox, `${SHOTS_DIR}/${safe}`);
+		const bytes = await readBinary(sandbox, `${shotsDir(featureId)}/${safe}`);
 		if (!bytes || bytes.length === 0) continue;
 		const key = `verify/${featureId}/${safe}`;
 		await env.ARTIFACTS.put(key, bytes, { httpMetadata: { contentType: 'image/png' } });
@@ -342,6 +387,7 @@ interface DemoInfo {
 // cannot play (renders a black box) — transcode to H.264 MP4 in the sandbox
 // so the demo plays everywhere. 40MB guard against runaway recordings.
 async function uploadDemo(sandbox: Sandbox, featureId: number): Promise<DemoInfo | undefined> {
+	const OUT_DIR = outDir(featureId);
 	const stat = await sandbox.exec(`stat -c %s "${OUT_DIR}/demo.webm"`, { timeout: 15_000 });
 	const size = Number(stat.stdout.trim());
 	if (!stat.success || !Number.isFinite(size) || size === 0) return undefined;


### PR DESCRIPTION
- Launch detection cached both ways (migration 0024: `repositories.launchable`): successful commands stored as before, and proven not-launchable repos skip discovery forever — previously re-paid on every verify
- Verification shares generation's per-repo container: hot boot, warm git + package caches; PR branch force-fetched into the shared cache, hardlink-cloned per feature, cleaned on exit

⚠️ Deploy: migrate first, verify applied, then deploy (`pnpm exec wrangler d1 migrations apply turbodiff --remote` → `migrations list` shows none pending → `pnpm run deploy`).

Typecheck/lint/build pass; migration exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)