### PR TITLE
Deploy to production on every push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+# Production deploy: every push to main applies D1 migrations and runs the
+# same `vp run deploy` used locally (Worker + sandbox container image; the
+# runner's Docker daemon does the image build).
+#
+# Requires two repository secrets:
+#   CLOUDFLARE_API_TOKEN   — Workers Scripts:Edit, D1:Edit, Containers:Edit
+#   CLOUDFLARE_ACCOUNT_ID
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+# Queue deploys instead of interleaving them; never cancel one mid-flight.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.20.0
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Apply D1 migrations
+        run: pnpm wrangler d1 migrations apply turbodiff --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy
+        run: pnpm vp run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -170,12 +170,17 @@ body in `x-hub-signature-256: sha256=<hex>`).
 
 ## Deploy
 
-```sh
-npm run deploy
-```
+Every commit to `main` deploys automatically via
+[GitHub Actions](.github/workflows/deploy.yml): D1 migrations are applied
+`--remote`, then the Worker and sandbox container image are built and pushed.
+The workflow needs two repository secrets, `CLOUDFLARE_API_TOKEN` (Workers
+Scripts:Edit, D1:Edit, Containers:Edit) and `CLOUDFLARE_ACCOUNT_ID`.
 
-This builds the Worker and the sandbox container image (Docker required) and
-pushes both.
+To deploy manually (Docker required):
+
+```sh
+pnpm vp run deploy
+```
 
 ## Use it
 


### PR DESCRIPTION
## What

Adds `.github/workflows/deploy.yml` — the simple migrate-and-deploy pipeline:

1. `pnpm install --frozen-lockfile` (pnpm pinned to 11.20.0, node from `.node-version`)
2. `pnpm wrangler d1 migrations apply turbodiff --remote`
3. `pnpm vp run deploy` — identical to the local command; the GitHub runner's Docker daemon builds the sandbox container image, so no changes to the deploy setup were needed

Deploys queue behind each other (`concurrency` group, no cancellation), with a 30-minute timeout. The README's Deploy section now documents this and drops the stale `npm run deploy` (removed in the vp migration) in favor of `pnpm vp run deploy`.

## Before merging

Add two repository secrets (Settings → Secrets and variables → Actions):

- `CLOUDFLARE_API_TOKEN` — API token with **Workers Scripts:Edit**, **D1:Edit**, and **Containers:Edit** on the account
- `CLOUDFLARE_ACCOUNT_ID`

The workflow only triggers on pushes to `main`, so merging this PR is what runs it for the first time.

## Verification

- `pnpm install --frozen-lockfile` verified clean with pnpm 11.20.0 (the system pnpm 10 can't parse the v11 lockfile in frozen mode — hence the pinned version in the workflow).
- `vp run build` (the deploy task's build half) passes locally.
- Workflow YAML validated; `vp check` findings identical to the main baseline.
- The deploy step itself can't be tested until the secrets exist — expect the first run to be the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)