### PR TITLE
Marketing: proof-first landing copy + real Proof of Build certificates

### DIFF
--- a/marketing/mockups/build-certificate.html
+++ b/marketing/mockups/build-certificate.html
@@ -213,11 +213,11 @@
   <div class="main">
     <header class="cert-head">
       <div class="cert-title">
-        <div class="kicker">Certificate of Build</div>
+        <div class="kicker">Proof of Build</div>
         <div class="org">issued by <b>turbodiff</b> autonomous software factory</div>
       </div>
       <div class="serial">
-        <div class="label">Unit No.</div>
+        <div class="label">Build No.</div>
         <div class="no">TD-2026-0058</div>
         <div class="barcode" aria-hidden="true"></div>
       </div>
@@ -226,13 +226,13 @@
     <section class="feature">
       <h1>OAuth flow support for MCP servers</h1>
       <p class="meta">
-        <b>Ngineer101/turbodiff</b> &middot; PR #58 &middot; merged 12 Aug 2026 &middot; shift <b>sh_9f42</b>
+        <b>Ngineer101/turbodiff</b> &middot; PR #58 &middot; merged 12 Aug 2026 &middot; run <b>#9f42</b>
       </p>
     </section>
 
     <section class="criteria">
       <div class="head">
-        <span>Acceptance criteria — inspected</span>
+        <span>Acceptance criteria — verified</span>
         <span class="score">9 / 9 passed</span>
       </div>
       <ul>
@@ -246,7 +246,7 @@
     </section>
 
     <section class="captures">
-      <div class="head">QC captures — 14 attached</div>
+      <div class="head">Screenshot proof — 14 attached</div>
       <div class="thumbs">
         <figure class="thumb"><figcaption>ac-01 · connect</figcaption></figure>
         <figure class="thumb"><figcaption>ac-03 · callback</figcaption></figure>
@@ -258,23 +258,23 @@
 
     <footer class="cert-foot">
       <span class="tagline">Anyone can generate code. We ship proof.</span>
-      <span class="verify">verify this unit &rarr; <b>turbodiff.dev/u/TD-2026-0058</b></span>
+      <span class="verify">see the receipts &rarr; <b>turbodiff.dev/b/TD-2026-0058</b></span>
     </footer>
   </div>
 
   <aside class="stub">
     <span class="punch" aria-hidden="true"></span>
-    <div class="head">Inspection stub</div>
+    <div class="head">Build stats</div>
     <div class="gauges">
-      <div class="gauge"><b>38 min</b><span>factory time</span></div>
+      <div class="gauge"><b>38 min</b><span>agent time</span></div>
       <div class="gauge human"><b>4 min</b><span>human time</span></div>
-      <div class="gauge"><b>2</b><span>rework passes</span></div>
-      <div class="gauge"><b>14</b><span>qc captures</span></div>
+      <div class="gauge"><b>2</b><span>fix iterations</span></div>
+      <div class="gauge"><b>14</b><span>screenshots</span></div>
     </div>
     <div class="stamp-zone">
       <div class="stamp">
-        <div class="big">Passed QC</div>
-        <div class="sub">Turbodiff factory</div>
+        <div class="big">Verified</div>
+        <div class="sub">All checks passed</div>
         <div class="date">12 · 08 · 2026</div>
       </div>
     </div>

--- a/marketing/mockups/build-certificate.html
+++ b/marketing/mockups/build-certificate.html
@@ -1,0 +1,289 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Turbodiff — Certificate of Build (mockup)</title>
+<!--
+  Design mockup for the shareable "Build Certificate" — the OG-card-shaped
+  artifact every shipped unit gets. Manufacturing QC-tag aesthetic: paper
+  stub on the brand's grainy dark floor, green ink, rubber stamp, serial
+  number, perforated inspection stub. Not wired into the app.
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=IBM+Plex+Sans:wght@400;500&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --floor: #15171c;
+    --paper: #ece7da;
+    --paper-edge: #dcd6c6;
+    --ink: #242a32;
+    --ink-soft: #5c6470;
+    --green-ink: #1f7a33;
+    --green-bright: #2f9e44;
+    --red-ink: #b8362c;
+    --mono: "IBM Plex Mono", ui-monospace, monospace;
+    --serif: "Instrument Serif", Georgia, serif;
+  }
+  * { box-sizing: border-box; margin: 0; }
+  body {
+    min-height: 100vh;
+    background: var(--floor);
+    display: grid; place-items: center;
+    padding: 3rem 1.5rem;
+    font: 400 15px/1.5 "IBM Plex Sans", system-ui, sans-serif;
+    color: var(--ink);
+  }
+  .grain {
+    position: fixed; inset: 0; pointer-events: none; opacity: 0.9; mix-blend-mode: overlay;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3'/%3E%3CfeColorMatrix values='0 0 0 0 0.5 0 0 0 0 0.52 0 0 0 0 0.56 0 0 0 0.3 0'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)'/%3E%3C/svg%3E");
+  }
+
+  /* ---- the certificate ---- */
+  .cert {
+    position: relative;
+    width: min(1080px, 96vw);
+    display: grid;
+    grid-template-columns: 1fr 280px;
+    background:
+      radial-gradient(120% 90% at 30% 0%, rgba(255,255,255,0.5), transparent 60%),
+      var(--paper);
+    border-radius: 6px;
+    box-shadow:
+      0 1px 0 rgba(255,255,255,0.06),
+      0 30px 80px rgba(0,0,0,0.55),
+      0 6px 18px rgba(0,0,0,0.4);
+    transform: rotate(-0.4deg);
+  }
+  .cert::after { /* paper grain */
+    content: ""; position: absolute; inset: 0; border-radius: 6px; pointer-events: none;
+    opacity: 0.5; mix-blend-mode: multiply;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='p'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3CfeColorMatrix values='0 0 0 0 0.72 0 0 0 0 0.7 0 0 0 0 0.64 0 0 0 0.16 0'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23p)'/%3E%3C/svg%3E");
+  }
+
+  .main { padding: 2.2rem 2.4rem 1.9rem; min-width: 0; }
+
+  .cert-head {
+    display: flex; justify-content: space-between; align-items: flex-start; gap: 1.5rem;
+    padding-bottom: 1.1rem; border-bottom: 2px solid var(--ink);
+  }
+  .cert-title { font-family: var(--mono); }
+  .cert-title .kicker {
+    font-size: 0.7rem; letter-spacing: 0.32em; text-transform: uppercase; color: var(--ink);
+    font-weight: 600;
+  }
+  .cert-title .org {
+    margin-top: 0.35rem; font-size: 0.72rem; letter-spacing: 0.08em; color: var(--ink-soft);
+  }
+  .cert-title .org b { color: var(--green-ink); font-weight: 600; }
+  .serial { text-align: right; font-family: var(--mono); }
+  .serial .label { font-size: 0.62rem; letter-spacing: 0.24em; color: var(--ink-soft); text-transform: uppercase; }
+  .serial .no { font-size: 1.5rem; font-weight: 600; letter-spacing: 0.06em; margin-top: 0.1rem; }
+  .barcode {
+    margin-top: 0.4rem; height: 26px; width: 190px; margin-left: auto;
+    background: repeating-linear-gradient(90deg,
+      var(--ink) 0 2px, transparent 2px 4px, var(--ink) 4px 7px, transparent 7px 9px,
+      var(--ink) 9px 10px, transparent 10px 14px, var(--ink) 14px 18px, transparent 18px 20px);
+  }
+
+  .feature { margin-top: 1.5rem; }
+  .feature h1 {
+    font-family: var(--serif); font-weight: 400;
+    font-size: clamp(1.7rem, 3.4vw, 2.5rem); line-height: 1.08; letter-spacing: -0.01em;
+  }
+  .feature .meta {
+    margin-top: 0.55rem; font-family: var(--mono); font-size: 0.76rem;
+    color: var(--ink-soft); letter-spacing: 0.04em;
+  }
+  .feature .meta b { color: var(--ink); font-weight: 500; }
+
+  .criteria { margin-top: 1.4rem; }
+  .criteria .head {
+    display: flex; justify-content: space-between; align-items: baseline;
+    font-family: var(--mono); font-size: 0.66rem; letter-spacing: 0.22em;
+    text-transform: uppercase; color: var(--ink-soft); margin-bottom: 0.6rem;
+  }
+  .criteria .head .score { color: var(--green-ink); font-weight: 600; letter-spacing: 0.1em; }
+  .criteria ul { list-style: none; padding: 0; columns: 2; column-gap: 2.2rem; }
+  .criteria li {
+    break-inside: avoid; display: flex; gap: 0.55rem; align-items: baseline;
+    font-size: 0.83rem; line-height: 1.4; padding: 0.28rem 0;
+    border-bottom: 1px dotted rgba(36, 42, 50, 0.35);
+  }
+  .criteria li::before {
+    content: "✓"; font-family: var(--mono); font-weight: 600; color: var(--green-ink);
+    flex: none;
+  }
+
+  .captures { margin-top: 1.4rem; }
+  .captures .head {
+    font-family: var(--mono); font-size: 0.66rem; letter-spacing: 0.22em;
+    text-transform: uppercase; color: var(--ink-soft); margin-bottom: 0.55rem;
+  }
+  .thumbs { display: flex; gap: 0.6rem; }
+  .thumb {
+    flex: 1; aspect-ratio: 16 / 10; border: 1px solid rgba(36,42,50,0.5); border-radius: 3px;
+    position: relative; overflow: hidden;
+    background:
+      linear-gradient(160deg, #1b1e24 0%, #23272f 55%, #1b1e24 100%);
+  }
+  .thumb::before { /* fake ui bars */
+    content: ""; position: absolute; inset: 12% 10% auto 10%; height: 8%;
+    background: rgba(232, 234, 238, 0.25); border-radius: 2px;
+    box-shadow: 0 14px 0 rgba(232,234,238,0.14), 0 28px 0 rgba(232,234,238,0.14), 0 42px 0 rgba(63,185,80,0.5);
+  }
+  .thumb figcaption {
+    position: absolute; left: 0; right: 0; bottom: 0;
+    font-family: var(--mono); font-size: 0.52rem; letter-spacing: 0.12em; text-transform: uppercase;
+    color: #9aa2ad; background: rgba(12, 14, 17, 0.75); padding: 0.2rem 0.4rem;
+  }
+
+  .cert-foot {
+    margin-top: 1.6rem; padding-top: 0.9rem; border-top: 2px solid var(--ink);
+    display: flex; justify-content: space-between; align-items: baseline; gap: 1rem;
+    font-family: var(--mono); font-size: 0.72rem; color: var(--ink-soft); letter-spacing: 0.05em;
+  }
+  .cert-foot .tagline { font-family: var(--serif); font-style: italic; font-size: 1.02rem; color: var(--ink); letter-spacing: 0; }
+  .cert-foot .verify b { color: var(--green-ink); font-weight: 600; }
+
+  /* ---- inspection stub ---- */
+  .stub {
+    position: relative;
+    border-left: 2px dashed rgba(36, 42, 50, 0.5);
+    padding: 2rem 1.6rem 1.9rem;
+    display: flex; flex-direction: column;
+    background: linear-gradient(180deg, rgba(31, 122, 51, 0.06), transparent 40%);
+  }
+  .stub::before, .stub::after { /* perforation notches */
+    content: ""; position: absolute; left: -13px; width: 24px; height: 24px; border-radius: 50%;
+    background: var(--floor);
+  }
+  .stub::before { top: -12px; }
+  .stub::after { bottom: -12px; }
+  .punch {
+    position: absolute; top: 1.35rem; right: 1.35rem; width: 22px; height: 22px; border-radius: 50%;
+    background: var(--floor);
+    box-shadow: inset 0 1px 2px rgba(0,0,0,0.7), 0 1px 0 rgba(255,255,255,0.5);
+  }
+  .stub .head {
+    font-family: var(--mono); font-size: 0.62rem; letter-spacing: 0.28em;
+    text-transform: uppercase; color: var(--ink-soft);
+  }
+  .gauges { margin-top: 1.1rem; display: grid; gap: 0.85rem; }
+  .gauge { font-family: var(--mono); border-left: 3px solid var(--green-ink); padding-left: 0.7rem; }
+  .gauge b { display: block; font-size: 1.25rem; font-weight: 600; letter-spacing: 0.02em; }
+  .gauge span { font-size: 0.6rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-soft); }
+  .gauge.human { border-left-color: var(--red-ink); }
+  .gauge.human b { color: var(--red-ink); }
+
+  .stamp-zone { margin-top: auto; padding-top: 1.4rem; display: grid; place-items: center; }
+  .stamp {
+    --sink: var(--green-bright);
+    transform: rotate(-8deg);
+    border: 3px double var(--sink); border-radius: 10px;
+    padding: 0.55rem 1.1rem 0.65rem; text-align: center;
+    color: var(--sink);
+    font-family: var(--mono); text-transform: uppercase;
+    mix-blend-mode: multiply; opacity: 0.9;
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='r'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.11' numOctaves='3'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.92 0.05'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23r)'/%3E%3C/svg%3E");
+    mask-size: 120px;
+  }
+  .stamp .big { font-size: 1.55rem; font-weight: 600; letter-spacing: 0.14em; line-height: 1.1; }
+  .stamp .sub { font-size: 0.58rem; letter-spacing: 0.3em; margin-top: 0.25rem; }
+  .stamp .date { font-size: 0.66rem; letter-spacing: 0.14em; margin-top: 0.35rem; border-top: 1px solid var(--sink); padding-top: 0.3rem; }
+
+  .stub .sig { margin-top: 1.3rem; font-family: var(--mono); font-size: 0.6rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-soft); }
+  .stub .sig .line { font-family: var(--serif); font-style: italic; font-size: 1.05rem; color: var(--ink); text-transform: none; letter-spacing: 0; border-bottom: 1px solid var(--ink); padding-bottom: 0.15rem; margin-bottom: 0.3rem; }
+
+  @media (max-width: 860px) {
+    .cert { grid-template-columns: 1fr; transform: none; }
+    .stub { border-left: 0; border-top: 2px dashed rgba(36,42,50,0.5); }
+    .stub::before { top: -12px; left: -12px; }
+    .stub::after { top: -12px; left: auto; right: -12px; bottom: auto; }
+    .criteria ul { columns: 1; }
+    .thumbs .thumb:nth-child(n+4) { display: none; }
+  }
+</style>
+</head>
+<body>
+<div class="grain" aria-hidden="true"></div>
+
+<article class="cert">
+  <div class="main">
+    <header class="cert-head">
+      <div class="cert-title">
+        <div class="kicker">Certificate of Build</div>
+        <div class="org">issued by <b>turbodiff</b> autonomous software factory</div>
+      </div>
+      <div class="serial">
+        <div class="label">Unit No.</div>
+        <div class="no">TD-2026-0058</div>
+        <div class="barcode" aria-hidden="true"></div>
+      </div>
+    </header>
+
+    <section class="feature">
+      <h1>OAuth flow support for MCP servers</h1>
+      <p class="meta">
+        <b>Ngineer101/turbodiff</b> &middot; PR #58 &middot; merged 12 Aug 2026 &middot; shift <b>sh_9f42</b>
+      </p>
+    </section>
+
+    <section class="criteria">
+      <div class="head">
+        <span>Acceptance criteria — inspected</span>
+        <span class="score">9 / 9 passed</span>
+      </div>
+      <ul>
+        <li>Connect button starts the OAuth handshake</li>
+        <li>Callback exchanges code for tokens</li>
+        <li>Tokens stored encrypted per user</li>
+        <li>Expired tokens refresh silently</li>
+        <li>Failed auth shows a recoverable error</li>
+        <li>Server list reflects connection state</li>
+      </ul>
+    </section>
+
+    <section class="captures">
+      <div class="head">QC captures — 14 attached</div>
+      <div class="thumbs">
+        <figure class="thumb"><figcaption>ac-01 · connect</figcaption></figure>
+        <figure class="thumb"><figcaption>ac-03 · callback</figcaption></figure>
+        <figure class="thumb"><figcaption>ac-05 · error state</figcaption></figure>
+        <figure class="thumb"><figcaption>ac-08 · refresh</figcaption></figure>
+        <figure class="thumb"><figcaption>ac-09 · server list</figcaption></figure>
+      </div>
+    </section>
+
+    <footer class="cert-foot">
+      <span class="tagline">Anyone can generate code. We ship proof.</span>
+      <span class="verify">verify this unit &rarr; <b>turbodiff.dev/u/TD-2026-0058</b></span>
+    </footer>
+  </div>
+
+  <aside class="stub">
+    <span class="punch" aria-hidden="true"></span>
+    <div class="head">Inspection stub</div>
+    <div class="gauges">
+      <div class="gauge"><b>38 min</b><span>factory time</span></div>
+      <div class="gauge human"><b>4 min</b><span>human time</span></div>
+      <div class="gauge"><b>2</b><span>rework passes</span></div>
+      <div class="gauge"><b>14</b><span>qc captures</span></div>
+    </div>
+    <div class="stamp-zone">
+      <div class="stamp">
+        <div class="big">Passed QC</div>
+        <div class="sub">Turbodiff factory</div>
+        <div class="date">12 · 08 · 2026</div>
+      </div>
+    </div>
+    <div class="sig">
+      <div class="line">Nico Botha</div>
+      approved &amp; merged by
+    </div>
+  </aside>
+</article>
+
+</body>
+</html>

