### PR TITLE
Add Worker-runtime D1 invariant tests and safe CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm vp run check:types
+
+      - name: Lint
+        run: pnpm vp lint
+
+      - name: Unit tests
+        run: pnpm test
+
+      - name: Worker and D1 integration tests
+        run: pnpm test:worker
+
+      - name: Build
+        run: pnpm vp run build
+
+      - name: Validate Worker deployment
+        run: pnpm wrangler deploy --dry-run

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
-# Production deploy: every push to main applies D1 migrations and runs the
-# same `vp run deploy` used locally (Worker + sandbox container image; the
-# runner's Docker daemon does the image build).
+# Production deploy: every push to main first passes the same quality, test,
+# build, and dry-run gates as a pull request. Only then may it apply D1
+# migrations and deploy the Worker + sandbox container image.
 #
 # Requires two repository secrets:
 #   CLOUDFLARE_API_TOKEN   — Workers Scripts:Edit, D1:Edit, Containers:Edit
@@ -17,7 +17,41 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm vp run check:types
+
+      - name: Lint
+        run: pnpm vp lint
+
+      - name: Unit tests
+        run: pnpm test
+
+      - name: Worker and D1 integration tests
+        run: pnpm test:worker
+
+      - name: Build
+        run: pnpm vp run build
+
+      - name: Validate Worker deployment
+        run: pnpm wrangler deploy --dry-run
+
   deploy:
+    needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/migrations/0029_idempotency.sql
+++ b/migrations/0029_idempotency.sql
@@ -1,0 +1,11 @@
+-- Database-backed idempotency for the two UI actions that fan out into paid
+-- factory work. A repeated/concurrent plan approval may create at most one
+-- feature per repository, and a todo may be the origin of at most one plan.
+
+CREATE UNIQUE INDEX idx_features_plan_repo ON features(plan_id, repository_id);
+
+ALTER TABLE plans ADD COLUMN todo_id INTEGER REFERENCES todos(id) ON DELETE SET NULL;
+UPDATE plans SET todo_id = (
+	SELECT id FROM todos WHERE todos.plan_id = plans.id ORDER BY id LIMIT 1
+);
+CREATE UNIQUE INDEX idx_plans_todo ON plans(todo_id);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "check": "vp check",
     "lint": "vp lint",
     "fmt": "vp fmt",
