### PR TITLE
Exclude stalled dispatches from the dashboard's running count

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2004,6 +2004,10 @@ export async function dashboardStats(installationIds: number[]): Promise<Dashboa
   };
   if (installationIds.length === 0) return empty;
   const placeholders = installationIds.map((_, i) => `?${i + 1}`).join(', ');
+  // `running` counts only dispatches younger than the 20-minute stall window
+  // (STALL_AFTER_MS in routes/api.ts): a review row flips out of 'running'
+  // solely when its agent posts, so a run that dies mid-flight would
+  // otherwise pin the dashboard's active count forever.
   const row = await env.DB.prepare(
     `SELECT
 			COALESCE(SUM(strftime('%Y-%m', created_at) = strftime('%Y-%m', 'now')), 0) AS month_reviews,
@@ -2016,7 +2020,8 @@ export async function dashboardStats(installationIds: number[]): Promise<Dashboa
 			AVG(CASE WHEN status = 'completed' AND findings_count IS NOT NULL
 				AND strftime('%Y-%m', created_at) = strftime('%Y-%m', 'now')
 				THEN findings_count END) AS avg_findings,
-			COALESCE(SUM(status = 'running'), 0) AS running
+			COALESCE(SUM(status = 'running'
+				AND created_at > datetime('now', '-20 minutes')), 0) AS running
 		 FROM reviews
 		 WHERE installation_id IN (${placeholders})`,
   )


### PR DESCRIPTION
The board's "active runs" counter read `SUM(status = 'running')` with no age cutoff — but a review row only leaves `'running'` when its agent calls `post_review`, so an agent that dies mid-flight pins the counter forever. In production, review id 5 (a pre-agent review of PR #1 dispatched 2026-08-03) sat `running` for 11 days, showing a permanent "1 active run".

Fix: `dashboardStats` now counts only dispatches younger than the same 20-minute stall window the reviews list already applies (`STALL_AFTER_MS` in `routes/api.ts` — anything older renders as "stalled" there, and now stops counting as running here too).

The stuck production row has already been repaired directly (`UPDATE reviews SET status = 'failed' WHERE id = 5 AND status = 'running'` — 1 row changed, 0 running remain), so this PR is purely the guard against recurrence. No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)