### PR TITLE
Reposition as a software factory; switch reading text to IBM Plex Sans

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,21 @@
 
 <img src="public/logo-small.png" alt="Turbodiff logo" width="64" align="right" />
 
-Open-source AI code review — growing into a software factory. Turbodiff is a
-GitHub App hosted end-to-end on Cloudflare (Workers, Durable Objects, D1,
-Queues, Containers, R2) and built with [Flue](https://flueframework.com).
+The open-source software factory: agents that take a feature from free-form
+requirements to a merged, verified pull request. The goal is to automate ~90%
+of the software creation process — you decide what to build and approve the
+plan; agents do the rest. Turbodiff is a GitHub App hosted end-to-end on
+Cloudflare (Workers, Durable Objects, D1, Queues, Containers, R2) and built
+with [Flue](https://flueframework.com).
 
-Install it and every new pull request gets an automatic review: a short summary
-plus inline comments on the exact lines each finding concerns. Beyond review,
-the factory pipeline takes a feature from free-form requirements to a verified
-pull request: an agent plans it against your actual code (asking clarifying
-questions where the requirements are ambiguous), you approve the plan, agents
-generate the code, review it, fix blocking findings automatically, and verify
-the result empirically — launching the app in a sandbox and posting screenshot
-evidence for every acceptance criterion to the PR.
+Describe a feature and the pipeline takes over: an agent plans it against your
+actual code (asking clarifying questions where the requirements are
+ambiguous), you approve the plan, agents generate the code, review it, fix
+blocking findings automatically, and verify the result empirically — launching
+the app in a sandbox and posting screenshot evidence for every acceptance
+criterion to the PR. The review stage also works standalone: install the app
+and every new pull request gets an automatic review, a short summary plus
+inline comments on the exact lines each finding concerns.
 
 **Live at [turbodiff.dev](https://turbodiff.dev)** — or self-host on your own
 Cloudflare account ([One-time setup](#one-time-setup)).
@@ -27,18 +30,6 @@ Cloudflare account ([One-time setup](#one-time-setup)).
 > align on the approach.
 
 ## What's inside
-
-**Review** (the original product):
-
-- One durable agent instance per PR (`owner--repo--number`), so re-reviews
-  continue the same conversation and reconcile against earlier findings.
-- Risk tiering sizes the effort: trivial changes get one generalist agent,
-  large or sensitive changes the full agent fleet.
-- Optional blocking mode: a P1 finding posts `REQUEST_CHANGES`, a clean review
-  approves.
-- Custom review agents (personas) per installation, with optional remote
-  [MCP](https://modelcontextprotocol.io) tool connections (bearer tokens
-  encrypted at rest; servers are treated as untrusted, like the PR itself).
 
 **Factory** (in active development — see
 [docs/software-factory-design.md](docs/software-factory-design.md)):
@@ -55,6 +46,18 @@ Cloudflare account ([One-time setup](#one-time-setup)).
   the app in the sandbox, visual criteria by driving headless Chrome. The PR
   gets a report comment with a verdict table and inline screenshots; unmet
   criteria feed the auto-fix loop.
+
+**Review** (where Turbodiff started — also works standalone):
+
+- One durable agent instance per PR (`owner--repo--number`), so re-reviews
+  continue the same conversation and reconcile against earlier findings.
+- Risk tiering sizes the effort: trivial changes get one generalist agent,
+  large or sensitive changes the full agent fleet.
+- Optional blocking mode: a P1 finding posts `REQUEST_CHANGES`, a clean review
+  approves.
+- Custom review agents (personas) per installation, with optional remote
+  [MCP](https://modelcontextprotocol.io) tool connections (bearer tokens
+  encrypted at rest; servers are treated as untrusted, like the PR itself).
 
 Agent runs execute inside Cloudflare Containers (the sandbox) and can spend
 either your existing Claude subscription (`claude setup-token`) or API credits
@@ -179,15 +182,16 @@ pushes both.
 
 ## Use it
 
-1. Install the GitHub App, selecting the repositories to review.
-2. Open a pull request — Turbodiff reviews it automatically (capped per
-   installation per day via `REVIEW_DAILY_LIMIT`).
-3. Sign in to configure repositories on `/settings` — per-repo toggles for
-   re-review on push, blocking reviews, auto-fix, and the sandbox check
-   command — and watch reviews on `/reviews`.
-4. Plan and build features on `/factory`: submit requirements, answer the
-   planning agent's questions, approve the plan, and follow the generated PR
-   through review and verification.
+1. Install the GitHub App, selecting the repositories it may work on.
+2. Sign in — the board at `/` is the factory: add a todo, start it, answer
+   the planning agent's questions, approve the plan, and follow the generated
+   PR through review, auto-fix, and verification in the cockpit.
+3. Every pull request — yours or the factory's — gets an automatic review
+   (capped per installation per day via `REVIEW_DAILY_LIMIT`); recent reviews
+   and costs are on `/usage`.
+4. Configure per-repo behavior on `/settings`: the factory toggle, re-review
+   on push, blocking reviews, auto-fix, auto-merge, demo videos, and the
+   sandbox check command.
 
 Operator endpoints (Bearer `REVIEW_SECRET`) mirror the UI for automation:
 `POST /review` (manual re-review), `POST /internal/generate`,

--- a/src/client/components/agent-form.tsx
+++ b/src/client/components/agent-form.tsx
@@ -57,6 +57,7 @@ export function AgentForm({
           readOnly={!slugEditable}
           required
           maxLength={31}
+          className="font-mono"
         />
       </Field>
       <Field label="description" hint="shown in lists">
@@ -77,7 +78,12 @@ export function AgentForm({
         />
       </Field>
       <Field label="model" hint={`any AI Gateway model id; default ${defaultModel}`}>
-        <Input value={values.model} onChange={(e) => set({ model: e.target.value })} required />
+        <Input
+          value={values.model}
+          onChange={(e) => set({ model: e.target.value })}
+          required
+          className="font-mono"
+        />
       </Field>
       {error ? <p className="mt-4 text-[0.85rem] text-danger">{error}</p> : null}
       <div className="mt-5 flex gap-2">

--- a/src/client/components/app-shell.tsx
+++ b/src/client/components/app-shell.tsx
@@ -15,7 +15,7 @@ function Logo() {
   return (
     <Link
       to="/"
-      className="flex items-baseline gap-0.5 text-base font-semibold tracking-wide text-ink"
+      className="flex items-baseline gap-0.5 font-mono text-base font-semibold tracking-wide text-ink"
     >
       turbodiff
       <span className="animate-cursor text-accent-bright" aria-hidden>
@@ -94,7 +94,7 @@ function BottomTabs() {
 function UserBlock({ login }: { login: string }) {
   return (
     <div className="flex items-center justify-between gap-2">
-      <span className="truncate text-xs text-mute">@{login}</span>
+      <span className="truncate font-mono text-xs text-mute">@{login}</span>
       <form method="post" action="/auth/logout">
         <button
           className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs text-mute hover:bg-raised hover:text-ink"

--- a/src/client/components/file-tree.tsx
+++ b/src/client/components/file-tree.tsx
@@ -154,5 +154,9 @@ export function FileTree({
     </ul>
   );
 
-  return <nav aria-label="Changed files">{renderChildren(tree, 0)}</nav>;
+  return (
+    <nav aria-label="Changed files" className="font-mono">
+      {renderChildren(tree, 0)}
+    </nav>
+  );
 }

--- a/src/client/components/reviews-table.tsx
+++ b/src/client/components/reviews-table.tsx
@@ -41,12 +41,12 @@ export function ReviewsTable({ reviews }: { reviews: ApiReview[] }) {
                   href={r.pr_url}
                   target="_blank"
                   rel="noopener"
-                  className="text-accent-bright hover:underline"
+                  className="font-mono text-accent-bright hover:underline"
                 >
                   {r.repo}#{r.pr_number}
                 </a>
               ) : (
-                <>(removed repository)#{r.pr_number}</>
+                <span className="font-mono">(removed repository)#{r.pr_number}</span>
               )}
               <div className="text-xs text-mute">
                 {r.agent_slug ?? 'review'} · {r.trigger_event}

--- a/src/client/components/section.tsx
+++ b/src/client/components/section.tsx
@@ -12,7 +12,9 @@ export function SectionHeading({
 }) {
   return (
     <div className={cn('mt-9 mb-3 flex flex-wrap items-baseline justify-between gap-2', className)}>
-      <h2 className="text-xs font-medium tracking-[0.14em] text-mute uppercase">{children}</h2>
+      <h2 className="font-mono text-xs font-medium tracking-[0.14em] text-mute uppercase">
+        {children}
+      </h2>
       {aside}
     </div>
   );

--- a/src/client/components/stat-tile.tsx
+++ b/src/client/components/stat-tile.tsx
@@ -15,7 +15,7 @@ export function StatTile({
   return (
     <Card className="animate-rise" style={{ animationDelay: `${index * 60}ms` }}>
       <div className="text-xs text-mute">{label}</div>
-      <div className="mt-0.5 text-2xl font-semibold tabular-nums">{value}</div>
+      <div className="mt-0.5 font-mono text-2xl font-semibold tabular-nums">{value}</div>
       <div className="mt-0.5 min-h-4 text-xs text-mute">{sub ?? ' '}</div>
     </Card>
   );

--- a/src/client/components/ui/pill.tsx
+++ b/src/client/components/ui/pill.tsx
@@ -5,7 +5,7 @@ import { cn } from '../../lib/utils.ts';
 // The v1 status pill, kept as the app's core status vocabulary. `running`
 // prefixes a pulsing dot.
 const pillVariants = cva(
-  'inline-flex items-center gap-1 rounded-full border px-2.5 py-px text-xs whitespace-nowrap',
+  'inline-flex items-center gap-1 rounded-full border px-2.5 py-px font-mono text-xs whitespace-nowrap',
   {
     variants: {
       tone: {

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -193,7 +193,7 @@ createRoot(document.getElementById('root')!).render(
             background: 'var(--color-surface)',
             border: '1px solid var(--color-line-2)',
             color: 'var(--color-ink)',
-            fontFamily: 'var(--font-mono)',
+            fontFamily: 'var(--font-sans)',
             fontSize: '0.8rem',
           },
         }}

--- a/src/client/pages/agents.tsx
+++ b/src/client/pages/agents.tsx
@@ -56,7 +56,7 @@ export function AgentsPage() {
                     {a.description ? (
                       <p className="mt-1 truncate text-xs text-mute">{a.description}</p>
                     ) : null}
-                    <p className="mt-0.5 text-xs text-mute/70">
+                    <p className="mt-0.5 font-mono text-xs text-mute/70">
                       {a.model.replace('cloudflare/', '')}
                     </p>
                   </div>

--- a/src/client/pages/board.tsx
+++ b/src/client/pages/board.tsx
@@ -324,7 +324,7 @@ function TaskCard({ task }: { task: ApiPlan }) {
         ) : null}
       </div>
       <div className="mt-2 flex items-center justify-between text-xs text-mute">
-        <span className="truncate">{task.repo}</span>
+        <span className="truncate font-mono">{task.repo}</span>
         <span className="shrink-0">{ago(task.created_at)}</span>
       </div>
     </Card>
@@ -344,7 +344,7 @@ function Column({
 }) {
   return (
     <section className="min-w-0">
-      <h2 className="mb-2.5 text-xs font-medium tracking-[0.14em] text-mute uppercase">
+      <h2 className="mb-2.5 font-mono text-xs font-medium tracking-[0.14em] text-mute uppercase">
         {title} <span className="ml-1 text-mute/60">{count}</span>
       </h2>
       <div className="flex flex-col gap-2.5">

--- a/src/client/pages/feature.tsx
+++ b/src/client/pages/feature.tsx
@@ -253,7 +253,7 @@ function FileSection({
           )}
           title={file.status}
         />
-        <span className="min-w-0 truncate font-medium">
+        <span className="min-w-0 truncate font-mono font-medium">
           {dir ? <span className="font-normal text-mute">{dir}</span> : null}
           {base}
         </span>
@@ -434,13 +434,13 @@ export default function FeaturePage() {
         ) : null}
       </div>
       <p className="mt-2.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-mute sm:text-[0.85rem]">
-        <span className="truncate">{data.repo}</span>
+        <span className="truncate font-mono">{data.repo}</span>
         <span>·</span>
         <a
           href={data.pr.html_url}
           target="_blank"
           rel="noopener"
-          className="text-accent-bright hover:underline"
+          className="font-mono text-accent-bright hover:underline"
         >
           PR #{data.feature.pr_number}
         </a>

--- a/src/client/pages/integrations.tsx
+++ b/src/client/pages/integrations.tsx
@@ -51,9 +51,9 @@ function TestDialog({
             <tbody>
               {result.tools.map((t) => (
                 <tr key={t}>
-                  <Td>{t}</Td>
+                  <Td className="font-mono">{t}</Td>
                   <Td>
-                    <Muted>
+                    <Muted className="font-mono">
                       mcp__{name}__{t}
                     </Muted>
                   </Td>
@@ -126,9 +126,11 @@ function IntegrationCard({ conn }: { conn: ApiIntegration }) {
           </ConfirmButton>
         </span>
       </div>
-      <div className="mt-1 text-xs break-all text-mute">{conn.url}</div>
+      <div className="mt-1 font-mono text-xs break-all text-mute">{conn.url}</div>
       {conn.tools ? (
-        <div className="mt-1 text-xs text-mute">tools: {conn.tools.join(', ')}</div>
+        <div className="mt-1 text-xs text-mute">
+          tools: <span className="font-mono">{conn.tools.join(', ')}</span>
+        </div>
       ) : null}
       {conn.kind === 'mcp' ? (
         <div className="mt-3 flex flex-wrap items-center gap-1.5">

--- a/src/client/pages/settings.tsx
+++ b/src/client/pages/settings.tsx
@@ -88,7 +88,7 @@ function CheckCommandForm({ repo }: { repo: ApiRepoSettings }) {
         value={command}
         onChange={(e) => setCommand(e.target.value)}
         placeholder="check command (e.g. npm ci && npm test) — blocks factory pushes on failure"
-        className="py-1 text-xs"
+        className="py-1 font-mono text-xs"
       />
       <Button size="sm" variant="secondary" type="submit" loading={patchRepo.isPending}>
         save
@@ -131,7 +131,10 @@ function RepoRow({ repo }: { repo: ApiRepoSettings }) {
   return (
     <Card className="mt-2">
       <div className="flex items-center justify-between gap-3">
-        <span className="min-w-0 truncate font-medium" title={`${repo.owner}/${repo.name}`}>
+        <span
+          className="min-w-0 truncate font-mono font-medium"
+          title={`${repo.owner}/${repo.name}`}
+        >
           {repo.owner}/{repo.name}
         </span>
         <label className="flex shrink-0 cursor-pointer items-center gap-2 text-xs text-mute">

--- a/src/client/pages/task.tsx
+++ b/src/client/pages/task.tsx
@@ -164,7 +164,7 @@ export function TaskPage() {
         {task.archived ? <Pill>archived</Pill> : null}
       </div>
       <p className="mt-2.5 text-xs text-mute sm:text-[0.85rem]">
-        {task.repo} · {ago(task.created_at)}
+        <span className="font-mono">{task.repo}</span> · {ago(task.created_at)}
       </p>
       {task.attachments.length > 0 ? (
         <div className="mt-2 flex flex-wrap gap-1.5">

--- a/src/client/pages/usage.tsx
+++ b/src/client/pages/usage.tsx
@@ -162,7 +162,10 @@ export function UsagePage() {
             {data.recent_repos.map((r) => (
               <tr key={r.id}>
                 <Td>
-                  {r.owner}/{r.name} {r.suspended ? <Pill tone="red">suspended</Pill> : null}
+                  <span className="font-mono">
+                    {r.owner}/{r.name}
+                  </span>{' '}
+                  {r.suspended ? <Pill tone="red">suspended</Pill> : null}
                 </Td>
                 <Td>{r.enabled ? <Pill tone="on">on</Pill> : <Pill>off</Pill>}</Td>
                 <Td numeric>{r.reviews > 0 ? r.reviews : <Muted>0</Muted>}</Td>

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -1,9 +1,10 @@
 @import 'tailwindcss';
 
 /* Turbodiff's terminal identity as Tailwind v4 theme tokens: phosphor green
-   on near-black, IBM Plex Mono everywhere (loaded in the shell). */
+   on near-black. IBM Plex Sans for reading text, IBM Plex Mono for code,
+   identifiers, and terminal chrome (both loaded in the shell). */
 @theme {
-  --font-sans: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-sans: 'IBM Plex Sans', system-ui, -apple-system, 'Segoe UI', sans-serif;
   --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 
   --color-bg: #070b09;
@@ -27,7 +28,7 @@
     color-scheme: dark;
   }
   body {
-    @apply bg-bg font-mono text-sm text-ink antialiased;
+    @apply bg-bg font-sans text-sm text-ink antialiased;
   }
   ::selection {
     background: color-mix(in srgb, var(--color-accent) 35%, transparent);
@@ -98,4 +99,5 @@
   border-radius: 8px;
   overflow: hidden;
   background: var(--color-surface);
+  font-family: var(--font-mono);
 }

--- a/src/routes/landing.tsx
+++ b/src/routes/landing.tsx
@@ -4,8 +4,8 @@
 // The Three.js scene occupies only the right half of desktop viewports (hidden
 // on narrow screens) so it never overlaps the hero copy. It is a floating 3D
 // terminal: a glossy black slab whose screen is a live CanvasTexture where a
-// Turbodiff review session types itself out on loop — prompt, diff hunk,
-// "review posted" — over a scrolling wireframe grid floor. Black, white and
+// Turbodiff factory run types itself out on loop — plan, generate, review,
+// fix, verify, PR — over a scrolling wireframe grid floor. Black, white and
 // the brand greens only.
 //
 // CSS and the client script are kept as plain strings injected with
@@ -23,13 +23,14 @@ const CSS = `
 		--green-bright: #56d364;
 		--red: #f85149;
 		--line: #1c2620;
+		--mono: "IBM Plex Mono", ui-monospace, monospace;
 	}
 	* { box-sizing: border-box; margin: 0; }
 	html, body { height: 100%; }
 	body {
 		background: var(--bg);
 		color: var(--ink);
-		font: 400 15px/1.6 "IBM Plex Mono", ui-monospace, monospace;
+		font: 400 15px/1.6 "IBM Plex Sans", system-ui, sans-serif;
 		overflow: hidden;
 	}
 	/* --- background layers --- */
@@ -66,11 +67,13 @@ const CSS = `
 		mix-blend-mode: screen;
 	}
 	.wordmark {
+		font-family: var(--mono);
 		font-size: 0.95rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink);
 	}
 	.wordmark b { color: var(--green-bright); font-weight: 500; }
 	.nav { display: flex; align-items: center; gap: 1.6rem; }
 	.nav a {
+		font-family: var(--mono);
 		color: var(--muted); text-decoration: none; font-size: 0.85rem;
 		border-bottom: 1px solid transparent; transition: color 0.2s, border-color 0.2s;
 	}
@@ -113,10 +116,12 @@ const CSS = `
 	.cta-ghost:hover { transform: translateY(-2px); border-color: rgba(63, 185, 80, 0.6); background: #0d1310; }
 	.cta svg, .cta-ghost svg { width: 1.1em; height: 1.1em; fill: currentColor; }
 	.cta-note {
+		font-family: var(--mono);
 		display: block; margin-top: 0.9rem; color: var(--muted); font-size: 0.8rem;
 		animation: rise 0.7s 0.38s cubic-bezier(0.2, 0.7, 0.2, 1) both;
 	}
 	footer {
+		font-family: var(--mono);
 		display: flex; gap: 2rem; flex-wrap: wrap;
 		color: var(--muted); font-size: 0.78rem; letter-spacing: 0.06em;
 		border-top: 1px solid var(--line); padding-top: 1.1rem;
@@ -183,7 +188,7 @@ if (renderer) {
 
 	// ---------------------------------------------------------------
 	// The terminal screen: a 2D canvas re-drawn every frame and used
-	// as a texture. A review session types itself out on loop.
+	// as a texture. A factory run types itself out on loop.
 	// ---------------------------------------------------------------
 	const TW = 1024, TH = 800;
 	const tcv = document.createElement('canvas');
@@ -197,19 +202,19 @@ if (renderer) {
 	const DIM = 'rgba(230, 239, 233, 0.45)';
 	// [text, color, ms-per-char, ms-pause-before-line]
 	const SCRIPT = [
-		['$ turbodiff review #128', BRIGHT, 34, 500],
+		['$ turbodiff build "session expiry"', BRIGHT, 34, 500],
 		['', INK, 0, 120],
-		['\\u203a fetching diff\\u2026  4 files, +182 \\u221247', DIM, 10, 420],
-		['\\u203a reading src/lib/session.ts', DIM, 10, 260],
+		['\\u203a planning against your code\\u2026', DIM, 10, 420],
+		['\\u2713 plan approved \\u2014 4 files, 2 criteria', BRIGHT, 12, 300],
 		['', INK, 0, 160],
-		['@@ \\u221240,3 +40,6 @@', DIM, 12, 300],
+		['\\u203a generating in sandbox\\u2026', DIM, 10, 300],
 		['+ const s = await unseal(token)', GREEN, 16, 180],
 		['+ if (s.exp < now()) return null', GREEN, 16, 90],
-		['+ return s', GREEN, 16, 90],
 		['', INK, 0, 200],
-		['\\u203a posting review\\u2026', DIM, 10, 500],
-		['\\u2713 2 inline comments anchored', BRIGHT, 12, 420],
-		['\\u2713 review posted in 38s', BRIGHT, 12, 200],
+		['\\u203a review: 1 finding \\u2192 auto-fixed', DIM, 10, 500],
+		['\\u203a verifying\\u2026 app launched, screenshots', DIM, 10, 420],
+		['\\u2713 2/2 criteria met', BRIGHT, 12, 420],
+		['\\u2713 PR ready to merge', BRIGHT, 12, 200],
 	];
 
 	let li = 0, ci = 0, nextAt = 0, phase = 'type', phaseAt = 0, wipe = 0, lastTypeAt = -1e9;
@@ -256,7 +261,7 @@ if (renderer) {
 		dot(118, null, 'rgba(63, 185, 80, 0.55)');
 		tctx.font = '400 23px "IBM Plex Mono", ui-monospace, monospace';
 		tctx.fillStyle = DIM;
-		tctx.fillText('turbodiff@edge \\u2014 pr #128', 156, CHROME / 2 + 8);
+		tctx.fillText('turbodiff@edge \\u2014 factory run', 156, CHROME / 2 + 8);
 		tctx.fillStyle = 'rgba(63, 185, 80, 0.3)';
 		tctx.fillRect(0, CHROME, TW, 2);
 
@@ -456,16 +461,16 @@ function Landing({ appSlug }: { appSlug: string }) {
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Turbodiff — open-source AI code review for every pull request</title>
+        <title>Turbodiff — the open-source software factory</title>
         <meta
           name="description"
-          content="Open-source AI code review for teams that ship constantly. Turbodiff reviews every pull request with inline comments as it opens. Fully built and hosted on Cloudflare Workers, and self-hostable."
+          content="Turbodiff turns free-form requirements into verified pull requests: agents plan against your real code, generate the change in a sandbox, review it, fix blocking findings, and post screenshot evidence for every acceptance criterion. Open source, self-hostable, built on Cloudflare."
         />
         <link rel="icon" type="image/png" href="/logo-small.png" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=IBM+Plex+Mono:wght@400;500&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=IBM+Plex+Sans:wght@400;500&family=IBM+Plex+Mono:wght@400;500&display=swap"
           rel="stylesheet"
         />
         <style dangerouslySetInnerHTML={{ __html: CSS }} />
@@ -492,12 +497,13 @@ function Landing({ appSlug }: { appSlug: string }) {
           <main>
             <div class="hero">
               <h1>
-                Every diff, <em>reviewed</em> in seconds.
+                Requirements in. <em>Verified</em> pull requests out.
               </h1>
               <p class="sub">
-                Ship more code than you can review? Let Turbodiff handle the review queue. Using
-                state of the art AI models, you can review code faster than ever before. Open
-                source, self-hostable &amp; built on Cloudflare.
+                Describe a feature and the factory takes over: agents plan it against your real
+                code, build it in a sandbox, review the PR, fix what's blocking, and post screenshot
+                proof for every acceptance criterion. You approve the plan and merge. Open source,
+                self-hostable &amp; built on Cloudflare.
               </p>
               <div class="cta-row">
                 <a class="cta" href={installUrl}>
@@ -509,7 +515,7 @@ function Landing({ appSlug }: { appSlug: string }) {
                   Star on GitHub
                 </a>
               </div>
-              <span class="cta-note">free &middot; MIT-licensed &middot; yours to run</span>
+              <span class="cta-note">free &middot; FSL-licensed &middot; yours to run</span>
             </div>
           </main>
 

--- a/src/routes/ui.ts
+++ b/src/routes/ui.ts
@@ -32,7 +32,7 @@ const SHELL = `<!doctype html>
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link
-			href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap"
+			href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap"
 			rel="stylesheet"
 		/>
 		<link rel="stylesheet" href="/app/app.css" />


### PR DESCRIPTION
## What

Two changes, per the updated project vision (automating ~90% of software creation, not just code review):

### Copy — factory-first positioning
- **Landing page**: headline is now "Requirements in. *Verified* pull requests out." with a subhead walking the pipeline (plan → generate → review → fix → verify). Title tag and meta description updated to match.
- **Hero terminal**: the 3D terminal now types out a condensed factory run (plan approval, sandbox generation, auto-fixed review finding, verification with screenshots, PR ready) instead of a review session.
- **Fixed an inaccuracy**: the CTA note claimed "MIT-licensed" — the repo is FSL-1.1-ALv2, so it now says FSL.
- **README**: reframed intro around the factory vision with review as the standalone-capable stage it started as; swapped the "What's inside" order (Factory first); updated the stale "Use it" steps to the actual routes (board at `/`, reviews on `/usage` — `/factory` and `/reviews` no longer exist).

### Fonts — IBM Plex Sans for reading text
IBM Plex Mono everywhere read poorly in paragraphs. Now:
- **Sans (new)**: body text, paragraphs, forms, buttons, toasts — on both the landing page and the signed-in app (`--font-sans` is now IBM Plex Sans; body switched from `font-mono` to `font-sans`).
- **Mono (kept)**: diff surfaces (explicit `font-family` on `.diffs-scope` plus Tailwind's `pre`/`code` preflight), the wordmark, section labels, pills, stat values, and identifier-shaped content (repo names, PR numbers, file paths, check commands, agent slugs, model ids).

Plex Sans keeps the existing terminal aesthetic coherent as a sibling of Plex Mono.

## Verification
- `vp check` passes formatting; `vp lint` error/warning counts identical to main (all findings pre-existing).
- `vp test`: 10/10 pass.
- Client bundle builds; compiled CSS contains the Plex Sans token and the mono diff-scope rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)