### PR TITLE
Improve acceptance criteria styling on task detail page

### DIFF
--- a/src/client/pages/task.tsx
+++ b/src/client/pages/task.tsx
@@ -220,12 +220,32 @@ export function TaskPage() {
           </div>
           {task.acceptance.length > 0 ? (
             <>
-              <div className="mt-3 text-xs text-mute">Acceptance criteria</div>
-              <ul className="mt-1 list-disc pl-5 text-[0.85rem]">
+              <SectionHeading
+                className="mt-6 mb-2"
+                aside={
+                  <span className="text-xs text-mute tabular-nums">
+                    {task.acceptance.length} to verify
+                  </span>
+                }
+              >
+                Acceptance criteria
+              </SectionHeading>
+              <ol className="divide-y divide-line/40 overflow-hidden rounded-xl border border-line/60 bg-raised/30">
                 {task.acceptance.map((a, i) => (
-                  <li key={i}>{a}</li>
+                  <li
+                    key={i}
+                    className="flex items-baseline gap-3 px-3.5 py-2.5 text-[0.85rem] leading-relaxed"
+                  >
+                    <span className="shrink-0 font-mono text-[0.68rem] tracking-wider text-accent-bright/80">
+                      AC-{String(i + 1).padStart(2, '0')}
+                    </span>
+                    <span className="min-w-0">{a}</span>
+                  </li>
                 ))}
-              </ul>
+              </ol>
+              <p className="mt-2 text-xs text-mute/70">
+                Each criterion is checked against the generated PR during verification.
+              </p>
             </>
           ) : null}
 


### PR DESCRIPTION
## What

The acceptance criteria section on the plan/task detail page was a plain `list-disc` bullet list — with the long, dense criteria the planner writes it read as a wall of text, especially on mobile.

Now each criterion is a row in a bordered card list:
- Monospace `AC-01` tag per row in the accent green (matching the `ac-nn` capture labels on the Proof of Build certificate)
- Hairline separators between rows, `SectionHeading` with an "N to verify" count aside
- Footnote linking the criteria to the verification step

One file changed: `src/client/pages/task.tsx`. Verified with client `tsc` and `vp check` (the 5 files `vp check` still flags have pre-existing formatting issues on main, untouched here); layout screenshot-checked at 390px mobile width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)