### PR TITLE
Add webhook and authenticated API scenarios

### DIFF
--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -452,13 +452,21 @@ async function authorizedAutomation(c: Context<ApiEnv>): Promise<AutomationRow |
 async function requireRepoPush(
   c: Context<ApiEnv>,
   repo: { owner: string; name: string },
+  canPush: typeof userCanPushToRepo,
 ): Promise<Response | null> {
-  if (await userCanPushToRepo(c.get('user'), repo.owner, repo.name)) return null;
+  if (await canPush(c.get('user'), repo.owner, repo.name)) return null;
   return c.json({ error: 'push access to the repository is required for this action' }, 403);
 }
 
-export function createApiRoutes() {
+export interface ApiRouteDependencies {
+  authenticate?: typeof requireUser;
+  canPushToRepo?: typeof userCanPushToRepo;
+}
+
+export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
   const app = new Hono<ApiEnv>();
+  const authenticate = dependencies.authenticate ?? requireUser;
+  const canPushToRepo = dependencies.canPushToRepo ?? userCanPushToRepo;
 
   // CSRF gate for the cookie-authed data plane: browsers attach Origin to
   // every POST (same-origin and cross-site alike), so a mismatched Origin is
@@ -478,7 +486,7 @@ export function createApiRoutes() {
   });
 
   app.use('*', async (c, next) => {
-    const user = await requireUser(c);
+    const user = await authenticate(c);
     if (!user) return c.json({ error: 'unauthorized' }, 401);
     c.set('user', user);
     await next();
@@ -1019,7 +1027,7 @@ export function createApiRoutes() {
     // The fix run pushes commits to the PR branch with a write-scoped token
     // and executes the repo's check command — dispatching it requires the
     // same push permission GitHub would demand to push those commits.
-    const denied = await requireRepoPush(c, repo);
+    const denied = await requireRepoPush(c, repo, canPushToRepo);
     if (denied) return denied;
     const claimed = await dispatchOpenCockpitComments(feature.id);
     if (claimed.length === 0) {
@@ -1142,7 +1150,7 @@ export function createApiRoutes() {
       return c.json({ error: 'unknown feature' }, 404);
     }
     if (!feature.pr_number) return c.json({ error: 'no pull request yet' }, 409);
-    const denied = await requireRepoPush(c, repo);
+    const denied = await requireRepoPush(c, repo, canPushToRepo);
     if (denied) return denied;
     const appToken = await installationToken(repo.installation_id);
     const mergeability = await checkMergeability(
@@ -1209,7 +1217,7 @@ export function createApiRoutes() {
     if (!feature.pr_number) return c.json({ error: 'no pull request yet' }, 409);
     // Same bar as Merge: closing PRs and deleting branches via the App-token
     // fallback must not exceed what GitHub lets the caller do directly.
-    const denied = await requireRepoPush(c, repo);
+    const denied = await requireRepoPush(c, repo, canPushToRepo);
     if (denied) return denied;
     const appToken = await installationToken(repo.installation_id);
     const userToken = c.get('user').session.ghToken;
@@ -2021,7 +2029,7 @@ export function createApiRoutes() {
   app.patch('/repos/:id', async (c) => {
     const repo = await authorizedRepo(c);
     if (!repo) return c.json({ error: 'unknown repository' }, 404);
-    const denied = await requireRepoPush(c, repo);
+    const denied = await requireRepoPush(c, repo, canPushToRepo);
     if (denied) return denied;
     const body = await c.req
       .json<{
@@ -2054,7 +2062,7 @@ export function createApiRoutes() {
   app.put('/repos/:id/agents/:agentId', async (c) => {
     const repo = await authorizedRepo(c);
     if (!repo) return c.json({ error: 'unknown repository' }, 404);
-    const denied = await requireRepoPush(c, repo);
+    const denied = await requireRepoPush(c, repo, canPushToRepo);
     if (denied) return denied;
     const agentId = Number(c.req.param('agentId'));
     const agent = Number.isInteger(agentId) ? await getAgentById(agentId) : null;
@@ -2072,7 +2080,7 @@ export function createApiRoutes() {
   app.put('/repos/:id/skills/:skillId', async (c) => {
     const repo = await authorizedRepo(c);
     if (!repo) return c.json({ error: 'unknown repository' }, 404);
-    const denied = await requireRepoPush(c, repo);
+    const denied = await requireRepoPush(c, repo, canPushToRepo);
     if (denied) return denied;
     const skillId = Number(c.req.param('skillId'));
     const skill = Number.isInteger(skillId) ? await getSkillById(skillId) : null;

--- a/src/routes/api.worker.test.ts
+++ b/src/routes/api.worker.test.ts
@@ -1,0 +1,209 @@
+/* oxlint-disable typescript/triple-slash-reference -- generated Worker bindings */
+/// <reference path="../../worker-configuration.d.ts" />
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+
+import type { D1Migration } from '@cloudflare/vitest-pool-workers';
+import { env } from 'cloudflare:workers';
+import { applyD1Migrations } from 'cloudflare:test';
+import { Hono } from 'hono';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import type { AuthedUser } from '../lib/auth.ts';
+import type { ApiBoard } from '../shared/api-types.ts';
+import { createApiRoutes, type ApiRouteDependencies } from './api.ts';
+
+type TestEnv = Cloudflare.Env & { TEST_MIGRATIONS: D1Migration[] };
+type Authenticate = NonNullable<ApiRouteDependencies['authenticate']>;
+const testEnv = env as TestEnv;
+
+const acmeUser: AuthedUser = {
+  session: { userId: 3001, login: 'octocat', ghToken: 'test-user-token' },
+  installationIds: [1001],
+};
+
+function apiApp(dependencies: ApiRouteDependencies = {}) {
+  const app = new Hono();
+  app.route('/api', createApiRoutes(dependencies));
+  return app;
+}
+
+function authenticatedApi(canPush = async () => true) {
+  return apiApp({
+    authenticate: async () => acmeUser,
+    canPushToRepo: canPush,
+  });
+}
+
+async function seedTenants(): Promise<void> {
+  await testEnv.DB.batch([
+    testEnv.DB.prepare(
+      `INSERT INTO installations (id, account_login, account_id, account_type)
+		 VALUES (1001, 'acme', 2001, 'Organization'),
+		        (2002, 'other', 2002, 'Organization')`,
+    ),
+    testEnv.DB.prepare(
+      `INSERT INTO repositories (id, installation_id, owner, name)
+		 VALUES (101, 1001, 'acme', 'api'),
+		        (202, 2002, 'other', 'private')`,
+    ),
+    testEnv.DB.prepare(
+      `INSERT INTO todos (id, installation_id, title, created_by_login, created_by_id)
+		 VALUES (401, 1001, 'Acme backlog', 'octocat', 3001),
+		        (402, 2002, 'Other backlog', 'someone-else', 4001)`,
+    ),
+    testEnv.DB.prepare(
+      `INSERT INTO todo_repositories (todo_id, repository_id, position)
+		 VALUES (401, 101, 0), (402, 202, 0)`,
+    ),
+  ]);
+}
+
+beforeAll(async () => {
+  await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+});
+
+beforeEach(async () => {
+  const tables = [
+    'todo_repositories',
+    'todos',
+    'repo_agents',
+    'agents',
+    'repositories',
+    'installations',
+    'session',
+    'account',
+    'user',
+  ];
+  await testEnv.DB.batch(tables.map((table) => testEnv.DB.prepare(`DELETE FROM "${table}"`)));
+  await seedTenants();
+});
+
+describe('API authentication and CSRF', () => {
+  it('rejects a request without a durable session', async () => {
+    const response = await apiApp().request('https://turbodiff.test/api/me');
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'unauthorized' });
+  });
+
+  it('rejects a cross-origin mutation before invoking authentication', async () => {
+    const authenticate = vi.fn<Authenticate>(async () => acmeUser);
+    const response = await apiApp({ authenticate }).request('https://turbodiff.test/api/todos', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'https://attacker.example',
+      },
+      body: JSON.stringify({ title: 'Forged request' }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: 'cross-origin request rejected' });
+    expect(authenticate).not.toHaveBeenCalled();
+  });
+});
+
+describe('authenticated tenant isolation', () => {
+  it('returns only installations, repositories, and todos owned by the caller', async () => {
+    const response = await authenticatedApi().request('https://turbodiff.test/api/board');
+    expect(response.status).toBe(200);
+    const board = (await response.json()) as ApiBoard;
+
+    expect(board.installations).toEqual([{ id: 1001, account_login: 'acme' }]);
+    expect(board.repos.map((repo) => repo.id)).toEqual([101]);
+    expect(board.todos.map((todo) => todo.id)).toEqual([401]);
+  });
+
+  it('rejects foreign todo inputs and attributes an accepted todo to the session user', async () => {
+    const app = authenticatedApi();
+    const foreignInstallation = await app.request('https://turbodiff.test/api/todos', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ installation_id: 2002, title: 'Cross-tenant todo' }),
+    });
+    expect(foreignInstallation.status).toBe(404);
+
+    const foreignRepo = await app.request('https://turbodiff.test/api/todos', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        installation_id: 1001,
+        title: 'Cross-tenant repo',
+        repository_ids: [202],
+      }),
+    });
+    expect(foreignRepo.status).toBe(400);
+
+    const accepted = await app.request('https://turbodiff.test/api/todos', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        installation_id: 1001,
+        title: 'Owned todo',
+        repository_ids: [101],
+      }),
+    });
+    expect(accepted.status).toBe(200);
+    const created = await testEnv.DB.prepare(
+      `SELECT installation_id, created_by_login, created_by_id
+		 FROM todos WHERE title = 'Owned todo'`,
+    ).first<{ installation_id: number; created_by_login: string; created_by_id: number }>();
+    expect(created).toEqual({
+      installation_id: 1001,
+      created_by_login: 'octocat',
+      created_by_id: 3001,
+    });
+  });
+
+  it('conceals and preserves a foreign todo during deletion', async () => {
+    const app = authenticatedApi();
+    const foreign = await app.request('https://turbodiff.test/api/todos/402', {
+      method: 'DELETE',
+    });
+    expect(foreign.status).toBe(404);
+    expect(
+      await testEnv.DB.prepare('SELECT id FROM todos WHERE id = 402').first<{ id: number }>(),
+    ).toEqual({ id: 402 });
+
+    const owned = await app.request('https://turbodiff.test/api/todos/401', {
+      method: 'DELETE',
+    });
+    expect(owned.status).toBe(200);
+    expect(await testEnv.DB.prepare('SELECT id FROM todos WHERE id = 401').first()).toBeNull();
+  });
+
+  it('checks ownership before push permission and requires both to mutate repo posture', async () => {
+    const canPush = vi.fn(async () => false);
+    const denied = await authenticatedApi(canPush).request('https://turbodiff.test/api/repos/101', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(denied.status).toBe(403);
+    expect(canPush).toHaveBeenCalledWith(acmeUser, 'acme', 'api');
+
+    canPush.mockClear();
+    const foreign = await authenticatedApi(canPush).request(
+      'https://turbodiff.test/api/repos/202',
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: false }),
+      },
+    );
+    expect(foreign.status).toBe(404);
+    expect(canPush).not.toHaveBeenCalled();
+
+    const allowed = await authenticatedApi(async () => true).request(
+      'https://turbodiff.test/api/repos/101',
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: false }),
+      },
+    );
+    expect(allowed.status).toBe(200);
+    const repo = await testEnv.DB.prepare('SELECT enabled FROM repositories WHERE id = 101').first<{
+      enabled: number;
+    }>();
+    expect(repo?.enabled).toBe(0);
+  });
+});

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -82,10 +82,18 @@ export type ReviewDispatcher = (
   opts?: { riskTier?: string; modelOverride?: string },
 ) => Promise<boolean>;
 