-    "test": "vp test"
+    "test": "vp test",
+    "test:worker": "vp test --config vitest.worker.config.ts"
   },
   "dependencies": {
     "@cloudflare/sandbox": "^0.12.4",
@@ -36,6 +37,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.39.2",
+    "@cloudflare/vitest-pool-workers": "^0.21.3",
     "@flue/cli": "^2.0.1",
     "@flue/vite": "^2.0.1",
     "@tailwindcss/vite": "^4.3.3",
@@ -43,11 +45,14 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",
+    "@vitest/runner": "4.1.10",
+    "@vitest/snapshot": "4.1.10",
     "esbuild": "^0.28.1",
     "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2",
     "vite": "catalog:",
     "vite-plus": "catalog:",
+    "vitest": "4.1.10",
     "wrangler": "^4.97.0"
   },
   "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,10 +248,10 @@ importers:
         version: 1.170.24(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       agents:
         specifier: ^0.14.2
-        version: 0.14.5(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260809.1)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(ai@6.0.246(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(supports-color@10.2.2)(zod@4.4.3)
+        version: 0.14.5(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260813.1)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(ai@6.0.246(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(supports-color@10.2.2)(zod@4.4.3)
       better-auth:
         specifier: ^1.6.27
-        version: 1.6.27(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+        version: 1.6.27(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -291,13 +291,16 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.39.2
-        version: 1.51.1(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(wrangler@4.120.0(@cloudflare/workers-types@5.20260809.1))
+        version: 1.51.1(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(wrangler@4.120.0(@cloudflare/workers-types@5.20260813.1))
+      '@cloudflare/vitest-pool-workers':
+        specifier: ^0.21.3
+        version: 0.21.3(@cloudflare/workers-types@5.20260813.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@flue/cli':
         specifier: ^2.0.1
-        version: 2.0.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260809.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@types/node@22.20.1)(ai@6.0.246(zod@4.4.3))(esbuild@0.28.2)(hono@4.13.1)(jiti@2.7.0)(just-bash@3.2.0(supports-color@10.2.2))(react@19.2.8)(rolldown@1.2.3)(supports-color@10.2.2)(typescript@7.0.2)(ws@8.21.3)(yaml@2.9.0)(zod@4.4.3)
+        version: 2.0.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260813.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@types/node@22.20.1)(ai@6.0.246(zod@4.4.3))(esbuild@0.28.2)(hono@4.13.1)(jiti@2.7.0)(just-bash@3.2.0(supports-color@10.2.2))(react@19.2.8)(rolldown@1.2.3)(supports-color@10.2.2)(typescript@7.0.2)(ws@8.21.3)(yaml@2.9.0)(zod@4.4.3)
       '@flue/vite':
         specifier: ^2.0.1
-        version: 2.0.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260809.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(ai@6.0.246(zod@4.4.3))(hono@4.13.1)(just-bash@3.2.0(supports-color@10.2.2))(react@19.2.8)(rolldown@1.2.3)(supports-color@10.2.2)(typescript@7.0.2)(ws@8.21.3)(zod@4.4.3)
+        version: 2.0.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260813.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(ai@6.0.246(zod@4.4.3))(hono@4.13.1)(just-bash@3.2.0(supports-color@10.2.2))(react@19.2.8)(rolldown@1.2.3)(supports-color@10.2.2)(typescript@7.0.2)(ws@8.21.3)(zod@4.4.3)
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
@@ -313,6 +316,12 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.5
         version: 6.0.5(@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(rolldown@1.2.3))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      '@vitest/runner':
+        specifier: 4.1.10
+        version: 4.1.10
+      '@vitest/snapshot':
+        specifier: 4.1.10
+        version: 4.1.10
       esbuild:
         specifier: ^0.28.1
         version: 0.28.2
@@ -328,9 +337,12 @@ importers:
       vite-plus:
         specifier: 'catalog:'
         version: 0.2.8(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
       wrangler:
         specifier: ^4.97.0
-        version: 4.120.0(@cloudflare/workers-types@5.20260809.1)
+        version: 4.120.0(@cloudflare/workers-types@5.20260813.1)
 
 packages:
 
@@ -793,8 +805,21 @@ packages:
       vite: ^6.1.0 || ^7.0.0 || ^8.0.0
       wrangler: ^4.120.0
 
+  '@cloudflare/vitest-pool-workers@0.21.3':
+    resolution: {integrity: sha512-jCoGRQ6FlsP5adp1GJISvITOGdTHTpsWOq3KkSGIfeDY/5RKjTUagDwaXjpqBXY5gAk6id/QbgnGuCTAg6lSTQ==}
+    peerDependencies:
+      '@vitest/runner': ^4.1.0
+      '@vitest/snapshot': ^4.1.0
+      vitest: ^4.1.0
+
   '@cloudflare/workerd-darwin-64@1.20260801.1':
     resolution: {integrity: sha512-wuJWbXpKvncJi1P0GKS+iYpN5tHdb7JPJJ/+6ZQe8zzovHHVMkLJPNBsgWpqeUhpM3g9qTwEKd2rglNKejuh5A==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-64@1.20260811.1':
+    resolution: {integrity: sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -805,8 +830,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-arm64@1.20260811.1':
+    resolution: {integrity: sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@cloudflare/workerd-linux-64@1.20260801.1':
     resolution: {integrity: sha512-r0vAxCZH+Jih9Unm1yoyiByPNWNgawcKciOHDm5Q37ZVGOkKLsT9AtLe3yLSaul76WrKqtf+JP2n0WW32VBLJg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-64@1.20260811.1':
+    resolution: {integrity: sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -817,14 +854,26 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260811.1':
+    resolution: {integrity: sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20260801.1':
     resolution: {integrity: sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@5.20260809.1':
-    resolution: {integrity: sha512-sBM+0I5lCY9LgTnorn/N2UyrA6KVbUzj9tncxwH8v6sH8tVeAyJj+i0z3xXWY4l4fd1oDcwt8CGf50vGwVISYQ==}
+  '@cloudflare/workerd-windows-64@1.20260811.1':
+    resolution: {integrity: sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@5.20260813.1':
+    resolution: {integrity: sha512-RQNfm7xD10hNHEQZFxQPmyGMJ9+aDGPcdFZ0x1LtmjRoLFcgZkGvfaqJAbOMQBAUFSESO3bYJS4p9mOLv28Ihg==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -3222,6 +3271,9 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -4098,6 +4150,10 @@ packages:
     resolution: {integrity: sha512-BHPVzIDA6mbx7LefxpvkXW7DHx9FKB9GorZatbnrrFTt3CVMU8zuUpbgyCuebwDKcTTOZos43ta8GQ0eMVEpxA==}
     engines: {node: '>=22.0.0'}
 
+  miniflare@5.20260811.1-alpha:
+    resolution: {integrity: sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA==}
+    engines: {node: '>=22.0.0'}
+
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
@@ -4885,12 +4941,27 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20260811.1:
+    resolution: {integrity: sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   wrangler@4.120.0:
     resolution: {integrity: sha512-cBmu/MeaB/fPacC0JpATs4duTOCagBxrZo+vBzuTX06tLzwSyAHE1drlHUZ8rP0VqVz1fy3ReGYTiHdKkoHltg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^5.20260801.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  wrangler@4.123.0:
+    resolution: {integrity: sha512-VXo2I1oa0x9aGAKIFPRSQPqTh0RBY5Ktl44YOhNmsJQFUdJKDA2vVTU6Xj+FC2koll6orJqWZN8jbXVIk9O67Q==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^5.20260811.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -5457,7 +5528,7 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0
       '@babel/helper-validator-identifier': 8.0.4
 
-  '@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)':
+  '@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)':
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
@@ -5469,39 +5540,39 @@ snapshots:
       nanostores: 1.4.2
       zod: 4.4.3
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260809.1
+      '@cloudflare/workers-types': 5.20260813.1
       '@opentelemetry/api': 1.9.0
 
-  '@better-auth/drizzle-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/drizzle-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/kysely-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
+  '@better-auth/kysely-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.5
 
-  '@better-auth/memory-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/mongo-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/prisma-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -5547,35 +5618,71 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260801.1
 
-  '@cloudflare/vite-plugin@1.51.1(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(wrangler@4.120.0(@cloudflare/workers-types@5.20260809.1))':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260811.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260811.1
+
+  '@cloudflare/vite-plugin@1.51.1(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(wrangler@4.120.0(@cloudflare/workers-types@5.20260813.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260801.1)
       miniflare: 5.20260801.1-alpha
       unenv: 2.0.0-rc.24
       vite: '@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)'
       workerd: 1.20260801.1
-      wrangler: 4.120.0(@cloudflare/workers-types@5.20260809.1)
+      wrangler: 4.120.0(@cloudflare/workers-types@5.20260813.1)
       ws: 8.21.0
     transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@cloudflare/vitest-pool-workers@0.21.3(@cloudflare/workers-types@5.20260813.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)':
+    dependencies:
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      cjs-module-lexer: 1.2.3
+      esbuild: 0.28.1
+      miniflare: 5.20260811.1-alpha
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      wrangler: 4.123.0(@cloudflare/workers-types@5.20260813.1)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
       - bufferutil
       - utf-8-validate
 
   '@cloudflare/workerd-darwin-64@1.20260801.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-64@1.20260811.1':
+    optional: true
+
   '@cloudflare/workerd-darwin-arm64@1.20260801.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260811.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260801.1':
     optional: true
 
+  '@cloudflare/workerd-linux-64@1.20260811.1':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20260801.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260811.1':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260801.1':
     optional: true
 
-  '@cloudflare/workers-types@5.20260809.1': {}
+  '@cloudflare/workerd-windows-64@1.20260811.1':
+    optional: true
+
+  '@cloudflare/workers-types@5.20260813.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -5797,10 +5904,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@flue/cli@2.0.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260809.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@types/node@22.20.1)(ai@6.0.246(zod@4.4.3))(esbuild@0.28.2)(hono@4.13.1)(jiti@2.7.0)(just-bash@3.2.0(supports-color@10.2.2))(react@19.2.8)(rolldown@1.2.3)(supports-color@10.2.2)(typescript@7.0.2)(ws@8.21.3)(yaml@2.9.0)(zod@4.4.3)':
+  '@flue/cli@2.0.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260813.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@types/node@22.20.1)(ai@6.0.246(zod@4.4.3))(esbuild@0.28.2)(hono@4.13.1)(jiti@2.7.0)(just-bash@3.2.0(supports-color@10.2.2))(react@19.2.8)(rolldown@1.2.3)(supports-color@10.2.2)(typescript@7.0.2)(ws@8.21.3)(yaml@2.9.0)(zod@4.4.3)':
     dependencies:
       '@flue/runtime': 2.0.3(patch_hash=6bfbc4c1e00a6c521d7070d99ee25af60a34df651b4b2e5814c18dfa46cc32a9)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(typescript@7.0.2)(ws@8.21.3)(zod@4.4.3)
-      '@flue/vite': 2.0.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260809.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(ai@6.0.246(zod@4.4.3))(hono@4.13.1)(just-bash@3.2.0(supports-color@10.2.2))(react@19.2.8)(rolldown@1.2.3)(supports-color@10.2.2)(typescript@7.0.2)(ws@8.21.3)(zod@4.4.3)
+      '@flue/vite': 2.0.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260813.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(ai@6.0.246(zod@4.4.3))(hono@4.13.1)(just-bash@3.2.0(supports-color@10.2.2))(react@19.2.8)(rolldown@1.2.3)(supports-color@10.2.2)(typescript@7.0.2)(ws@8.21.3)(zod@4.4.3)
       '@vercel/detect-agent': 1.2.4
       cac: 7.0.0
       minisearch: 7.2.0
@@ -5870,11 +5977,11 @@ snapshots:
       - ws
       - zod
 
-  '@flue/vite@2.0.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260809.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(ai@6.0.246(zod@4.4.3))(hono@4.13.1)(just-bash@3.2.0(supports-color@10.2.2))(react@19.2.8)(rolldown@1.2.3)(supports-color@10.2.2)(typescript@7.0.2)(ws@8.21.3)(zod@4.4.3)':
+  '@flue/vite@2.0.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260813.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(ai@6.0.246(zod@4.4.3))(hono@4.13.1)(just-bash@3.2.0(supports-color@10.2.2))(react@19.2.8)(rolldown@1.2.3)(supports-color@10.2.2)(typescript@7.0.2)(ws@8.21.3)(zod@4.4.3)':
     dependencies:
       '@flue/runtime': 2.0.3(patch_hash=6bfbc4c1e00a6c521d7070d99ee25af60a34df651b4b2e5814c18dfa46cc32a9)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(typescript@7.0.2)(ws@8.21.3)(zod@4.4.3)
       '@hono/node-server': 2.1.0(hono@4.13.1)
-      agents: 0.20.1(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260809.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(ai@6.0.246(zod@4.4.3))(just-bash@3.2.0(supports-color@10.2.2))(react@19.2.8)(rolldown@1.2.3)(zod@4.4.3)
+      agents: 0.20.1(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260813.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(ai@6.0.246(zod@4.4.3))(just-bash@3.2.0(supports-color@10.2.2))(react@19.2.8)(rolldown@1.2.3)(zod@4.4.3)
       magic-string: 1.1.0
       tinyglobby: 0.2.17
       ulidx: 2.4.1
@@ -7057,7 +7164,7 @@ snapshots:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.1)
       '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -7073,7 +7180,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -7247,7 +7354,7 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agents@0.14.5(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260809.1)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(ai@6.0.246(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(supports-color@10.2.2)(zod@4.4.3):
+  agents@0.14.5(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260813.1)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(ai@6.0.246(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(supports-color@10.2.2)(zod@4.4.3):
     dependencies:
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@8.0.1)(supports-color@10.2.2)
       '@cfworker/json-schema': 4.1.1
@@ -7260,7 +7367,7 @@ snapshots:
       just-bash: 3.2.0(supports-color@10.2.2)
       mimetext: 3.0.28
       nanoid: 5.1.16
-      partyserver: 0.5.10(@cloudflare/workers-types@5.20260809.1)
+      partyserver: 0.5.10(@cloudflare/workers-types@5.20260813.1)
       partysocket: 1.1.19(react@19.2.8)
       react: 19.2.8
       yaml: 2.9.0
@@ -7276,7 +7383,7 @@ snapshots:
       - rolldown
       - supports-color
 
-  agents@0.20.1(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260809.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(ai@6.0.246(zod@4.4.3))(just-bash@3.2.0(supports-color@10.2.2))(react@19.2.8)(rolldown@1.2.3)(zod@4.4.3):
+  agents@0.20.1(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260813.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(ai@6.0.246(zod@4.4.3))(just-bash@3.2.0(supports-color@10.2.2))(react@19.2.8)(rolldown@1.2.3)(zod@4.4.3):
     dependencies:
       '@babel/plugin-proposal-decorators': 8.0.2(@babel/core@8.0.1)
       '@cfworker/json-schema': 4.1.1
@@ -7288,7 +7395,7 @@ snapshots:
       esbuild: 0.28.2
       mimetext: 3.0.28
       nanoid: 5.1.16
-      partyserver: 0.5.10(@cloudflare/workers-types@5.20260809.1)
+      partyserver: 0.5.10(@cloudflare/workers-types@5.20260813.1)
       partysocket: 1.3.0(react@19.2.8)
       react: 19.2.8
       yaml: 2.9.0
@@ -7356,15 +7463,15 @@ snapshots:
 
   baseline-browser-mapping@2.11.13: {}
 
-  better-auth@1.6.27(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10):
+  better-auth@1.6.27(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10):
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
-      '@better-auth/drizzle-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)
-      '@better-auth/memory-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260809.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/drizzle-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)
+      '@better-auth/memory-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.3.0
@@ -7378,7 +7485,7 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -7471,6 +7578,8 @@ snapshots:
 
   chownr@1.1.4:
     optional: true
+
+  cjs-module-lexer@1.2.3: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -8573,6 +8682,18 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  miniflare@5.20260811.1-alpha:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.2
+      undici: 7.29.0
+      workerd: 1.20260811.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.6:
     dependencies:
       brace-expansion: 5.0.9
@@ -8735,9 +8856,9 @@ snapshots:
 
   partial-json@0.1.7: {}
 
-  partyserver@0.5.10(@cloudflare/workers-types@5.20260809.1):
+  partyserver@0.5.10(@cloudflare/workers-types@5.20260813.1):
     dependencies:
-      '@cloudflare/workers-types': 5.20260809.1
+      '@cloudflare/workers-types': 5.20260813.1
       nanoid: 5.1.16
 
   partysocket@1.1.19(react@19.2.8):
@@ -9443,7 +9564,7 @@ snapshots:
       oxfmt: 0.61.0(vite-plus@0.2.8(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
       oxlint: 1.76.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.8(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.8
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.8
@@ -9484,7 +9605,7 @@ snapshots:
       - vite
       - yaml
 
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
@@ -9532,7 +9653,15 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260801.1
       '@cloudflare/workerd-windows-64': 1.20260801.1
 
-  wrangler@4.120.0(@cloudflare/workers-types@5.20260809.1):
+  workerd@1.20260811.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260811.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260811.1
+      '@cloudflare/workerd-linux-64': 1.20260811.1
+      '@cloudflare/workerd-linux-arm64': 1.20260811.1
+      '@cloudflare/workerd-windows-64': 1.20260811.1
+
+  wrangler@4.120.0(@cloudflare/workers-types@5.20260813.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260801.1)
@@ -9543,7 +9672,24 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260801.1
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260809.1
+      '@cloudflare/workers-types': 5.20260813.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  wrangler@4.123.0(@cloudflare/workers-types@5.20260813.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260811.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 5.20260811.1-alpha
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260811.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 5.20260813.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,9 @@ minimumReleaseAgeExclude:
   - '@tanstack/react-router@1.170.22'
   - '@tanstack/router-core@1.171.19'
   - lucide-react@1.30.0
+  - '@cloudflare/vitest-pool-workers@0.21.3'
+  - miniflare@5.20260811.1-alpha
+  - wrangler@4.123.0
 patchedDependencies:
   '@flue/runtime': patches/@flue__runtime.patch
 catalog:

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,13 @@
+declare namespace Cloudflare {
+  interface Env {
+    CLAUDE_CODE_OAUTH_TOKEN: string;
+    FIXER_ANTHROPIC_API_KEY: string;
+    GITHUB_APP_ID: string;
+    GITHUB_APP_PRIVATE_KEY: string;
+    GITHUB_OAUTH_CLIENT_ID: string;
+    GITHUB_OAUTH_CLIENT_SECRET: string;
+    GITHUB_WEBHOOK_SECRET: string;
+    REVIEW_SECRET: string;
+    SESSION_SECRET: string;
+  }
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -690,6 +690,81 @@ export async function createFeature(
   return row!.id;
 }
 
+export interface ApprovedFeatureFields {
+  repositoryId: number;
+  title: string;
+  spec: string;
+  acceptance: string | null;
+  authorLogin: string | null;
+  authorId: number | null;
+  coauthorLogin: string | null;
+  coauthorId: number | null;
+  tier: string | null;
+}
+
+// Claims a ready plan and creates its per-repository features in one D1
+// transaction. The unique (plan_id, repository_id) index is the final guard:
+// repeated requests and concurrent isolates can never duplicate paid work.
+export async function approvePlanFeatures(
+  planId: number,
+  features: ApprovedFeatureFields[],
+): Promise<number[] | null> {
+  if (features.length === 0) return null;
+  const results = await env.DB.batch([
+    env.DB.prepare(
+      `UPDATE plans SET status = 'approving'
+		 WHERE id = ?1 AND status = 'plan_ready' AND plan IS NOT NULL
+		 RETURNING id`,
+    ).bind(planId),
+    ...features.map((feature) =>
+      env.DB.prepare(
+        `INSERT INTO features
+		   (repository_id, title, spec, acceptance, author_login, author_id,
+		    coauthor_login, coauthor_id, tier, plan_id)
+		 SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10
+		 FROM plans p
+		 JOIN plan_repositories pr ON pr.plan_id = p.id AND pr.repository_id = ?1
+		 WHERE p.id = ?10 AND p.status = 'approving'
+		 ON CONFLICT(plan_id, repository_id) DO NOTHING
+		 RETURNING id`,
+      ).bind(
+        feature.repositoryId,
+        feature.title,
+        feature.spec,
+        feature.acceptance,
+        feature.authorLogin,
+        feature.authorId,
+        feature.coauthorLogin,
+        feature.coauthorId,
+        feature.tier,
+        planId,
+      ),
+    ),
+    env.DB.prepare(
+      `UPDATE plans
+		 SET status = 'approved',
+		     feature_id = (
+		       SELECT id FROM features
+		       WHERE plan_id = ?1 AND repository_id = plans.repository_id
+		       LIMIT 1
+		     )
+		 WHERE id = ?1 AND status = 'approving'`,
+    ).bind(planId),
+  ]);
+  const claimed = (results[0].results as { id: number }[] | undefined)?.length;
+  if (!claimed) return null;
+  const rows = await env.DB.prepare(
+    `SELECT f.id FROM features f
+		 JOIN plan_repositories pr
+		   ON pr.plan_id = f.plan_id AND pr.repository_id = f.repository_id
+		 WHERE f.plan_id = ?1
+		 ORDER BY pr.position`,
+  )
+    .bind(planId)
+    .all<{ id: number }>();
+  return rows.results.map((row) => row.id);
+}
+
 export async function getFeature(id: number): Promise<FeatureRow | null> {
   return env.DB.prepare('SELECT * FROM features WHERE id = ?1').bind(id).first<FeatureRow>();
 }
@@ -765,6 +840,7 @@ export interface PlanRow {
   archived: number; // started tasks are never deleted, only hidden
   feedback: string | null; // JSON [{snippet, comment}] awaiting a revise run
   attachments: string | null; // JSON [{key, name, content_type}] in R2
+  todo_id: number | null; // unique origin todo; prevents concurrent double-start
 }
 
 // repositoryIds[0] becomes plans.repository_id (the "primary" repo — every
@@ -803,6 +879,66 @@ export async function createPlan(
     ),
   );
   return planId;
+}
+
+export interface CreatePlanForTodoResult {
+  planId: number;
+  created: boolean;
+}
+
+// Idempotent todo start. The first caller inserts the plan; concurrent or
+// repeated callers recover the existing plan through plans.todo_id. Repo links
+// and the legacy todos.plan_id pointer are then repaired idempotently, so a
+// retry also completes a partially interrupted start.
+export async function createPlanForTodo(
+  todoId: number,
+  repositoryIds: number[],
+  title: string,
+  requirements: string,
+  createdBy?: { login: string; id: number },
+  attachments?: string,
+): Promise<CreatePlanForTodoResult | null> {
+  if (repositoryIds.length === 0) return null;
+  const inserted = await env.DB.prepare(
+    `INSERT INTO plans
+		 (repository_id, title, requirements, created_by_login, created_by_id, attachments, todo_id)
+		 SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7
+		 FROM todos WHERE id = ?7 AND plan_id IS NULL
+		 ON CONFLICT(todo_id) DO NOTHING
+		 RETURNING id`,
+  )
+    .bind(
+      repositoryIds[0],
+      title,
+      requirements,
+      createdBy?.login ?? null,
+      createdBy?.id ?? null,
+      attachments ?? null,
+      todoId,
+    )
+    .first<{ id: number }>();
+  const existing = inserted
+    ? null
+    : await env.DB.prepare('SELECT id FROM plans WHERE todo_id = ?1')
+        .bind(todoId)
+        .first<{ id: number }>();
+  const planId = inserted?.id ?? existing?.id;
+  if (!planId) return null;
+
+  await env.DB.batch([
+    ...repositoryIds.map((repoId, position) =>
+      env.DB.prepare(
+        `INSERT INTO plan_repositories (plan_id, repository_id, position)
+		   VALUES (?1, ?2, ?3)
+		   ON CONFLICT(plan_id, repository_id) DO NOTHING`,
+      ).bind(planId, repoId, position),
+    ),
+    env.DB.prepare(
+      `UPDATE todos SET plan_id = ?2
+		 WHERE id = ?1 AND (plan_id IS NULL OR plan_id = ?2)`,
+    ).bind(todoId, planId),
+  ]);
+  return { planId, created: inserted !== null };
 }
 
 export async function getPlan(id: number): Promise<PlanRow | null> {

--- a/src/lib/db.worker.test.ts
+++ b/src/lib/db.worker.test.ts
@@ -1,0 +1,241 @@
+/* oxlint-disable typescript/triple-slash-reference -- generated Worker bindings */
+/// <reference path="../../worker-configuration.d.ts" />
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+
+import { env } from 'cloudflare:workers';
+import { applyD1Migrations } from 'cloudflare:test';
+import { beforeAll, beforeEach, describe, expect, it } from 'vite-plus/test';
+import type { D1Migration } from '@cloudflare/vitest-pool-workers';
+import {
+  approvePlanFeatures,
+  claimAutomation,
+  createAutomation,
+  createCockpitComment,
+  createFeature,
+  createPlan,
+  createPlanForTodo,
+  createTodo,
+  dispatchOpenCockpitComments,
+  finishFixAttempt,
+  listReposForPlan,
+  tryRecordAutomationRun,
+  tryRecordFixAttempt,
+  updatePlan,
+} from './db.ts';
+
+type TestEnv = Cloudflare.Env & { TEST_MIGRATIONS: D1Migration[] };
+const testEnv = env as TestEnv;
+
+async function seedTenant(): Promise<void> {
+  await testEnv.DB.batch([
+    testEnv.DB.prepare(
+      `INSERT INTO installations (id, account_login, account_id, account_type)
+		 VALUES (1001, 'acme', 2001, 'Organization')`,
+    ),
+    testEnv.DB.prepare(
+      `INSERT INTO repositories (id, installation_id, owner, name)
+		 VALUES (101, 1001, 'acme', 'api'), (102, 1001, 'acme', 'web')`,
+    ),
+  ]);
+}
+
+beforeAll(async () => {
+  await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+});
+
+beforeEach(async () => {
+  const tables = [
+    'agent_runs',
+    'cockpit_comments',
+    'verifications',
+    'fix_attempts',
+    'automation_runs',
+    'automations',
+    'repo_agents',
+    'repo_skills',
+    'agent_connection_links',
+    'connections',
+    'skills',
+    'agents',
+    'reviews',
+    'todo_repositories',
+    'plan_repositories',
+    'features',
+    'todos',
+    'plans',
+    'repositories',
+    'installations',
+    'session',
+    'account',
+    'verification',
+    'user',
+    'user_tokens',
+  ];
+  await testEnv.DB.batch(tables.map((table) => testEnv.DB.prepare(`DELETE FROM "${table}"`)));
+  await seedTenant();
+});
+
+describe('fix attempt invariants', () => {
+  it('admits one concurrent run and never exceeds the attempt cap', async () => {
+    const first = await Promise.all(
+      Array.from({ length: 8 }, () => tryRecordFixAttempt(101, 7, 'blocking_review', 3)),
+    );
+    expect(first.filter((id) => id !== null)).toHaveLength(1);
+
+    await finishFixAttempt(
+      first.find((id): id is number => id !== null)!,
+      'failed',
+    );
+    const second = await tryRecordFixAttempt(101, 7, 'blocking_review', 3);
+    expect(second).not.toBeNull();
+    await finishFixAttempt(second!, 'failed');
+    const third = await tryRecordFixAttempt(101, 7, 'blocking_review', 3);
+    expect(third).not.toBeNull();
+    await finishFixAttempt(third!, 'failed');
+    expect(await tryRecordFixAttempt(101, 7, 'blocking_review', 3)).toBeNull();
+
+    const count = await testEnv.DB.prepare(
+      'SELECT COUNT(*) AS count FROM fix_attempts WHERE repository_id = 101 AND pr_number = 7',
+    ).first<{ count: number }>();
+    expect(count?.count).toBe(3);
+  });
+
+  it('fails a stale run before admitting its replacement', async () => {
+    const stale = await tryRecordFixAttempt(101, 8, 'blocking_review', 3);
+    await testEnv.DB.prepare(
+      `UPDATE fix_attempts SET created_at = datetime('now', '-21 minutes') WHERE id = ?1`,
+    )
+      .bind(stale)
+      .run();
+
+    const replacement = await tryRecordFixAttempt(101, 8, 'blocking_review', 3);
+    expect(replacement).not.toBeNull();
+    expect(replacement).not.toBe(stale);
+    const old = await testEnv.DB.prepare('SELECT status, error FROM fix_attempts WHERE id = ?1')
+      .bind(stale)
+      .first<{ status: string; error: string }>();
+    expect(old).toMatchObject({ status: 'failed' });
+    expect(old?.error).toContain('stale');
+  });
+});
+
+describe('single-flight database claims', () => {
+  it('dispatches each cockpit comment exactly once under concurrent submits', async () => {
+    const featureId = await createFeature(101, 'Feature', 'Spec');
+    const commentIds = await Promise.all([
+      createCockpitComment(featureId, 'src/a.ts', 10, 'additions', 'Fix A', 'octocat', 1),
+      createCockpitComment(featureId, 'src/b.ts', 20, 'additions', 'Fix B', 'octocat', 1),
+    ]);
+
+    const claims = await Promise.all([
+      dispatchOpenCockpitComments(featureId),
+      dispatchOpenCockpitComments(featureId),
+    ]);
+    const claimedIds = claims.flat().map((comment) => comment.id);
+    expect(claimedIds.sort((a, b) => a - b)).toEqual(commentIds.sort((a, b) => a - b));
+    expect(new Set(claimedIds).size).toBe(2);
+  });
+
+  it('lets one poll claim an automation and one run enter flight', async () => {
+    const automationId = await createAutomation(
+      101,
+      {
+        name: 'Dependency update',
+        prompt: 'Update dependencies',
+        schedule_kind: 'daily',
+        time_of_day: '09:00',
+        day_of_week: null,
+      },
+      '2026-08-14 09:00:00',
+    );
+    const claims = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        claimAutomation(automationId, '2026-08-15 09:00:00', '2026-08-14 10:00:00'),
+      ),
+    );
+    expect(claims.filter(Boolean)).toHaveLength(1);
+
+    const runs = await Promise.all(
+      Array.from({ length: 8 }, () => tryRecordAutomationRun(automationId)),
+    );
+    expect(runs.filter((id) => id !== null)).toHaveLength(1);
+  });
+});
+
+describe('paid-work idempotency', () => {
+  it('starts a todo once and preserves its ordered repository set', async () => {
+    const todoId = await createTodo(1001, 'Build it', null, { login: 'octocat', id: 1 });
+    const starts = await Promise.all([
+      createPlanForTodo(todoId, [101, 102], 'Build it', 'Requirements', {
+        login: 'octocat',
+        id: 1,
+      }),
+      createPlanForTodo(todoId, [101, 102], 'Build it', 'Requirements', {
+        login: 'octocat',
+        id: 1,
+      }),
+    ]);
+
+    expect(starts.filter((result) => result?.created)).toHaveLength(1);
+    expect(new Set(starts.map((result) => result?.planId))).toHaveLength(1);
+    const planId = starts[0]!.planId;
+    const count = await testEnv.DB.prepare('SELECT COUNT(*) AS count FROM plans WHERE todo_id = ?1')
+      .bind(todoId)
+      .first<{ count: number }>();
+    const todo = await testEnv.DB.prepare('SELECT plan_id FROM todos WHERE id = ?1')
+      .bind(todoId)
+      .first<{ plan_id: number }>();
+    expect(count?.count).toBe(1);
+    expect(todo?.plan_id).toBe(planId);
+    expect((await listReposForPlan(planId)).map((repo) => repo.id)).toEqual([101, 102]);
+  });
+
+  it('approves a multi-repo plan once and creates one feature per repository', async () => {
+    const planId = await createPlan([101, 102], 'Ship feature', 'Requirements', {
+      login: 'creator',
+      id: 1,
+    });
+    await updatePlan(planId, {
+      status: 'plan_ready',
+      plan: '## acme/api\nChange API.\n\n## acme/web\nChange web.',
+      acceptance: '["The feature works"]',
+    });
+    const features = [101, 102].map((repositoryId) => ({
+      repositoryId,
+      title: 'Ship feature',
+      spec: 'Implementation spec',
+      acceptance: '["The feature works"]',
+      authorLogin: 'approver',
+      authorId: 2,
+      coauthorLogin: 'creator',
+      coauthorId: 1,
+      tier: 'standard',
+    }));
+
+    const approvals = await Promise.all([
+      approvePlanFeatures(planId, features),
+      approvePlanFeatures(planId, features),
+    ]);
+    expect(approvals.filter((ids) => ids !== null)).toHaveLength(1);
+    expect(approvals.find((ids) => ids !== null)).toHaveLength(2);
+
+    const rows = await testEnv.DB.prepare(
+      'SELECT id, repository_id FROM features WHERE plan_id = ?1 ORDER BY repository_id',
+    )
+      .bind(planId)
+      .all<{ id: number; repository_id: number }>();
+    const plan = await testEnv.DB.prepare('SELECT status, feature_id FROM plans WHERE id = ?1')
+      .bind(planId)
+      .first<{ status: string; feature_id: number }>();
+    expect(rows.results.map((row) => row.repository_id)).toEqual([101, 102]);
+    expect(plan).toMatchObject({ status: 'approved', feature_id: rows.results[0].id });
+    await expect(
+      testEnv.DB.prepare(
+        `INSERT INTO features (repository_id, title, spec, plan_id)
+		 VALUES (101, 'Duplicate', 'Must fail', ?1)`,
+      )
+        .bind(planId)
+        .run(),
+    ).rejects.toThrow(/UNIQUE constraint failed/);
+  });
+});

--- a/src/lib/migrations.worker.test.ts
+++ b/src/lib/migrations.worker.test.ts
@@ -1,0 +1,173 @@
+/* oxlint-disable typescript/triple-slash-reference -- generated Worker bindings */
+/// <reference path="../../worker-configuration.d.ts" />
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+
+import { env } from 'cloudflare:workers';
+import { applyD1Migrations } from 'cloudflare:test';
+import { describe, expect, it } from 'vite-plus/test';
+import type { D1Migration } from '@cloudflare/vitest-pool-workers';
+
+type TestEnv = Cloudflare.Env & {
+  TEST_MIGRATIONS: D1Migration[];
+  DB_MIGRATIONS_FRESH: D1Database;
+  DB_MIGRATIONS_CONNECTIONS: D1Database;
+  DB_MIGRATIONS_MULTI_REPO: D1Database;
+  DB_MIGRATIONS_IDEMPOTENCY: D1Database;
+};
+const testEnv = env as TestEnv;
+
+function migrationIndex(name: string): number {
+  const index = testEnv.TEST_MIGRATIONS.findIndex((migration) => migration.name === name);
+  if (index === -1) throw new Error(`migration fixture not found: ${name}`);
+  return index;
+}
+
+async function applyBefore(db: D1Database, name: string): Promise<number> {
+  const index = migrationIndex(name);
+  await applyD1Migrations(db, testEnv.TEST_MIGRATIONS.slice(0, index));
+  return index;
+}
+
+describe('D1 migrations', () => {
+  it('builds the complete production schema from an empty database', async () => {
+    const db = testEnv.DB_MIGRATIONS_FRESH;
+    await applyD1Migrations(db, testEnv.TEST_MIGRATIONS);
+
+    const schema = await db
+      .prepare(
+        `SELECT name FROM sqlite_master
+		 WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+		 ORDER BY name`,
+      )
+      .all<{ name: string }>();
+    const names = schema.results.map((row) => row.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'account',
+        'agent_runs',
+        'automations',
+        'automation_runs',
+        'connections',
+        'features',
+        'plans',
+        'repositories',
+        'reviews',
+        'session',
+        'todos',
+        'user',
+        'verifications',
+      ]),
+    );
+    const applied = await db.prepare('SELECT COUNT(*) AS count FROM d1_migrations').first<{
+      count: number;
+    }>();
+    expect(applied?.count).toBe(testEnv.TEST_MIGRATIONS.length);
+  });
+
+  it('preserves legacy agent connections while moving them to the registry', async () => {
+    const db = testEnv.DB_MIGRATIONS_CONNECTIONS;
+    const start = await applyBefore(db, '0022_board_and_integrations.sql');
+    await db.batch([
+      db.prepare(
+        `INSERT INTO installations (id, account_login, account_id, account_type)
+		 VALUES (1001, 'acme', 2001, 'Organization')`,
+      ),
+      db.prepare(
+        `INSERT INTO agents (id, installation_id, slug, name, instructions)
+		 VALUES (11, 1001, 'review', 'Review', 'Review the change')`,
+      ),
+      db.prepare(
+        `INSERT INTO agent_connections
+		 (id, agent_id, name, url, tool_allowlist, auth_ciphertext, optional)
+		 VALUES (21, 11, 'catalog', 'https://mcp.example.test', '["search"]', 'sealed', 0)`,
+      ),
+    ]);
+
+    await applyD1Migrations(db, testEnv.TEST_MIGRATIONS.slice(start));
+
+    const connection = await db
+      .prepare(
+        `SELECT c.*, l.agent_id FROM connections c
+		 JOIN agent_connection_links l ON l.connection_id = c.id`,
+      )
+      .first<{ name: string; auth_ciphertext: string; optional: number; agent_id: number }>();
+    expect(connection).toMatchObject({
+      name: 'catalog',
+      auth_ciphertext: 'sealed',
+      optional: 0,
+      agent_id: 11,
+    });
+  });
+
+  it('backfills multi-repo ownership for existing plans and features', async () => {
+    const db = testEnv.DB_MIGRATIONS_MULTI_REPO;
+    const start = await applyBefore(db, '0024_multi_repo_tasks.sql');
+    await db.batch([
+      db.prepare(
+        `INSERT INTO installations (id, account_login, account_id, account_type)
+		 VALUES (1001, 'acme', 2001, 'Organization')`,
+      ),
+      db.prepare(
+        `INSERT INTO repositories (id, installation_id, owner, name)
+		 VALUES (101, 1001, 'acme', 'api')`,
+      ),
+      db.prepare(
+        `INSERT INTO features (id, repository_id, title, spec)
+		 VALUES (301, 101, 'Existing feature', 'Existing spec')`,
+      ),
+      db.prepare(
+        `INSERT INTO plans (id, repository_id, title, requirements, feature_id, status)
+		 VALUES (201, 101, 'Existing plan', 'Existing requirements', 301, 'approved')`,
+      ),
+    ]);
+
+    await applyD1Migrations(db, testEnv.TEST_MIGRATIONS.slice(start));
+
+    const repoLink = await db
+      .prepare('SELECT repository_id, position FROM plan_repositories WHERE plan_id = 201')
+      .first<{ repository_id: number; position: number }>();
+    const feature = await db.prepare('SELECT plan_id FROM features WHERE id = 301').first<{
+      plan_id: number;
+    }>();
+    expect(repoLink).toEqual({ repository_id: 101, position: 0 });
+    expect(feature?.plan_id).toBe(201);
+  });
+
+  it('backfills a todo origin and enforces one plan per todo', async () => {
+    const db = testEnv.DB_MIGRATIONS_IDEMPOTENCY;
+    const start = await applyBefore(db, '0029_idempotency.sql');
+    await db.batch([
+      db.prepare(
+        `INSERT INTO installations (id, account_login, account_id, account_type)
+		 VALUES (1001, 'acme', 2001, 'Organization')`,
+      ),
+      db.prepare(
+        `INSERT INTO repositories (id, installation_id, owner, name)
+		 VALUES (101, 1001, 'acme', 'api')`,
+      ),
+      db.prepare(
+        `INSERT INTO plans (id, repository_id, title, requirements)
+		 VALUES (201, 101, 'Existing plan', 'Existing requirements')`,
+      ),
+      db.prepare(
+        `INSERT INTO todos (id, installation_id, title, plan_id)
+		 VALUES (401, 1001, 'Existing todo', 201)`,
+      ),
+    ]);
+
+    await applyD1Migrations(db, testEnv.TEST_MIGRATIONS.slice(start));
+
+    const plan = await db.prepare('SELECT todo_id FROM plans WHERE id = 201').first<{
+      todo_id: number;
+    }>();
+    expect(plan?.todo_id).toBe(401);
+    await expect(
+      db
+        .prepare(
+          `INSERT INTO plans (repository_id, title, requirements, todo_id)
+		 VALUES (101, 'Duplicate', 'Must fail', 401)`,
+        )
+        .run(),
+    ).rejects.toThrow(/UNIQUE constraint failed/);
+  });
+});

--- a/src/lib/planner.ts
+++ b/src/lib/planner.ts
@@ -4,7 +4,7 @@ import type { ApiPlanQuestion as Question } from '../shared/api-types.ts';
 import { gh } from '../tools/github.ts';
 import { signArtifactKey } from './crypto.ts';
 import {
-  createFeature,
+  approvePlanFeatures,
   getPlan,
   listReposForPlan,
   updatePlan,
@@ -529,20 +529,18 @@ export async function approvePlan(
   // Criteria travel structured (not only embedded in the spec text) so the
   // verify step can check them one by one after generation. Each repo's
   // feature is fully independent — one failing never blocks the others.
-  const featureIds = await Promise.all(
-    repos.map((repo) =>
-      createFeature(
-        repo.id,
-        plan.title,
-        spec,
-        plan.acceptance ?? undefined,
-        author,
-        coauthor,
-        plan.tier ?? undefined,
-        plan.id,
-      ),
-    ),
+  return approvePlanFeatures(
+    planId,
+    repos.map((repo) => ({
+      repositoryId: repo.id,
+      title: plan.title,
+      spec,
+      acceptance: plan.acceptance,
+      authorLogin: author?.login ?? null,
+      authorId: author?.id ?? null,
+      coauthorLogin: coauthor?.login ?? null,
+      coauthorId: coauthor?.id ?? null,
+      tier: plan.tier,
+    })),
   );
-  await updatePlan(planId, { status: 'approved', featureId: featureIds[0] });
-  return featureIds;
 }

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -8,7 +8,7 @@ import {
   createAutomation,
   createCockpitComment,
   createConnection,
-  createPlan,
+  createPlanForTodo,
   createSkill,
   createTodo,
   dashboardStats,
@@ -37,7 +37,6 @@ import {
   getPlanByFeatureId,
   getRepoById,
   latestVerificationForFeature,
-  linkTodoToPlan,
   listAgentConnections,
   listAgentRunsForAutomationRun,
   listAgentRunsForFeature,
@@ -711,16 +710,18 @@ export function createApiRoutes() {
       .filter((a) => a.key.startsWith('plan-uploads/'))
       .slice(0, 5);
     const { session } = c.get('user');
-    const planId = await createPlan(
+    const started = await createPlanForTodo(
+      todo.id,
       repos.map((r) => r.id),
       title,
       requirements,
       { login: session.login, id: session.userId },
       attachments.length > 0 ? JSON.stringify(attachments) : undefined,
     );
-    await linkTodoToPlan(todo.id, planId);
-    await env.FACTORY_QUEUE.send({ kind: 'plan_analyze', planId });
-    return c.json({ ok: true, plan_id: planId });
+    if (!started) return c.json({ error: 'todo could not be started' }, 409);
+    if (!started.created) return c.json({ error: 'already started' }, 409);
+    await env.FACTORY_QUEUE.send({ kind: 'plan_analyze', planId: started.planId });
+    return c.json({ ok: true, plan_id: started.planId });
   });
 
   // Task detail for the board's compact cards.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "noEmit": true
   },
   "include": ["src", "worker-configuration.d.ts"],
-  "exclude": ["src/client"]
+  "exclude": ["src/client", "src/**/*.worker.test.ts"]
 }

--- a/tsconfig.worker-tests.json
+++ b/tsconfig.worker-tests.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "@cloudflare/vitest-pool-workers/types"]
+  },
+  "include": ["worker-configuration.d.ts", "src/env.d.ts", "src/**/*.worker.test.ts"],
+  "exclude": []
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,7 +33,10 @@ export default defineConfig({
       dev: { command: 'vp dev', dependsOn: ['build:app'] },
       build: { command: 'vp build', dependsOn: ['build:app'] },
       deploy: { command: 'wrangler deploy', dependsOn: ['build'] },
-      'check:types': { command: 'tsc --noEmit && tsc -p tsconfig.client.json --noEmit' },
+      'check:types': {
+        command:
+          'wrangler types && tsc --noEmit && tsc -p tsconfig.client.json --noEmit && tsc -p tsconfig.worker-tests.json --noEmit',
+      },
     },
   },
   // Tests live in vitest.config.ts (plugin-free) — see the note there.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,5 +9,6 @@ import { defineConfig } from 'vite-plus/test/config';
 export default defineConfig({
   test: {
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    exclude: ['src/**/*.worker.test.ts'],
   },
 });

--- a/vitest.worker.config.ts
+++ b/vitest.worker.config.ts
@@ -1,0 +1,17 @@
+import path from 'node:path';
+import { cloudflareTest, readD1Migrations } from '@cloudflare/vitest-pool-workers';
+import { defineConfig } from 'vite-plus/test/config';
+
+const migrations = await readD1Migrations(path.resolve('migrations'));
+
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      wrangler: { configPath: './wrangler.test.jsonc' },
+      miniflare: { bindings: { TEST_MIGRATIONS: migrations } },
+    }),
+  ],
+  test: {
+    include: ['src/**/*.worker.test.ts'],
+  },
+});

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -1,0 +1,34 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "turbodiff-tests",
+  "compatibility_date": "2026-06-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "turbodiff-tests",
+      "database_id": "00000000-0000-0000-0000-000000000001",
+      "migrations_dir": "migrations",
+    },
+    {
+      "binding": "DB_MIGRATIONS_FRESH",
+      "database_name": "turbodiff-tests-migrations-fresh",
+      "database_id": "00000000-0000-0000-0000-000000000002",
+    },
+    {
+      "binding": "DB_MIGRATIONS_CONNECTIONS",
+      "database_name": "turbodiff-tests-migrations-connections",
+      "database_id": "00000000-0000-0000-0000-000000000003",
+    },
+    {
+      "binding": "DB_MIGRATIONS_MULTI_REPO",
+      "database_name": "turbodiff-tests-migrations-multi-repo",
+      "database_id": "00000000-0000-0000-0000-000000000004",
+    },
+    {
+      "binding": "DB_MIGRATIONS_IDEMPOTENCY",
+      "database_name": "turbodiff-tests-migrations-idempotency",
+      "database_id": "00000000-0000-0000-0000-000000000005",
+    },
+  ],
+}


### PR DESCRIPTION
## Summary

- add a Cloudflare Workers Vitest runtime backed by isolated Miniflare D1 bindings
- exercise the full migration chain plus representative upgrades from pre-registry, pre-multi-repo, and pre-idempotency schemas
- test the concurrency invariants that protect fix attempts, cockpit dispatch, automation claims/runs, todo starts, and plan approval
- enforce one plan per todo and one feature per plan/repository in D1
- make todo start and plan approval atomic/idempotent so concurrent requests cannot duplicate paid work
- add PR validation and gate production migrations/deploys behind types, lint, unit tests, Worker/D1 tests, build, and a Wrangler deploy dry run

## Test plan

- `pnpm vp run check:types`
- `pnpm vp lint`
- `pnpm test` — 24 tests
- `pnpm test:worker` — 10 tests
- `pnpm vp run build`
- `pnpm wrangler deploy --dry-run`