--- a/marketing/mockups/build-certificate.html
+++ b/marketing/mockups/build-certificate.html
@@ -1,289 +1,535 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Turbodiff — Certificate of Build (mockup)</title>
-<!--
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Turbodiff — Certificate of Build (mockup)</title>
+    <!--
   Design mockup for the shareable "Build Certificate" — the OG-card-shaped
   artifact every shipped unit gets. Manufacturing QC-tag aesthetic: paper
   stub on the brand's grainy dark floor, green ink, rubber stamp, serial
   number, perforated inspection stub. Not wired into the app.
 -->
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=IBM+Plex+Sans:wght@400;500&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
-<style>
-  :root {
-    --floor: #15171c;
-    --paper: #ece7da;
-    --paper-edge: #dcd6c6;
-    --ink: #242a32;
-    --ink-soft: #5c6470;
-    --green-ink: #1f7a33;
-    --green-bright: #2f9e44;
-    --red-ink: #b8362c;
-    --mono: "IBM Plex Mono", ui-monospace, monospace;
-    --serif: "Instrument Serif", Georgia, serif;
-  }
-  * { box-sizing: border-box; margin: 0; }
-  body {
-    min-height: 100vh;
-    background: var(--floor);
-    display: grid; place-items: center;
-    padding: 3rem 1.5rem;
-    font: 400 15px/1.5 "IBM Plex Sans", system-ui, sans-serif;
-    color: var(--ink);
-  }
-  .grain {
-    position: fixed; inset: 0; pointer-events: none; opacity: 0.9; mix-blend-mode: overlay;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3'/%3E%3CfeColorMatrix values='0 0 0 0 0.5 0 0 0 0 0.52 0 0 0 0 0.56 0 0 0 0.3 0'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)'/%3E%3C/svg%3E");
-  }
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=IBM+Plex+Sans:wght@400;500&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --floor: #15171c;
+        --paper: #ece7da;
+        --paper-edge: #dcd6c6;
+        --ink: #242a32;
+        --ink-soft: #5c6470;
+        --green-ink: #1f7a33;
+        --green-bright: #2f9e44;
+        --red-ink: #b8362c;
+        --mono: 'IBM Plex Mono', ui-monospace, monospace;
+        --serif: 'Instrument Serif', Georgia, serif;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+      }
+      body {
+        min-height: 100vh;
+        background: var(--floor);
+        display: grid;
+        place-items: center;
+        padding: 3rem 1.5rem;
+        font:
+          400 15px/1.5 'IBM Plex Sans',
+          system-ui,
+          sans-serif;
+        color: var(--ink);
+      }
+      .grain {
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        opacity: 0.9;
+        mix-blend-mode: overlay;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3'/%3E%3CfeColorMatrix values='0 0 0 0 0.5 0 0 0 0 0.52 0 0 0 0 0.56 0 0 0 0.3 0'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)'/%3E%3C/svg%3E");
+      }
 
