### PR TITLE
Fix sign-in loop: persist login/githubId from GitHub profile

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -149,6 +149,13 @@ app.route('/webhooks', createWebhookRoutes(dispatchReviewAgent));
 
 // better-auth (sessions, OAuth callback, sign-out). Registered before the
 // /api data plane so it owns the /api/auth prefix.
+//
+// /update-user is closed: it's the only better-auth route that accepts user
+// additionalFields as client input, and login/githubId can't be input:false
+// (better-auth would strip them from the OAuth profile mapping — see
+// better-auth.ts). Nothing in the app updates users; GitHub is the source
+// of truth via overrideUserInfoOnSignIn.
+app.on(['GET', 'POST'], '/api/auth/update-user', (c) => c.json({ error: 'not found' }, 404));
 app.on(['GET', 'POST'], '/api/auth/*', (c) => auth().handler(c.req.raw));
 
 // SPA data plane (session cookie auth, JSON in/out).

--- a/src/lib/better-auth.ts
+++ b/src/lib/better-auth.ts
@@ -21,6 +21,15 @@ import { betterAuth } from 'better-auth';
 //     Email addresses permission; mapProfileToUser falls back to the noreply
 //     address so sign-in never depends on it. login/githubId are the fields
 //     the rest of the app actually keys on (attribution, user_tokens).
+//   - login/githubId must NOT be declared with input: false: better-auth
+//     strips input:false fields from the mapProfileToUser result before
+//     creating the user (parseAdditionalUserInputFromProviderProfile), so
+//     they would never persist and requireUser would 401 every session.
+//     The fields stay server-owned anyway — app.ts closes /update-user, the
+//     only route that accepts user additional fields as client input, and
+//     overrideUserInfoOnSignIn rewrites them from the GitHub profile on
+//     every sign-in (which also repairs rows created while the bug shipped,
+//     and tracks GitHub username renames).
 
 const SESSION_DAYS = 30;
 
@@ -47,6 +56,7 @@ function createAuth() {
         clientId: env.GITHUB_OAUTH_CLIENT_ID,
         clientSecret: env.GITHUB_OAUTH_CLIENT_SECRET,
         redirectURI: `${env.PUBLIC_BASE_URL}/auth/callback`,
+        overrideUserInfoOnSignIn: true,
         mapProfileToUser: (profile) => ({
           login: profile.login,
           githubId: profile.id,
@@ -57,8 +67,8 @@ function createAuth() {
     },
     user: {
       additionalFields: {
-        login: { type: 'string', required: false, input: false },
-        githubId: { type: 'number', required: false, input: false },
+        login: { type: 'string', required: false },
+        githubId: { type: 'number', required: false },
       },
     },
   });


### PR DESCRIPTION
## Summary
- better-auth strips `additionalFields` declared `input:false` from `mapProfileToUser` before creating the user, so every user created since the better-auth migration has NULL `login`/`githubId`. The session loads fine, but `requireUser` treats a user missing GitHub identity fields as malformed and 401s every API call — the client then answers the 401 by restarting OAuth, producing an infinite sign-in loop.
- Drop `input:false` on `login`/`githubId` so the profile mapping actually persists them.
- Add `overrideUserInfoOnSignIn: true` so these fields are rewritten from the GitHub profile on every sign-in — this repairs rows created while the bug was live and keeps GitHub username renames in sync.
- Close `/api/auth/update-user` in `app.ts`, since allowing `login`/`githubId` as client input opens the one route where a signed-in user could spoof their own GitHub identity (used for attribution and `user_tokens` keying). GitHub remains the only writer.

## Test plan
- [x] Verified in-memory: full `signInSocial` → callback flow against a memory adapter with mocked GitHub endpoints — deployed config reproduces the NULL fields; fixed config persists them on fresh sign-up and backfills the same user row on re-sign-in without duplicating user or account.
- [ ] Confirm existing affected users self-heal on next sign-in in staging/prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)