+export interface WebhookRouteDependencies {
+  computeRisk?: typeof computeRiskTier;
+}
+
 // A Hono sub-app; the caller supplies dispatch so this module doesn't need to
 // know about the agent router.
-export function createWebhookRoutes(dispatch: ReviewDispatcher) {
+export function createWebhookRoutes(
+  dispatch: ReviewDispatcher,
+  dependencies: WebhookRouteDependencies = {},
+) {
   const app = new Hono();
+  const computeRisk = dependencies.computeRisk ?? computeRiskTier;
 
   app.post('/github', async (c) => {
     const rawBody = await c.req.arrayBuffer();
@@ -94,7 +102,7 @@ export function createWebhookRoutes(dispatch: ReviewDispatcher) {
 
     const event = c.req.header('x-github-event') ?? '';
     const payload = JSON.parse(new TextDecoder().decode(rawBody));
-    const result = await handleEvent(event, payload, dispatch);
+    const result = await handleEvent(event, payload, dispatch, computeRisk);
     return c.json(result.body, result.status ?? 200);
   });
 
@@ -105,6 +113,7 @@ async function handleEvent(
   event: string,
   payload: unknown,
   dispatch: ReviewDispatcher,
+  computeRisk: typeof computeRiskTier,
 ): Promise<HandlerResult> {
   switch (event) {
     case 'installation':
@@ -112,7 +121,7 @@ async function handleEvent(
     case 'installation_repositories':
       return handleInstallationRepositories(payload as InstallationEvent);
     case 'pull_request':
-      return handlePullRequest(payload as PullRequestEvent, dispatch);
+      return handlePullRequest(payload as PullRequestEvent, dispatch, computeRisk);
     case 'pull_request_review':
       return handlePullRequestReview(payload as PullRequestReviewEvent);
     case 'repository': {
@@ -170,6 +179,7 @@ const PUSH_DEBOUNCE_MINUTES = 10;
 async function handlePullRequest(
   p: PullRequestEvent,
   dispatch: ReviewDispatcher,
+  computeRisk: typeof computeRiskTier,
 ): Promise<HandlerResult> {
   // Closed factory PRs feed the board's Done column: merged -> 'merged',
   // closed-unmerged -> 'pr_closed'. GitHub fires this for every merge path
@@ -224,7 +234,7 @@ async function handlePullRequest(
   // open to 'full' — a tiering hiccup must widen review, never skip it.
   let tier: RiskTier = 'full';
   try {
-    tier = await computeRiskTier(repo.installation_id, repo.owner, repo.name, p.number);
+    tier = await computeRisk(repo.installation_id, repo.owner, repo.name, p.number);
   } catch (err) {
     console.warn(
       `turbodiff: risk tier computation failed for ${p.repository.full_name}#${p.number}, defaulting to full:`,

--- a/src/routes/webhooks.worker.test.ts
+++ b/src/routes/webhooks.worker.test.ts
@@ -1,0 +1,242 @@
+/* oxlint-disable typescript/triple-slash-reference -- generated Worker bindings */
+/// <reference path="../../worker-configuration.d.ts" />
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+
+import type { D1Migration } from '@cloudflare/vitest-pool-workers';
+import { env } from 'cloudflare:workers';
+import { applyD1Migrations } from 'cloudflare:test';
+import { Hono } from 'hono';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import {
+  createFeature,
+  ensureBuiltinAgents,
+  getFeature,
+  recordReview,
+  updateFeature,
+  type AgentRow,
+  type RepositoryRow,
+} from '../lib/db.ts';
+import { createWebhookRoutes, type ReviewDispatcher } from './webhooks.ts';
+
+type TestEnv = Cloudflare.Env & {
+  TEST_MIGRATIONS: D1Migration[];
+  GITHUB_WEBHOOK_SECRET: string;
+};
+const testEnv = env as TestEnv;
+
+function webhookApp(dispatch: ReviewDispatcher = async () => true) {
+  const app = new Hono();
+  app.route('/webhooks', createWebhookRoutes(dispatch, { computeRisk: async () => 'full' }));
+  return app;
+}
+
+async function signature(body: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(testEnv.GITHUB_WEBHOOK_SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const bytes = new Uint8Array(
+    await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(body)),
+  );
+  return `sha256=${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+async function postWebhook(
+  app: Hono,
+  event: string,
+  payload: Record<string, unknown>,
+): Promise<Response> {
+  const body = JSON.stringify(payload);
+  return app.request('https://turbodiff.test/webhooks/github', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-github-event': event,
+      'x-hub-signature-256': await signature(body),
+    },
+    body,
+  });
+}
+
+async function seedRepo(): Promise<void> {
+  await testEnv.DB.batch([
+    testEnv.DB.prepare(
+      `INSERT INTO installations (id, account_login, account_id, account_type)
+		 VALUES (1001, 'acme', 2001, 'Organization')`,
+    ),
+    testEnv.DB.prepare(
+      `INSERT INTO repositories (id, installation_id, owner, name, review_on_push)
+		 VALUES (101, 1001, 'acme', 'api', 1)`,
+    ),
+  ]);
+}
+
+beforeAll(async () => {
+  await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+});
+
+beforeEach(async () => {
+  const tables = [
+    'agent_runs',
+    'reviews',
+    'repo_agents',
+    'agents',
+    'verifications',
+    'features',
+    'plan_repositories',
+    'plans',
+    'repositories',
+    'installations',
+  ];
+  await testEnv.DB.batch(tables.map((table) => testEnv.DB.prepare(`DELETE FROM "${table}"`)));
+});
+
+describe('GitHub webhook authentication and mirroring', () => {
+  it('rejects an invalid signature without mutating D1', async () => {
+    const payload = {
+      action: 'created',
+      installation: {
+        id: 1001,
+        account: { login: 'acme', id: 2001, type: 'Organization' },
+      },
+      repositories: [{ id: 101, name: 'api', full_name: 'acme/api' }],
+    };
+    const response = await webhookApp().request('https://turbodiff.test/webhooks/github', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-github-event': 'installation',
+        'x-hub-signature-256': 'sha256=invalid',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    expect(response.status).toBe(401);
+    expect(
+      await testEnv.DB.prepare('SELECT COUNT(*) AS n FROM installations').first<{ n: number }>(),
+    ).toMatchObject({ n: 0 });
+  });
+
+  it('mirrors an installation idempotently and applies suspension changes', async () => {
+    const created = {
+      action: 'created',
+      installation: {
+        id: 1001,
+        account: { login: 'acme', id: 2001, type: 'Organization' },
+      },
+      repositories: [{ id: 101, name: 'api', full_name: 'acme/api' }],
+    };
+    expect((await postWebhook(webhookApp(), 'installation', created)).status).toBe(200);
+    expect((await postWebhook(webhookApp(), 'installation', created)).status).toBe(200);
+
+    const counts = await testEnv.DB.batch([
+      testEnv.DB.prepare('SELECT COUNT(*) AS n FROM installations'),
+      testEnv.DB.prepare('SELECT COUNT(*) AS n FROM repositories'),
+      testEnv.DB.prepare('SELECT COUNT(*) AS n FROM agents'),
+    ]);
+    expect(counts.map((result) => (result.results[0] as { n: number }).n)).toEqual([1, 1, 4]);
+
+    const suspended = {
+      action: 'suspend',
+      installation: created.installation,
+    };
+    expect((await postWebhook(webhookApp(), 'installation', suspended)).status).toBe(200);
+    const installation = await testEnv.DB.prepare(
+      'SELECT suspended FROM installations WHERE id = 1001',
+    ).first<{ suspended: number }>();
+    expect(installation?.suspended).toBe(1);
+  });
+});
+
+describe('factory PR webhook decisions', () => {
+  it('never dispatches a human-opened pull request', async () => {
+    await seedRepo();
+    const dispatch = vi.fn<ReviewDispatcher>(async () => true);
+    const response = await postWebhook(webhookApp(dispatch), 'pull_request', {
+      action: 'opened',
+      number: 42,
+      pull_request: {
+        draft: false,
+        html_url: 'https://github.com/acme/api/pull/42',
+      },
+      repository: { id: 101, full_name: 'acme/api' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ skipped: 'not a factory PR' });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('dispatches a factory PR once and debounces a push while its review is active', async () => {
+    await seedRepo();
+    await ensureBuiltinAgents(1001);
+    const featureId = await createFeature(101, 'Factory feature', 'Implementation spec');
+    await updateFeature(featureId, { status: 'pr_opened', prNumber: 42 });
+
+    const calls: { agent: AgentRow; repo: RepositoryRow; trigger: string }[] = [];
+    const dispatch: ReviewDispatcher = async (agent, repo, prNumber, _url, trigger, options) => {
+      calls.push({ agent, repo, trigger });
+      await recordReview(
+        repo.id,
+        repo.installation_id,
+        prNumber,
+        trigger,
+        agent.slug,
+        `${agent.slug}--${repo.owner}--${repo.name}--${prNumber}`,
+        options?.riskTier ?? null,
+      );
+      return true;
+    };
+    const opened = {
+      action: 'opened',
+      number: 42,
+      pull_request: {
+        draft: false,
+        html_url: 'https://github.com/acme/api/pull/42',
+      },
+      repository: { id: 101, full_name: 'acme/api' },
+    };
+    const openedResponse = await postWebhook(webhookApp(dispatch), 'pull_request', opened);
+    expect(await openedResponse.json()).toMatchObject({ tier: 'full', agents: ['review'] });
+
+    const pushResponse = await postWebhook(webhookApp(dispatch), 'pull_request', {
+      ...opened,
+      action: 'synchronize',
+    });
+    expect(await pushResponse.json()).toMatchObject({
+      skipped: 'all agents busy or within push debounce',
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ trigger: 'opened' });
+  });
+
+  it('tracks merged closure without overwriting an explicit abandon', async () => {
+    await seedRepo();
+    const featureId = await createFeature(101, 'Factory feature', 'Implementation spec');
+    await updateFeature(featureId, { status: 'pr_opened', prNumber: 55 });
+    const closed = {
+      action: 'closed',
+      number: 55,
+      pull_request: {
+        draft: false,
+        merged: true,
+        html_url: 'https://github.com/acme/api/pull/55',
+      },
+      repository: { id: 101, full_name: 'acme/api' },
+    };
+
+    expect((await postWebhook(webhookApp(), 'pull_request', closed)).status).toBe(200);
+    expect((await getFeature(featureId))?.status).toBe('merged');
+
+    await updateFeature(featureId, { status: 'abandoned' });
+    const abandonedResponse = await postWebhook(webhookApp(), 'pull_request', {
+      ...closed,
+      pull_request: { ...closed.pull_request, merged: false },
+    });
+    expect(await abandonedResponse.json()).toMatchObject({ ignored: 'already abandoned' });
+    expect((await getFeature(featureId))?.status).toBe('abandoned');
+  });
+});

--- a/vitest.worker.config.ts
+++ b/vitest.worker.config.ts
@@ -8,7 +8,19 @@ export default defineConfig({
   plugins: [
     cloudflareTest({
       wrangler: { configPath: './wrangler.test.jsonc' },
-      miniflare: { bindings: { TEST_MIGRATIONS: migrations } },
+      miniflare: {
+        bindings: {
+          TEST_MIGRATIONS: migrations,
+          PUBLIC_BASE_URL: 'https://turbodiff.test',
+          GITHUB_APP_SLUG: 'turbodiff-test',
+          GITHUB_WEBHOOK_SECRET: 'worker-test-webhook-secret',
+          GITHUB_OAUTH_CLIENT_ID: 'worker-test-client',
+          GITHUB_OAUTH_CLIENT_SECRET: 'worker-test-client-secret',
+          SESSION_SECRET: 'worker-test-session-secret-at-least-32-characters',
+          REVIEW_DAILY_LIMIT: '50',
+          TRIVIAL_MODEL: '',
+        },
+      },
     }),
   ],
   test: {


### PR DESCRIPTION
## Summary

- add Worker-runtime webhook scenarios covering HMAC rejection, installation mirroring/idempotency, suspension, human-vs-factory PR decisions, review debounce, and terminal feature state
- add authenticated API scenarios covering no-session and CSRF rejection, tenant-filtered reads, cross-tenant mutation protection, session attribution, and repository push authorization
- introduce narrow dependency seams for authentication, push checks, and risk scoring while preserving production defaults
- run every scenario against an isolated Miniflare D1 database with explicit per-test cleanup

## Test plan

- `pnpm test` — 24 passed
- `pnpm test:worker` — 21 passed
- `pnpm vp run check:types`
- `pnpm vp lint`
- `pnpm vp fmt src/routes/api.ts src/routes/webhooks.ts src/routes/api.worker.test.ts src/routes/webhooks.worker.test.ts vitest.worker.config.ts --check`
- `pnpm vp run build`
- `pnpm wrangler deploy --dry-run`
- `git diff --check`