-  /* ---- the certificate ---- */
-  .cert {
-    position: relative;
-    width: min(1080px, 96vw);
-    display: grid;
-    grid-template-columns: 1fr 280px;
-    background:
-      radial-gradient(120% 90% at 30% 0%, rgba(255,255,255,0.5), transparent 60%),
-      var(--paper);
-    border-radius: 6px;
-    box-shadow:
-      0 1px 0 rgba(255,255,255,0.06),
-      0 30px 80px rgba(0,0,0,0.55),
-      0 6px 18px rgba(0,0,0,0.4);
-    transform: rotate(-0.4deg);
-  }
-  .cert::after { /* paper grain */
-    content: ""; position: absolute; inset: 0; border-radius: 6px; pointer-events: none;
-    opacity: 0.5; mix-blend-mode: multiply;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='p'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3CfeColorMatrix values='0 0 0 0 0.72 0 0 0 0 0.7 0 0 0 0 0.64 0 0 0 0.16 0'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23p)'/%3E%3C/svg%3E");
-  }
+      /* ---- the certificate ---- */
+      .cert {
+        position: relative;
+        width: min(1080px, 96vw);
+        display: grid;
+        grid-template-columns: 1fr 280px;
+        background:
+          radial-gradient(120% 90% at 30% 0%, rgba(255, 255, 255, 0.5), transparent 60%),
+          var(--paper);
+        border-radius: 6px;
+        box-shadow:
+          0 1px 0 rgba(255, 255, 255, 0.06),
+          0 30px 80px rgba(0, 0, 0, 0.55),
+          0 6px 18px rgba(0, 0, 0, 0.4);
+        transform: rotate(-0.4deg);
+      }
+      .cert::after {
+        /* paper grain */
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-radius: 6px;
+        pointer-events: none;
+        opacity: 0.5;
+        mix-blend-mode: multiply;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='p'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3CfeColorMatrix values='0 0 0 0 0.72 0 0 0 0 0.7 0 0 0 0 0.64 0 0 0 0.16 0'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23p)'/%3E%3C/svg%3E");
+      }
 
-  .main { padding: 2.2rem 2.4rem 1.9rem; min-width: 0; }
+      .main {
+        padding: 2.2rem 2.4rem 1.9rem;
+        min-width: 0;
+      }
 
-  .cert-head {
-    display: flex; justify-content: space-between; align-items: flex-start; gap: 1.5rem;
-    padding-bottom: 1.1rem; border-bottom: 2px solid var(--ink);
-  }
-  .cert-title { font-family: var(--mono); }
-  .cert-title .kicker {
-    font-size: 0.7rem; letter-spacing: 0.32em; text-transform: uppercase; color: var(--ink);
-    font-weight: 600;
-  }
-  .cert-title .org {
-    margin-top: 0.35rem; font-size: 0.72rem; letter-spacing: 0.08em; color: var(--ink-soft);
-  }
-  .cert-title .org b { color: var(--green-ink); font-weight: 600; }
-  .serial { text-align: right; font-family: var(--mono); }
-  .serial .label { font-size: 0.62rem; letter-spacing: 0.24em; color: var(--ink-soft); text-transform: uppercase; }
-  .serial .no { font-size: 1.5rem; font-weight: 600; letter-spacing: 0.06em; margin-top: 0.1rem; }
-  .barcode {
-    margin-top: 0.4rem; height: 26px; width: 190px; margin-left: auto;
-    background: repeating-linear-gradient(90deg,
-      var(--ink) 0 2px, transparent 2px 4px, var(--ink) 4px 7px, transparent 7px 9px,
-      var(--ink) 9px 10px, transparent 10px 14px, var(--ink) 14px 18px, transparent 18px 20px);
-  }
+      .cert-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 1.5rem;
+        padding-bottom: 1.1rem;
+        border-bottom: 2px solid var(--ink);
+      }
+      .cert-title {
+        font-family: var(--mono);
+      }
+      .cert-title .kicker {
+        font-size: 0.7rem;
+        letter-spacing: 0.32em;
+        text-transform: uppercase;
+        color: var(--ink);
+        font-weight: 600;
+      }
+      .cert-title .org {
+        margin-top: 0.35rem;
+        font-size: 0.72rem;
+        letter-spacing: 0.08em;
+        color: var(--ink-soft);
+      }
+      .cert-title .org b {
+        color: var(--green-ink);
+        font-weight: 600;
+      }
+      .serial {
+        text-align: right;
+        font-family: var(--mono);
+      }
+      .serial .label {
+        font-size: 0.62rem;
+        letter-spacing: 0.24em;
+        color: var(--ink-soft);
+        text-transform: uppercase;
+      }
+      .serial .no {
+        font-size: 1.5rem;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        margin-top: 0.1rem;
+      }
+      .barcode {
+        margin-top: 0.4rem;
+        height: 26px;
+        width: 190px;
+        margin-left: auto;
+        background: repeating-linear-gradient(
+          90deg,
+          var(--ink) 0 2px,
+          transparent 2px 4px,
+          var(--ink) 4px 7px,
+          transparent 7px 9px,
+          var(--ink) 9px 10px,
+          transparent 10px 14px,
+          var(--ink) 14px 18px,
+          transparent 18px 20px
+        );
+      }
 
-  .feature { margin-top: 1.5rem; }
-  .feature h1 {
-    font-family: var(--serif); font-weight: 400;
-    font-size: clamp(1.7rem, 3.4vw, 2.5rem); line-height: 1.08; letter-spacing: -0.01em;
-  }
-  .feature .meta {
-    margin-top: 0.55rem; font-family: var(--mono); font-size: 0.76rem;
-    color: var(--ink-soft); letter-spacing: 0.04em;
-  }
-  .feature .meta b { color: var(--ink); font-weight: 500; }
+      .feature {
+        margin-top: 1.5rem;
+      }
+      .feature h1 {
+        font-family: var(--serif);
+        font-weight: 400;
+        font-size: clamp(1.7rem, 3.4vw, 2.5rem);
+        line-height: 1.08;
+        letter-spacing: -0.01em;
+      }
+      .feature .meta {
+        margin-top: 0.55rem;
+        font-family: var(--mono);
+        font-size: 0.76rem;
+        color: var(--ink-soft);
+        letter-spacing: 0.04em;
+      }
+      .feature .meta b {
+        color: var(--ink);
+        font-weight: 500;
+      }
 
-  .criteria { margin-top: 1.4rem; }
-  .criteria .head {
-    display: flex; justify-content: space-between; align-items: baseline;
-    font-family: var(--mono); font-size: 0.66rem; letter-spacing: 0.22em;
-    text-transform: uppercase; color: var(--ink-soft); margin-bottom: 0.6rem;
-  }
-  .criteria .head .score { color: var(--green-ink); font-weight: 600; letter-spacing: 0.1em; }
-  .criteria ul { list-style: none; padding: 0; columns: 2; column-gap: 2.2rem; }
-  .criteria li {
-    break-inside: avoid; display: flex; gap: 0.55rem; align-items: baseline;
-    font-size: 0.83rem; line-height: 1.4; padding: 0.28rem 0;
-    border-bottom: 1px dotted rgba(36, 42, 50, 0.35);
-  }
-  .criteria li::before {
-    content: "✓"; font-family: var(--mono); font-weight: 600; color: var(--green-ink);
-    flex: none;
-  }
+      .criteria {
+        margin-top: 1.4rem;
+      }
+      .criteria .head {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        font-family: var(--mono);
+        font-size: 0.66rem;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+        margin-bottom: 0.6rem;
+      }
+      .criteria .head .score {
+        color: var(--green-ink);
+        font-weight: 600;
+        letter-spacing: 0.1em;
+      }
+      .criteria ul {
+        list-style: none;
+        padding: 0;
+        columns: 2;
+        column-gap: 2.2rem;
+      }
+      .criteria li {
+        break-inside: avoid;
+        display: flex;
+        gap: 0.55rem;
+        align-items: baseline;
+        font-size: 0.83rem;
+        line-height: 1.4;
+        padding: 0.28rem 0;
+        border-bottom: 1px dotted rgba(36, 42, 50, 0.35);
+      }
+      .criteria li::before {
+        content: '✓';
+        font-family: var(--mono);
+        font-weight: 600;
+        color: var(--green-ink);
+        flex: none;
+      }
 
-  .captures { margin-top: 1.4rem; }
-  .captures .head {
-    font-family: var(--mono); font-size: 0.66rem; letter-spacing: 0.22em;
-    text-transform: uppercase; color: var(--ink-soft); margin-bottom: 0.55rem;
-  }
-  .thumbs { display: flex; gap: 0.6rem; }
-  .thumb {
-    flex: 1; aspect-ratio: 16 / 10; border: 1px solid rgba(36,42,50,0.5); border-radius: 3px;
-    position: relative; overflow: hidden;
-    background:
-      linear-gradient(160deg, #1b1e24 0%, #23272f 55%, #1b1e24 100%);
-  }
-  .thumb::before { /* fake ui bars */
-    content: ""; position: absolute; inset: 12% 10% auto 10%; height: 8%;
-    background: rgba(232, 234, 238, 0.25); border-radius: 2px;
-    box-shadow: 0 14px 0 rgba(232,234,238,0.14), 0 28px 0 rgba(232,234,238,0.14), 0 42px 0 rgba(63,185,80,0.5);
-  }
-  .thumb figcaption {
-    position: absolute; left: 0; right: 0; bottom: 0;
-    font-family: var(--mono); font-size: 0.52rem; letter-spacing: 0.12em; text-transform: uppercase;
-    color: #9aa2ad; background: rgba(12, 14, 17, 0.75); padding: 0.2rem 0.4rem;
-  }
+      .captures {
+        margin-top: 1.4rem;
+      }
+      .captures .head {
+        font-family: var(--mono);
+        font-size: 0.66rem;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+        margin-bottom: 0.55rem;
+      }
+      .thumbs {
+        display: flex;
+        gap: 0.6rem;
+      }
+      .thumb {
+        flex: 1;
+        aspect-ratio: 16 / 10;
+        border: 1px solid rgba(36, 42, 50, 0.5);
+        border-radius: 3px;
+        position: relative;
+        overflow: hidden;
+        background: linear-gradient(160deg, #1b1e24 0%, #23272f 55%, #1b1e24 100%);
+      }
+      .thumb::before {
+        /* fake ui bars */
+        content: '';
+        position: absolute;
+        inset: 12% 10% auto 10%;
+        height: 8%;
+        background: rgba(232, 234, 238, 0.25);
+        border-radius: 2px;
+        box-shadow:
+          0 14px 0 rgba(232, 234, 238, 0.14),
+          0 28px 0 rgba(232, 234, 238, 0.14),
+          0 42px 0 rgba(63, 185, 80, 0.5);
+      }
+      .thumb figcaption {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        font-family: var(--mono);
+        font-size: 0.52rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: #9aa2ad;
+        background: rgba(12, 14, 17, 0.75);
+        padding: 0.2rem 0.4rem;
+      }
 
-  .cert-foot {
-    margin-top: 1.6rem; padding-top: 0.9rem; border-top: 2px solid var(--ink);
-    display: flex; justify-content: space-between; align-items: baseline; gap: 1rem;
-    font-family: var(--mono); font-size: 0.72rem; color: var(--ink-soft); letter-spacing: 0.05em;
-  }
-  .cert-foot .tagline { font-family: var(--serif); font-style: italic; font-size: 1.02rem; color: var(--ink); letter-spacing: 0; }
-  .cert-foot .verify b { color: var(--green-ink); font-weight: 600; }
+      .cert-foot {
+        margin-top: 1.6rem;
+        padding-top: 0.9rem;
+        border-top: 2px solid var(--ink);
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 1rem;
+        font-family: var(--mono);
+        font-size: 0.72rem;
+        color: var(--ink-soft);
+        letter-spacing: 0.05em;
+      }
+      .cert-foot .tagline {
+        font-family: var(--serif);
+        font-style: italic;
+        font-size: 1.02rem;
+        color: var(--ink);
+        letter-spacing: 0;
+      }
+      .cert-foot .verify b {
+        color: var(--green-ink);
+        font-weight: 600;
+      }
 
-  /* ---- inspection stub ---- */
-  .stub {
-    position: relative;
-    border-left: 2px dashed rgba(36, 42, 50, 0.5);
-    padding: 2rem 1.6rem 1.9rem;
-    display: flex; flex-direction: column;
-    background: linear-gradient(180deg, rgba(31, 122, 51, 0.06), transparent 40%);
-  }
-  .stub::before, .stub::after { /* perforation notches */
-    content: ""; position: absolute; left: -13px; width: 24px; height: 24px; border-radius: 50%;
-    background: var(--floor);
-  }
-  .stub::before { top: -12px; }
-  .stub::after { bottom: -12px; }
-  .punch {
-    position: absolute; top: 1.35rem; right: 1.35rem; width: 22px; height: 22px; border-radius: 50%;
-    background: var(--floor);
-    box-shadow: inset 0 1px 2px rgba(0,0,0,0.7), 0 1px 0 rgba(255,255,255,0.5);
-  }
-  .stub .head {
-    font-family: var(--mono); font-size: 0.62rem; letter-spacing: 0.28em;
-    text-transform: uppercase; color: var(--ink-soft);
-  }
-  .gauges { margin-top: 1.1rem; display: grid; gap: 0.85rem; }
-  .gauge { font-family: var(--mono); border-left: 3px solid var(--green-ink); padding-left: 0.7rem; }
-  .gauge b { display: block; font-size: 1.25rem; font-weight: 600; letter-spacing: 0.02em; }
-  .gauge span { font-size: 0.6rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-soft); }
-  .gauge.human { border-left-color: var(--red-ink); }
-  .gauge.human b { color: var(--red-ink); }
+      /* ---- inspection stub ---- */
+      .stub {
+        position: relative;
+        border-left: 2px dashed rgba(36, 42, 50, 0.5);
+        padding: 2rem 1.6rem 1.9rem;
+        display: flex;
+        flex-direction: column;
+        background: linear-gradient(180deg, rgba(31, 122, 51, 0.06), transparent 40%);
+      }
+      .stub::before,
+      .stub::after {
+        /* perforation notches */
+        content: '';
+        position: absolute;
+        left: -13px;
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        background: var(--floor);
+      }
+      .stub::before {
+        top: -12px;
+      }
+      .stub::after {
+        bottom: -12px;
+      }
+      .punch {
+        position: absolute;
+        top: 1.35rem;
+        right: 1.35rem;
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        background: var(--floor);
+        box-shadow:
+          inset 0 1px 2px rgba(0, 0, 0, 0.7),
+          0 1px 0 rgba(255, 255, 255, 0.5);
+      }
+      .stub .head {
+        font-family: var(--mono);
+        font-size: 0.62rem;
+        letter-spacing: 0.28em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+      }
+      .gauges {
+        margin-top: 1.1rem;
+        display: grid;
+        gap: 0.85rem;
+      }
+      .gauge {
+        font-family: var(--mono);
+        border-left: 3px solid var(--green-ink);
+        padding-left: 0.7rem;
+      }
+      .gauge b {
+        display: block;
+        font-size: 1.25rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+      .gauge span {
+        font-size: 0.6rem;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+      }
+      .gauge.human {
+        border-left-color: var(--red-ink);
+      }
+      .gauge.human b {
+        color: var(--red-ink);
+      }
 
-  .stamp-zone { margin-top: auto; padding-top: 1.4rem; display: grid; place-items: center; }
-  .stamp {
-    --sink: var(--green-bright);
-    transform: rotate(-8deg);
-    border: 3px double var(--sink); border-radius: 10px;
-    padding: 0.55rem 1.1rem 0.65rem; text-align: center;
-    color: var(--sink);
-    font-family: var(--mono); text-transform: uppercase;
-    mix-blend-mode: multiply; opacity: 0.9;
-    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='r'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.11' numOctaves='3'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.92 0.05'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23r)'/%3E%3C/svg%3E");
-    mask-size: 120px;
-  }
-  .stamp .big { font-size: 1.55rem; font-weight: 600; letter-spacing: 0.14em; line-height: 1.1; }
-  .stamp .sub { font-size: 0.58rem; letter-spacing: 0.3em; margin-top: 0.25rem; }
-  .stamp .date { font-size: 0.66rem; letter-spacing: 0.14em; margin-top: 0.35rem; border-top: 1px solid var(--sink); padding-top: 0.3rem; }
+      .stamp-zone {
+        margin-top: auto;
+        padding-top: 1.4rem;
+        display: grid;
+        place-items: center;
+      }
+      .stamp {
+        --sink: var(--green-bright);
+        transform: rotate(-8deg);
+        border: 3px double var(--sink);
+        border-radius: 10px;
+        padding: 0.55rem 1.1rem 0.65rem;
+        text-align: center;
+        color: var(--sink);
+        font-family: var(--mono);
+        text-transform: uppercase;
+        mix-blend-mode: multiply;
+        opacity: 0.9;
+        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='r'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.11' numOctaves='3'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.92 0.05'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23r)'/%3E%3C/svg%3E");
+        mask-size: 120px;
+      }
+      .stamp .big {
+        font-size: 1.55rem;
+        font-weight: 600;
+        letter-spacing: 0.14em;
+        line-height: 1.1;
+      }
+      .stamp .sub {
+        font-size: 0.58rem;
+        letter-spacing: 0.3em;
+        margin-top: 0.25rem;
+      }
+      .stamp .date {
+        font-size: 0.66rem;
+        letter-spacing: 0.14em;
+        margin-top: 0.35rem;
+        border-top: 1px solid var(--sink);
+        padding-top: 0.3rem;
+      }
 
-  .stub .sig { margin-top: 1.3rem; font-family: var(--mono); font-size: 0.6rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-soft); }
-  .stub .sig .line { font-family: var(--serif); font-style: italic; font-size: 1.05rem; color: var(--ink); text-transform: none; letter-spacing: 0; border-bottom: 1px solid var(--ink); padding-bottom: 0.15rem; margin-bottom: 0.3rem; }
+      .stub .sig {
+        margin-top: 1.3rem;
+        font-family: var(--mono);
+        font-size: 0.6rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+      }
+      .stub .sig .line {
+        font-family: var(--serif);
+        font-style: italic;
+        font-size: 1.05rem;
+        color: var(--ink);
+        text-transform: none;
+        letter-spacing: 0;
+        border-bottom: 1px solid var(--ink);
+        padding-bottom: 0.15rem;
+        margin-bottom: 0.3rem;
+      }
 
-  @media (max-width: 860px) {
-    .cert { grid-template-columns: 1fr; transform: none; }
-    .stub { border-left: 0; border-top: 2px dashed rgba(36,42,50,0.5); }
-    .stub::before { top: -12px; left: -12px; }
-    .stub::after { top: -12px; left: auto; right: -12px; bottom: auto; }
-    .criteria ul { columns: 1; }
-    .thumbs .thumb:nth-child(n+4) { display: none; }
-  }
-</style>
-</head>
-<body>
-<div class="grain" aria-hidden="true"></div>
+      @media (max-width: 860px) {
+        .cert {
+          grid-template-columns: 1fr;
+          transform: none;
+        }
+        .stub {
+          border-left: 0;
+          border-top: 2px dashed rgba(36, 42, 50, 0.5);
+        }
+        .stub::before {
+          top: -12px;
+          left: -12px;
+        }
+        .stub::after {
+          top: -12px;
+          left: auto;
+          right: -12px;
+          bottom: auto;
+        }
+        .criteria ul {
+          columns: 1;
+        }
+        .thumbs .thumb:nth-child(n + 4) {
+          display: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="grain" aria-hidden="true"></div>
 
-<article class="cert">
-  <div class="main">
-    <header class="cert-head">
-      <div class="cert-title">
-        <div class="kicker">Proof of Build</div>
-        <div class="org">issued by <b>turbodiff</b> autonomous software factory</div>
+    <article class="cert">
+      <div class="main">
+        <header class="cert-head">
+          <div class="cert-title">
+            <div class="kicker">Proof of Build</div>
+            <div class="org">issued by <b>turbodiff</b> autonomous software factory</div>
+          </div>
+          <div class="serial">
+            <div class="label">Build No.</div>
+            <div class="no">TD-2026-0058</div>
+            <div class="barcode" aria-hidden="true"></div>
+          </div>
+        </header>
+
+        <section class="feature">
+          <h1>OAuth flow support for MCP servers</h1>
+          <p class="meta">
+            <b>Ngineer101/turbodiff</b> &middot; PR #58 &middot; merged 12 Aug 2026 &middot; run
+            <b>#9f42</b>
+          </p>
+        </section>
+
+        <section class="criteria">
+          <div class="head">
+            <span>Acceptance criteria — verified</span>
+            <span class="score">9 / 9 passed</span>
+          </div>
+          <ul>
+            <li>Connect button starts the OAuth handshake</li>
+            <li>Callback exchanges code for tokens</li>
+            <li>Tokens stored encrypted per user</li>
+            <li>Expired tokens refresh silently</li>
+            <li>Failed auth shows a recoverable error</li>
+            <li>Server list reflects connection state</li>
+          </ul>
+        </section>
+
+        <section class="captures">
+          <div class="head">Screenshot proof — 14 attached</div>
+          <div class="thumbs">
+            <figure class="thumb"><figcaption>ac-01 · connect</figcaption></figure>
+            <figure class="thumb"><figcaption>ac-03 · callback</figcaption></figure>
+            <figure class="thumb"><figcaption>ac-05 · error state</figcaption></figure>
+            <figure class="thumb"><figcaption>ac-08 · refresh</figcaption></figure>
+            <figure class="thumb"><figcaption>ac-09 · server list</figcaption></figure>
+          </div>
+        </section>
+
+        <footer class="cert-foot">
+          <span class="tagline">Anyone can generate code. We ship proof.</span>
+          <span class="verify">see the receipts &rarr; <b>turbodiff.dev/b/TD-2026-0058</b></span>
+        </footer>
       </div>
-      <div class="serial">
-        <div class="label">Build No.</div>
-        <div class="no">TD-2026-0058</div>
-        <div class="barcode" aria-hidden="true"></div>
-      </div>
-    </header>
 
-    <section class="feature">
-      <h1>OAuth flow support for MCP servers</h1>
-      <p class="meta">
-        <b>Ngineer101/turbodiff</b> &middot; PR #58 &middot; merged 12 Aug 2026 &middot; run <b>#9f42</b>
-      </p>
-    </section>
-
-    <section class="criteria">
-      <div class="head">
-        <span>Acceptance criteria — verified</span>
-        <span class="score">9 / 9 passed</span>
-      </div>
-      <ul>
-        <li>Connect button starts the OAuth handshake</li>
-        <li>Callback exchanges code for tokens</li>
-        <li>Tokens stored encrypted per user</li>
-        <li>Expired tokens refresh silently</li>
-        <li>Failed auth shows a recoverable error</li>
-        <li>Server list reflects connection state</li>
-      </ul>
-    </section>
-
-    <section class="captures">
-      <div class="head">Screenshot proof — 14 attached</div>
-      <div class="thumbs">
-        <figure class="thumb"><figcaption>ac-01 · connect</figcaption></figure>
-        <figure class="thumb"><figcaption>ac-03 · callback</figcaption></figure>
-        <figure class="thumb"><figcaption>ac-05 · error state</figcaption></figure>
-        <figure class="thumb"><figcaption>ac-08 · refresh</figcaption></figure>
-        <figure class="thumb"><figcaption>ac-09 · server list</figcaption></figure>
-      </div>
-    </section>
-
-    <footer class="cert-foot">
-      <span class="tagline">Anyone can generate code. We ship proof.</span>
-      <span class="verify">see the receipts &rarr; <b>turbodiff.dev/b/TD-2026-0058</b></span>
-    </footer>
-  </div>
-
-  <aside class="stub">
-    <span class="punch" aria-hidden="true"></span>
-    <div class="head">Build stats</div>
-    <div class="gauges">
-      <div class="gauge"><b>38 min</b><span>agent time</span></div>
-      <div class="gauge human"><b>4 min</b><span>human time</span></div>
-      <div class="gauge"><b>2</b><span>fix iterations</span></div>
-      <div class="gauge"><b>14</b><span>screenshots</span></div>
-    </div>
-    <div class="stamp-zone">
-      <div class="stamp">
-        <div class="big">Verified</div>
-        <div class="sub">All checks passed</div>
-        <div class="date">12 · 08 · 2026</div>
-      </div>
-    </div>
-    <div class="sig">
-      <div class="line">Nico Botha</div>
-      approved &amp; merged by
-    </div>
-  </aside>
-</article>
-
-</body>
+      <aside class="stub">
+        <span class="punch" aria-hidden="true"></span>
+        <div class="head">Build stats</div>
+        <div class="gauges">
+          <div class="gauge"><b>38 min</b><span>agent time</span></div>
+          <div class="gauge human"><b>4 min</b><span>human time</span></div>
+          <div class="gauge"><b>2</b><span>fix iterations</span></div>
+          <div class="gauge"><b>14</b><span>screenshots</span></div>
+        </div>
+        <div class="stamp-zone">
+          <div class="stamp">
+            <div class="big">Verified</div>
+            <div class="sub">All checks passed</div>
+            <div class="date">12 · 08 · 2026</div>
+          </div>
+        </div>
+        <div class="sig">
+          <div class="line">Nico Botha</div>
+          approved &amp; merged by
+        </div>
+      </aside>
+    </article>
+  </body>
 </html>

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,8 @@ import { Hono } from 'hono';
 import { createMiddleware } from 'hono/factory';
 import { PrReviewer } from './agents/pr-reviewer.ts';
 import { timingSafeEqual, verifyArtifactSig } from './lib/crypto.ts';
+import { certificateSigKey, loadCertificateData } from './lib/certificate.ts';
+import { renderCertificatePage } from './routes/certificate-page.tsx';
 import {
   connectionSnapshot,
   createFeature,
@@ -84,6 +86,19 @@ app.get('/artifacts/*', async (c) => {
       'cache-control': 'public, max-age=31536000, immutable',
     },
   });
+});
+
+// Shareable "Proof of Build" certificate for a factory feature: the latest
+// verification evidence rendered as a public page. Same capability-URL scheme
+// as /artifacts/* — the signature over cert/<id> is the only credential.
+app.get('/b/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (!Number.isInteger(id) || id <= 0) return c.notFound();
+  const sig = c.req.query('sig') ?? '';
+  if (!(await verifyArtifactSig(certificateSigKey(id), sig))) return c.notFound();
+  const data = await loadCertificateData(id);
+  if (!data) return c.notFound();
+  return c.html(renderCertificatePage(data));
 });
 
 // Dispatches one configured agent against one PR and records the review row.

--- a/src/client/components/app-shell.tsx
+++ b/src/client/components/app-shell.tsx
@@ -66,7 +66,9 @@ function BottomTabs() {
       aria-label="Main"
       className="fixed inset-x-0 bottom-0 z-40 border-t border-line/60 bg-bg/95 pb-[env(safe-area-inset-bottom)] backdrop-blur md:hidden"
     >
-      <div className="grid grid-cols-5">
+      {/* flex, not a fixed column count, so adding a destination can never
+          wrap the bar onto a second row */}
+      <div className="flex">
         {NAV.map(({ to, label, icon: Icon, ...item }) => {
           const active = isActive(pathname, to, 'exact' in item && item.exact);
           return (
@@ -75,15 +77,18 @@ function BottomTabs() {
               to={to}
               aria-current={active ? 'page' : undefined}
               className={cn(
-                'flex flex-col items-center gap-1 py-2 text-[10px] tracking-wide transition-colors active:scale-95',
+                'flex min-w-0 flex-1 flex-col items-center gap-1 py-2 text-[10px] tracking-wide transition-colors active:scale-95',
                 active ? 'text-accent-bright' : 'text-mute',
               )}
             >
               <Icon
-                className={cn('size-5', active && 'drop-shadow-[0_0_6px_rgba(86,211,100,0.4)]')}
+                className={cn(
+                  'size-5 shrink-0',
+                  active && 'drop-shadow-[0_0_6px_rgba(86,211,100,0.4)]',
+                )}
                 aria-hidden
               />
-              {label}
+              <span className="max-w-full truncate px-0.5">{label}</span>
             </Link>
           );
         })}

--- a/src/lib/certificate.ts
+++ b/src/lib/certificate.ts
@@ -1,0 +1,102 @@
+// "Proof of Build" certificate assembly (design: marketing/mockups/
+// build-certificate.html; render: src/routes/certificate-page.tsx). Each
+// feature gets a public capability URL at GET /b/:id — the HMAC over
+// cert/<id> is the only credential, mirroring the /artifacts/* scheme, so
+// links are shareable but not enumerable.
+import { env } from 'cloudflare:workers';
+import { signArtifactKey } from './crypto.ts';
+import {
+  getFeature,
+  getRepoById,
+  latestVerificationForFeature,
+  listAgentRunsForFeature,
+  countFixAttempts,
+} from './db.ts';
+import type { CertificateData } from '../routes/certificate-page.tsx';
+
+// Scoped under cert/ so a certificate sig replayed against /artifacts/* hits
+// a key space where no object ever lives (and vice versa).
+export const certificateSigKey = (featureId: number) => `cert/${featureId}`;
+
+export async function certificateUrl(featureId: number): Promise<string> {
+  const sig = await signArtifactKey(certificateSigKey(featureId));
+  return `${env.PUBLIC_BASE_URL}/b/${featureId}?sig=${sig}`;
+}
+
+// Thumbnails shown on the card; the count line still reports every capture.
+const MAX_SHOTS = 5;
+
+interface RawResult {
+  index: number;
+  verdict: 'pass' | 'fail' | 'skip';
+  note: string;
+  screenshot?: string;
+}
+
+export async function loadCertificateData(featureId: number): Promise<CertificateData | null> {
+  const feature = await getFeature(featureId);
+  // A certificate only exists once there is a PR to certify.
+  if (!feature || !feature.pr_number) return null;
+  const repo = await getRepoById(feature.repository_id);
+  if (!repo) return null;
+
+  const verification = await latestVerificationForFeature(featureId);
+  const criteria: string[] = feature.acceptance ? JSON.parse(feature.acceptance) : [];
+  const results: RawResult[] = verification?.results ? JSON.parse(verification.results) : [];
+  const byIndex = new Map(results.map((r) => [r.index, r]));
+
+  const shotNames = [
+    ...new Set(results.map((r) => r.screenshot).filter((s): s is string => !!s)),
+  ].map((name) => ({ name, safe: name.replace(/[^\w.-]/g, '') }));
+  const screenshots = await Promise.all(
+    shotNames.slice(0, MAX_SHOTS).map(async ({ name, safe }) => {
+      const key = `verify/${featureId}/${safe}`;
+      return {
+        url: `${env.PUBLIC_BASE_URL}/artifacts/${key}?sig=${await signArtifactKey(key)}`,
+        label: name.replace(/\.png$/, '').replaceAll('-', ' '),
+      };
+    }),
+  );
+
+  const runs = await listAgentRunsForFeature(featureId);
+  // Wall clock of the factory run: generation start to the last agent run.
+  // Older features predate run_started_at/agent_runs — omit rather than guess.
+  let agentMinutes: number | null = null;
+  const lastRun = runs.at(-1);
+  if (feature.run_started_at && lastRun) {
+    const ms = sqliteMs(lastRun.created_at) - sqliteMs(feature.run_started_at);
+    if (Number.isFinite(ms) && ms > 0) agentMinutes = Math.max(1, Math.round(ms / 60_000));
+  }
+
+  const verdicts = criteria.map((_, i) => byIndex.get(i)?.verdict ?? null);
+  return {
+    serial: `TD-${yearOf(feature.created_at)}-${String(feature.id).padStart(4, '0')}`,
+    featureTitle: feature.title,
+    repoFullName: `${repo.owner}/${repo.name}`,
+    prNumber: feature.pr_number,
+    prUrl: `https://github.com/${repo.owner}/${repo.name}/pull/${feature.pr_number}`,
+    authorLogin: feature.author_login,
+    verifiedAt: verification?.created_at ?? null,
+    criteria: criteria.map((text, i) => ({ text, verdict: verdicts[i] })),
+    screenshots,
+    screenshotCount: shotNames.length,
+    agentMinutes,
+    fixIterations: await countFixAttempts(feature.repository_id, feature.pr_number),
+    agentRuns: runs.length,
+    verified:
+      verification?.status === 'passed' &&
+      criteria.length > 0 &&
+      verdicts.every((v) => v === 'pass' || v === 'skip'),
+    pageUrl: await certificateUrl(featureId),
+  };
+}
+
+// SQLite datetime('now') has no timezone marker; treat it as UTC.
+function sqliteMs(ts: string): number {
+  return new Date(ts.includes('T') ? ts : `${ts.replace(' ', 'T')}Z`).getTime();
+}
+
+function yearOf(ts: string): string {
+  const y = new Date(ts.includes('T') ? ts : `${ts.replace(' ', 'T')}Z`).getUTCFullYear();
+  return Number.isFinite(y) ? String(y) : '0000';
+}

--- a/src/lib/verifier.ts
+++ b/src/lib/verifier.ts
@@ -13,6 +13,7 @@ import {
 } from './db.ts';
 import { persistAgentLog } from './agent-runs.ts';
 import { maybeAutoMerge } from './auto-merge.ts';
+import { certificateUrl } from './certificate.ts';
 import { signArtifactKey } from './crypto.ts';
 import { resolveRunnerAuth } from './fixer.ts';
 import { installationToken, sandboxGitToken } from './github-app.ts';
@@ -447,6 +448,7 @@ async function postReport(
 ): Promise<void> {
   const failed = results.filter((r) => r.verdict === 'fail').length;
   const cockpit = `${env.PUBLIC_BASE_URL}/factory/features/${feature.id}`;
+  const cert = failed === 0 ? await certificateUrl(feature.id) : null;
   const lines = [
     `## 🔍 Turbodiff verification — ${failed === 0 ? 'all criteria met' : `${failed} criteria not met`}`,
     '',
@@ -456,6 +458,9 @@ async function postReport(
           '',
         ]
       : [`🔎 **[Review this PR in Turbodiff](${cockpit})**`, '']),
+    ...(cert
+      ? [`📜 **[Proof of build](${cert})** — shareable certificate of this evidence`, '']
+      : []),
     '| | Criterion | Evidence |',
     '|---|---|---|',
     ...results.map((r) => {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -85,6 +85,7 @@ import {
   type TaskRepoStatusRow,
 } from '../lib/db.ts';
 import { requireUser, type AuthedUser } from '../lib/auth.ts';
+import { certificateUrl } from '../lib/certificate.ts';
 import { syncInstallationRepos } from '../lib/repo-sync.ts';
 import { approvePlan } from '../lib/planner.ts';
 import {
@@ -733,6 +734,7 @@ export function createApiRoutes() {
       reviews: [],
       comments: [],
       demo: null,
+      certificate_url: null,
       criteria: [],
       verification: null,
       runs: [],
@@ -741,6 +743,7 @@ export function createApiRoutes() {
     // exactly the case where an advanced user most wants the full log.
     base.runs = (await listAgentRunsForFeature(feature.id)).map(serializeAgentRun);
     if (!feature.pr_number) return c.json(base);
+    base.certificate_url = await certificateUrl(feature.id);
 
     const [plan, verification, token, cockpitComments] = await Promise.all([
       getPlanByFeatureId(feature.id),

--- a/src/routes/certificate-page.tsx
+++ b/src/routes/certificate-page.tsx
@@ -1,0 +1,390 @@
+// Public "Proof of Build" certificate page, server-rendered as hono/jsx like
+// landing.tsx. Pure render — no env or DB access — so it can be previewed and
+// tested with fixture data outside the Worker. Data assembly lives in
+// src/lib/certificate.ts; the design source is
+// marketing/mockups/build-certificate.html.
+
+export interface CertificateCriterion {
+  text: string;
+  verdict: 'pass' | 'fail' | 'skip' | null; // null = not verified yet
+}
+
+export interface CertificateShot {
+  url: string; // signed absolute /artifacts URL
+  label: string;
+}
+
+export interface CertificateData {
+  serial: string; // e.g. TD-2026-0058
+  featureTitle: string;
+  repoFullName: string;
+  prNumber: number;
+  prUrl: string;
+  authorLogin: string | null;
+  verifiedAt: string | null; // ISO date of the latest verification
+  criteria: CertificateCriterion[];
+  screenshots: CertificateShot[]; // capped by the loader
+  screenshotCount: number;
+  agentMinutes: number | null; // wall clock of the factory run, when known
+  fixIterations: number;
+  agentRuns: number;
+  verified: boolean; // latest verification passed with zero failures
+  pageUrl: string; // canonical capability URL for og:url
+}
+
+const CSS = `
+	:root {
+		--floor: #15171c;
+		--paper: #ece7da;
+		--ink: #242a32;
+		--ink-soft: #5c6470;
+		--green-ink: #1f7a33;
+		--green-bright: #2f9e44;
+		--red-ink: #b8362c;
+		--mono: "IBM Plex Mono", ui-monospace, monospace;
+		--serif: "Instrument Serif", Georgia, serif;
+	}
+	* { box-sizing: border-box; margin: 0; }
+	body {
+		min-height: 100vh;
+		background: var(--floor);
+		display: grid; place-items: center;
+		padding: 3rem 1.5rem;
+		font: 400 15px/1.5 "IBM Plex Sans", system-ui, sans-serif;
+		color: var(--ink);
+	}
+	.grain {
+		position: fixed; inset: 0; pointer-events: none; opacity: 0.9; mix-blend-mode: overlay;
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3'/%3E%3CfeColorMatrix values='0 0 0 0 0.5 0 0 0 0 0.52 0 0 0 0 0.56 0 0 0 0.3 0'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)'/%3E%3C/svg%3E");
+	}
+	.wrap { width: min(1080px, 96vw); }
+	.cert {
+		position: relative;
+		display: grid;
+		grid-template-columns: 1fr 280px;
+		background:
+			radial-gradient(120% 90% at 30% 0%, rgba(255,255,255,0.5), transparent 60%),
+			var(--paper);
+		border-radius: 6px;
+		box-shadow:
+			0 1px 0 rgba(255,255,255,0.06),
+			0 30px 80px rgba(0,0,0,0.55),
+			0 6px 18px rgba(0,0,0,0.4);
+	}
+	.cert::after {
+		content: ""; position: absolute; inset: 0; border-radius: 6px; pointer-events: none;
+		opacity: 0.5; mix-blend-mode: multiply;
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='p'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3CfeColorMatrix values='0 0 0 0 0.72 0 0 0 0 0.7 0 0 0 0 0.64 0 0 0 0.16 0'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23p)'/%3E%3C/svg%3E");
+	}
+	.main { padding: 2.2rem 2.4rem 1.9rem; min-width: 0; }
+	.cert-head {
+		display: flex; justify-content: space-between; align-items: flex-start; gap: 1.5rem;
+		padding-bottom: 1.1rem; border-bottom: 2px solid var(--ink);
+	}
+	.cert-title { font-family: var(--mono); }
+	.cert-title .kicker {
+		font-size: 0.7rem; letter-spacing: 0.32em; text-transform: uppercase; color: var(--ink);
+		font-weight: 600;
+	}
+	.cert-title .org {
+		margin-top: 0.35rem; font-size: 0.72rem; letter-spacing: 0.08em; color: var(--ink-soft);
+	}
+	.cert-title .org b { color: var(--green-ink); font-weight: 600; }
+	.serial { text-align: right; font-family: var(--mono); }
+	.serial .label { font-size: 0.62rem; letter-spacing: 0.24em; color: var(--ink-soft); text-transform: uppercase; }
+	.serial .no { font-size: 1.5rem; font-weight: 600; letter-spacing: 0.06em; margin-top: 0.1rem; }
+	.barcode {
+		margin-top: 0.4rem; height: 26px; width: 190px; margin-left: auto;
+		background: repeating-linear-gradient(90deg,
+			var(--ink) 0 2px, transparent 2px 4px, var(--ink) 4px 7px, transparent 7px 9px,
+			var(--ink) 9px 10px, transparent 10px 14px, var(--ink) 14px 18px, transparent 18px 20px);
+	}
+	.feature { margin-top: 1.5rem; }
+	.feature h1 {
+		font-family: var(--serif); font-weight: 400;
+		font-size: clamp(1.7rem, 3.4vw, 2.5rem); line-height: 1.08; letter-spacing: -0.01em;
+	}
+	.feature .meta {
+		margin-top: 0.55rem; font-family: var(--mono); font-size: 0.76rem;
+		color: var(--ink-soft); letter-spacing: 0.04em;
+	}
+	.feature .meta b { color: var(--ink); font-weight: 500; }
+	.feature .meta a { color: var(--green-ink); text-decoration: none; font-weight: 500; }
+	.feature .meta a:hover { text-decoration: underline; }
+	.criteria { margin-top: 1.4rem; }
+	.criteria .head {
+		display: flex; justify-content: space-between; align-items: baseline;
+		font-family: var(--mono); font-size: 0.66rem; letter-spacing: 0.22em;
+		text-transform: uppercase; color: var(--ink-soft); margin-bottom: 0.6rem;
+	}
+	.criteria .head .score { color: var(--green-ink); font-weight: 600; letter-spacing: 0.1em; }
+	.criteria .head .score.partial { color: var(--red-ink); }
+	.criteria ul { list-style: none; padding: 0; columns: 2; column-gap: 2.2rem; }
+	.criteria li {
+		break-inside: avoid; display: flex; gap: 0.55rem; align-items: baseline;
+		font-size: 0.83rem; line-height: 1.4; padding: 0.28rem 0;
+		border-bottom: 1px dotted rgba(36, 42, 50, 0.35);
+	}
+	.criteria li .mark { font-family: var(--mono); font-weight: 600; color: var(--green-ink); flex: none; }
+	.criteria li.fail .mark { color: var(--red-ink); }
+	.criteria li.skip .mark, .criteria li.pending .mark { color: var(--ink-soft); }
+	.captures { margin-top: 1.4rem; }
+	.captures .head {
+		font-family: var(--mono); font-size: 0.66rem; letter-spacing: 0.22em;
+		text-transform: uppercase; color: var(--ink-soft); margin-bottom: 0.55rem;
+	}
+	.thumbs { display: flex; gap: 0.6rem; }
+	.thumb {
+		flex: 1; min-width: 0; aspect-ratio: 16 / 10; border: 1px solid rgba(36,42,50,0.5);
+		border-radius: 3px; position: relative; overflow: hidden; background: #1b1e24;
+	}
+	.thumb img { width: 100%; height: 100%; object-fit: cover; object-position: top; display: block; }
+	.thumb figcaption {
+		position: absolute; left: 0; right: 0; bottom: 0;
+		font-family: var(--mono); font-size: 0.52rem; letter-spacing: 0.12em; text-transform: uppercase;
+		color: #9aa2ad; background: rgba(12, 14, 17, 0.75); padding: 0.2rem 0.4rem;
+		white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+	}
+	.cert-foot {
+		margin-top: 1.6rem; padding-top: 0.9rem; border-top: 2px solid var(--ink);
+		display: flex; justify-content: space-between; align-items: baseline; gap: 1rem;
+		font-family: var(--mono); font-size: 0.72rem; color: var(--ink-soft); letter-spacing: 0.05em;
+	}
+	.cert-foot .tagline { font-family: var(--serif); font-style: italic; font-size: 1.02rem; color: var(--ink); letter-spacing: 0; }
+	.cert-foot a { color: var(--green-ink); text-decoration: none; font-weight: 600; }
+	.stub {
+		position: relative;
+		border-left: 2px dashed rgba(36, 42, 50, 0.5);
+		padding: 2rem 1.6rem 1.9rem;
+		display: flex; flex-direction: column;
+		background: linear-gradient(180deg, rgba(31, 122, 51, 0.06), transparent 40%);
+	}
+	.stub::before, .stub::after {
+		content: ""; position: absolute; left: -13px; width: 24px; height: 24px; border-radius: 50%;
+		background: var(--floor);
+	}
+	.stub::before { top: -12px; }
+	.stub::after { bottom: -12px; }
+	.punch {
+		position: absolute; top: 1.35rem; right: 1.35rem; width: 22px; height: 22px; border-radius: 50%;
+		background: var(--floor);
+		box-shadow: inset 0 1px 2px rgba(0,0,0,0.7), 0 1px 0 rgba(255,255,255,0.5);
+	}
+	.stub .head {
+		font-family: var(--mono); font-size: 0.62rem; letter-spacing: 0.28em;
+		text-transform: uppercase; color: var(--ink-soft);
+	}
+	.gauges { margin-top: 1.1rem; display: grid; gap: 0.85rem; }
+	.gauge { font-family: var(--mono); border-left: 3px solid var(--green-ink); padding-left: 0.7rem; }
+	.gauge b { display: block; font-size: 1.25rem; font-weight: 600; letter-spacing: 0.02em; }
+	.gauge span { font-size: 0.6rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-soft); }
+	.stamp-zone { margin-top: auto; padding-top: 1.4rem; display: grid; place-items: center; }
+	.stamp {
+		--sink: var(--green-bright);
+		transform: rotate(-8deg);
+		border: 3px double var(--sink); border-radius: 10px;
+		padding: 0.55rem 1.1rem 0.65rem; text-align: center;
+		color: var(--sink);
+		font-family: var(--mono); text-transform: uppercase;
+		mix-blend-mode: multiply; opacity: 0.9;
+		mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='r'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.11' numOctaves='3'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.92 0.05'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23r)'/%3E%3C/svg%3E");
+		mask-size: 120px;
+	}
+	.stamp.pending { --sink: var(--ink-soft); transform: rotate(-4deg); }
+	.stamp .big { font-size: 1.55rem; font-weight: 600; letter-spacing: 0.14em; line-height: 1.1; }
+	.stamp .sub { font-size: 0.58rem; letter-spacing: 0.3em; margin-top: 0.25rem; }
+	.stamp .date { font-size: 0.66rem; letter-spacing: 0.14em; margin-top: 0.35rem; border-top: 1px solid var(--sink); padding-top: 0.3rem; }
+	.stub .sig { margin-top: 1.3rem; font-family: var(--mono); font-size: 0.6rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-soft); }
+	.stub .sig .line { font-family: var(--serif); font-style: italic; font-size: 1.05rem; color: var(--ink); text-transform: none; letter-spacing: 0; border-bottom: 1px solid var(--ink); padding-bottom: 0.15rem; margin-bottom: 0.3rem; }
+	.colophon {
+		margin-top: 1.1rem; text-align: center;
+		font-family: var(--mono); font-size: 0.7rem; letter-spacing: 0.08em; color: #8b919c;
+	}
+	.colophon a { color: #56d364; text-decoration: none; }
+	.colophon a:hover { text-decoration: underline; }
+	@media (max-width: 860px) {
+		.cert { grid-template-columns: 1fr; }
+		.stub { border-left: 0; border-top: 2px dashed rgba(36,42,50,0.5); }
+		.stub::before { top: -12px; left: -12px; }
+		.stub::after { top: -12px; left: auto; right: -12px; bottom: auto; }
+		.criteria ul { columns: 1; }
+		.thumbs { flex-wrap: wrap; }
+		.thumb { flex: 1 1 45%; }
+	}
+`;
+
+const MARK: Record<string, string> = { pass: '✓', fail: '✗', skip: '–' };
+
+// e.g. "12 Aug 2026" from an ISO/SQLite timestamp; falls back to the raw string.
+function fmtDate(iso: string): string {
+  const d = new Date(iso.includes('T') ? iso : `${iso.replace(' ', 'T')}Z`);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+function stampDate(iso: string): string {
+  const d = new Date(iso.includes('T') ? iso : `${iso.replace(' ', 'T')}Z`);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(d.getUTCDate())} · ${pad(d.getUTCMonth() + 1)} · ${d.getUTCFullYear()}`;
+}
+
+function Certificate({ data }: { data: CertificateData }) {
+  const passed = data.criteria.filter((c) => c.verdict === 'pass').length;
+  const total = data.criteria.length;
+  const description = data.verified
+    ? `${passed}/${total} acceptance criteria verified with screenshot proof by the Turbodiff software factory.`
+    : `Built by the Turbodiff software factory — ${passed}/${total} acceptance criteria verified so far.`;
+  return (
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{`Proof of Build — ${data.featureTitle}`}</title>
+        <meta name="description" content={description} />
+        <meta name="robots" content="noindex" />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={`Proof of Build — ${data.featureTitle}`} />
+        <meta property="og:description" content={description} />
+        <meta property="og:url" content={data.pageUrl} />
+        {data.screenshots[0] ? (
+          <>
+            <meta property="og:image" content={data.screenshots[0].url} />
+            <meta name="twitter:card" content="summary_large_image" />
+          </>
+        ) : null}
+        <link rel="icon" type="image/png" href="/logo-small.png" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=IBM+Plex+Sans:wght@400;500&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+          rel="stylesheet"
+        />
+        <style dangerouslySetInnerHTML={{ __html: CSS }} />
+      </head>
+      <body>
+        <div class="grain" aria-hidden="true"></div>
+        <div class="wrap">
+          <article class="cert">
+            <div class="main">
+              <header class="cert-head">
+                <div class="cert-title">
+                  <div class="kicker">Proof of Build</div>
+                  <div class="org">
+                    issued by <b>turbodiff</b> autonomous software factory
+                  </div>
+                </div>
+                <div class="serial">
+                  <div class="label">Build No.</div>
+                  <div class="no">{data.serial}</div>
+                  <div class="barcode" aria-hidden="true"></div>
+                </div>
+              </header>
+
+              <section class="feature">
+                <h1>{data.featureTitle}</h1>
+                <p class="meta">
+                  <b>{data.repoFullName}</b> &middot; <a href={data.prUrl}>PR #{data.prNumber}</a>
+                  {data.verifiedAt ? <> &middot; verified {fmtDate(data.verifiedAt)}</> : null}
+                </p>
+              </section>
+
+              {total > 0 ? (
+                <section class="criteria">
+                  <div class="head">
+                    <span>Acceptance criteria — verified</span>
+                    <span class={passed === total ? 'score' : 'score partial'}>
+                      {passed} / {total} passed
+                    </span>
+                  </div>
+                  <ul>
+                    {data.criteria.map((c) => (
+                      <li class={c.verdict ?? 'pending'}>
+                        <span class="mark">{c.verdict ? MARK[c.verdict] : '·'}</span>
+                        {c.text}
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ) : null}
+
+              {data.screenshots.length > 0 ? (
+                <section class="captures">
+                  <div class="head">Screenshot proof — {data.screenshotCount} attached</div>
+                  <div class="thumbs">
+                    {data.screenshots.map((s) => (
+                      <figure class="thumb">
+                        <img src={s.url} alt={s.label} loading="lazy" />
+                        <figcaption>{s.label}</figcaption>
+                      </figure>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+
+              <footer class="cert-foot">
+                <span class="tagline">Anyone can generate code. We ship proof.</span>
+                <span>
+                  built by <a href="https://turbodiff.dev">turbodiff.dev</a>
+                </span>
+              </footer>
+            </div>
+
+            <aside class="stub">
+              <span class="punch" aria-hidden="true"></span>
+              <div class="head">Build stats</div>
+              <div class="gauges">
+                {data.agentMinutes !== null ? (
+                  <div class="gauge">
+                    <b>{data.agentMinutes} min</b>
+                    <span>agent time</span>
+                  </div>
+                ) : null}
+                <div class="gauge">
+                  <b>{data.agentRuns}</b>
+                  <span>agent runs</span>
+                </div>
+                <div class="gauge">
+                  <b>{data.fixIterations}</b>
+                  <span>fix iterations</span>
+                </div>
+                <div class="gauge">
+                  <b>{data.screenshotCount}</b>
+                  <span>screenshots</span>
+                </div>
+              </div>
+              <div class="stamp-zone">
+                {data.verified ? (
+                  <div class="stamp">
+                    <div class="big">Verified</div>
+                    <div class="sub">All checks passed</div>
+                    {data.verifiedAt ? <div class="date">{stampDate(data.verifiedAt)}</div> : null}
+                  </div>
+                ) : (
+                  <div class="stamp pending">
+                    <div class="big">In progress</div>
+                    <div class="sub">Verification pending</div>
+                  </div>
+                )}
+              </div>
+              {data.authorLogin ? (
+                <div class="sig">
+                  <div class="line">{data.authorLogin}</div>
+                  approved &amp; merged by
+                </div>
+              ) : null}
+            </aside>
+          </article>
+          <p class="colophon">
+            This certificate is generated from the factory&apos;s own verification run — the
+            receipts are real. <a href="https://turbodiff.dev">Get your own factory &rarr;</a>
+          </p>
+        </div>
+      </body>
+    </html>
+  );
+}
+
+export function renderCertificatePage(data: CertificateData): string {
+  return `<!doctype html>${(<Certificate data={data} />).toString()}`;
+}

--- a/src/routes/landing.tsx
+++ b/src/routes/landing.tsx
@@ -491,7 +491,7 @@ function Landing() {
         <title>Turbodiff — the software factory that built itself</title>
         <meta
           name="description"
-          content="Turbodiff is an open-source software factory whose own commit history is the pitch: features planned, built, reviewed and QC-stamped by the factory itself, with screenshot proof for every acceptance criterion. Anyone can generate code. We ship proof."
+          content="Turbodiff is an open-source software factory whose own commit history is the pitch: features planned, built, reviewed and verified by the factory itself, with screenshot proof for every acceptance criterion. Anyone can generate code. We ship proof."
         />
         <link rel="icon" type="image/png" href="/logo-small.png" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -527,23 +527,23 @@ function Landing() {
               </h1>
               <p class="sub">
                 Turbodiff is an open-source software factory &mdash; and its own commit history is
-                the pitch: the features on this site were planned, built, reviewed and QC-stamped by
-                the factory itself, with screenshot proof for every acceptance criterion. You write
-                the work order, approve the plan, and merge.
+                the pitch: the features on this site were planned, built, reviewed and verified by
+                the factory itself, with screenshot proof for every acceptance criterion. You
+                describe the feature, approve the plan, and merge the PR.
               </p>
               <p class="proof-line">Anyone can generate code. We ship proof.</p>
               <div class="ledger" aria-label="factory ledger">
                 <div class="stat">
                   <b>63%</b>
-                  <span>commits factory-authored</span>
+                  <span>commits written by agents</span>
                 </div>
                 <div class="stat">
                   <b>4 min</b>
-                  <span>human time / unit</span>
+                  <span>human time / feature</span>
                 </div>
                 <div class="stat">
-                  <b>TD-0058</b>
-                  <span>last unit &middot; qc passed</span>
+                  <b>PR #58</b>
+                  <span>last merge &middot; checks passed</span>
                 </div>
               </div>
               <div class="cta-row">
@@ -554,7 +554,7 @@ function Landing() {
                 <span class="soon">coming soon</span>
               </div>
               <span class="cta-note">
-                open source &middot; FSL-licensed &middot; every unit ships with receipts
+                open source &middot; FSL-licensed &middot; every PR ships with receipts
               </span>
             </div>
           </main>

--- a/src/routes/landing.tsx
+++ b/src/routes/landing.tsx
@@ -523,13 +523,13 @@ function Landing() {
           <main>
             <div class="hero">
               <h1>
-                This factory <em>built itself</em>.
+                Requirements in. <em>Working</em> features out.
               </h1>
               <p class="sub">
-                Turbodiff is an open-source software factory &mdash; and its own commit history is
-                the pitch: the features on this site were planned, built, reviewed and verified by
-                the factory itself, with screenshot proof for every acceptance criterion. You
-                describe the feature, approve the plan, and merge the PR.
+                Describe a feature and agents take it from there &mdash; planning against your real
+                code, building in a sandbox, reviewing, fixing, and attaching screenshot proof for
+                every acceptance criterion. You approve the plan and merge the PR. It's how
+                Turbodiff builds itself.
               </p>
               <p class="proof-line">Anyone can generate code. We ship proof.</p>
               <div class="ledger" aria-label="factory ledger">

--- a/src/routes/landing.tsx
+++ b/src/routes/landing.tsx
@@ -92,8 +92,33 @@ const CSS = `
 		color: var(--muted); max-width: 30rem; font-size: 0.95rem;
 		animation: rise 0.7s 0.24s cubic-bezier(0.2, 0.7, 0.2, 1) both;
 	}
+	.proof-line {
+		margin-top: 1.15rem;
+		font-family: "Instrument Serif", Georgia, serif; font-style: italic;
+		font-size: clamp(1.15rem, 2vw, 1.4rem); line-height: 1.3;
+		color: var(--green-bright);
+		animation: rise 0.7s 0.28s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+	}
+	.ledger {
+		display: flex; gap: clamp(1rem, 2vw, 1.5rem); flex-wrap: wrap;
+		margin-top: 1.7rem;
+		animation: rise 0.7s 0.3s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+	}
+	.ledger .stat {
+		font-family: var(--mono);
+		border-left: 2px solid rgba(63, 185, 80, 0.45);
+		padding-left: 0.7rem;
+	}
+	.ledger .stat b {
+		display: block; font-weight: 500; font-size: 1.2rem; letter-spacing: 0.02em;
+		color: var(--ink);
+	}
+	.ledger .stat span {
+		font-size: 0.62rem; letter-spacing: 0.08em; text-transform: uppercase;
+		color: var(--muted);
+	}
 	.cta-row {
-		display: flex; align-items: center; gap: 0.9rem; margin-top: 2rem; flex-wrap: wrap;
+		display: flex; align-items: center; gap: 0.9rem; margin-top: 1.9rem; flex-wrap: wrap;
 		animation: rise 0.7s 0.32s cubic-bezier(0.2, 0.7, 0.2, 1) both;
 	}
 	.cta {
@@ -158,7 +183,7 @@ const CSS = `
 		footer { margin-top: 1.5rem; padding-top: 1.5rem; gap: 0.9rem 1.4rem; padding-bottom: 0.5rem; }
 	}
 	@media (prefers-reduced-motion: reduce) {
-		header, h1, .sub, .cta-row, .cta-note, footer { animation: none; }
+		header, h1, .sub, .proof-line, .ledger, .cta-row, .cta-note, footer { animation: none; }
 		.soon::before { animation: none; }
 	}
 `;
@@ -463,10 +488,10 @@ function Landing() {
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Turbodiff — the open-source software factory</title>
+        <title>Turbodiff — the software factory that built itself</title>
         <meta
           name="description"
-          content="Turbodiff turns free-form requirements into verified pull requests: agents plan against your real code, generate the change in a sandbox, review it, fix blocking findings, and post screenshot evidence for every acceptance criterion. Open source, self-hostable, built on Cloudflare."
+          content="Turbodiff is an open-source software factory whose own commit history is the pitch: features planned, built, reviewed and QC-stamped by the factory itself, with screenshot proof for every acceptance criterion. Anyone can generate code. We ship proof."
         />
         <link rel="icon" type="image/png" href="/logo-small.png" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -498,14 +523,29 @@ function Landing() {
           <main>
             <div class="hero">
               <h1>
-                Requirements in. <em>Working</em> features out.
+                This factory <em>built itself</em>.
               </h1>
               <p class="sub">
-                Describe a feature and the factory takes over: agents plan it against your real
-                code, build it in a sandbox, review the PR, fix what's blocking, and post screenshot
-                proof for every acceptance criterion. You approve the plan and merge. Open source,
-                self-hostable &amp; built on Cloudflare.
+                Turbodiff is an open-source software factory &mdash; and its own commit history is
+                the pitch: the features on this site were planned, built, reviewed and QC-stamped by
+                the factory itself, with screenshot proof for every acceptance criterion. You write
+                the work order, approve the plan, and merge.
               </p>
+              <p class="proof-line">Anyone can generate code. We ship proof.</p>
+              <div class="ledger" aria-label="factory ledger">
+                <div class="stat">
+                  <b>63%</b>
+                  <span>commits factory-authored</span>
+                </div>
+                <div class="stat">
+                  <b>4 min</b>
+                  <span>human time / unit</span>
+                </div>
+                <div class="stat">
+                  <b>TD-0058</b>
+                  <span>last unit &middot; qc passed</span>
+                </div>
+              </div>
               <div class="cta-row">
                 <a class="cta" href={REPO_URL}>
                   <StarIcon />
@@ -514,7 +554,7 @@ function Landing() {
                 <span class="soon">coming soon</span>
               </div>
               <span class="cta-note">
-                open source &middot; FSL-licensed &middot; follow along on GitHub
+                open source &middot; FSL-licensed &middot; every unit ships with receipts
               </span>
             </div>
           </main>

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -179,6 +179,8 @@ export interface ApiFeatureDetail {
   reviews: { state: string; body: string; author: string | null }[];
   comments: ApiCockpitComment[];
   demo: { url: string; caption: string | null } | null;
+  // Public shareable "Proof of Build" page; null until a PR exists.
+  certificate_url: string | null;
   criteria: {
     text: string;
     verdict: string | null;


### PR DESCRIPTION
## What

The "proof-first" marketing angle from our brainstorm, in engineer-native language — plus a working implementation of the shareable certificate.

### Landing page (`src/routes/landing.tsx`)
- Keeps the original hero: **Requirements in. Working features out.**
- Tighter sub copy ending on the self-built hook: *"It's how Turbodiff builds itself."*
- New tagline line: *"Anyone can generate code. We ship proof."*
- New stats ledger strip: **63%** commits written by agents · **4 min** human time / feature · **PR #58** last merge, checks passed — numbers are illustrative placeholders for now; wiring them to real git/DB stats is a follow-up
- Page `<title>`/meta description carry the spicier claim ("the software factory that built itself") for link shares

### Proof of Build certificate — real, per feature
Every feature with a PR gets a public shareable certificate at `GET /b/:id`, using the same HMAC capability-URL scheme as `/artifacts/*` (the signature over `cert/<id>` is the only credential — shareable but not enumerable).

- `src/routes/certificate-page.tsx` — pure hono/jsx render: acceptance criteria with real verdicts, verification screenshot thumbnails, agent time / agent runs / fix iterations, a VERIFIED stamp when the latest verification passed (IN PROGRESS otherwise), and OG meta tags (first screenshot as `og:image`) so shared links unfurl
- `src/lib/certificate.ts` — data assembly from features, verifications, agent_runs, fix_attempts
- `src/lib/verifier.ts` — the PR verification report now links the certificate when all criteria pass
- `src/routes/api.ts` — feature detail exposes `certificate_url` for a future share button in the cockpit
- `marketing/mockups/build-certificate.html` stays as the design source

Verified: `tsc` (server + client) and `vp check` clean; page rendered from fixture data and screenshot-checked in both verified and in-progress states.

## Follow-ups (not in this PR)
- Wire landing ledger stats to real data
- Share button in the cockpit feature page (uses the new `certificate_url`)
- Dedicated OG image endpoint (1200×630 PNG) if link unfurls should show the card itself rather than a screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)