### PR TITLE
Fix CI check:types failure and pnpm version mismatch warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,5 @@
       "onFail": "download"
     }
   },
-  "packageManager": "pnpm@11.21.0"
+  "packageManager": "pnpm@11.20.0"
 }

--- a/src/routes/webhooks.worker.test.ts
+++ b/src/routes/webhooks.worker.test.ts
@@ -11,7 +11,7 @@ import {
   createFeature,
   ensureBuiltinAgents,
   getFeature,
-  recordReview,
+  tryRecordReview,
   updateFeature,
   type AgentRow,
   type RepositoryRow,
@@ -179,7 +179,7 @@ describe('factory PR webhook decisions', () => {
     const calls: { agent: AgentRow; repo: RepositoryRow; trigger: string }[] = [];
     const dispatch: ReviewDispatcher = async (agent, repo, prNumber, _url, trigger, options) => {
       calls.push({ agent, repo, trigger });
-      await recordReview(
+      await tryRecordReview(
         repo.id,
         repo.installation_id,
         prNumber,


### PR DESCRIPTION
CI's `check:types` step fails on main:

```
src/routes/webhooks.worker.test.ts:14:3 - error TS2724: '"../lib/db.ts"' has no exported member named 'recordReview'. Did you mean 'tryRecordReview'?
```

`recordReview` was renamed to `tryRecordReview` when review dispatch gained its atomic claim (stale-row sweep + NOT EXISTS insert), but the webhook worker test's fake dispatcher still imported the old name. The signature is unchanged, so the fix is the rename — the test dispatcher keeps mirroring what `dispatchReviewAgent` actually calls.

Also fixes the other noise in the same log: `packageManager` (pnpm@11.21.0) disagreed with `devEngines.packageManager` (11.20.0), which pnpm warns "will become an error in a future release". Since `packageManager` is ignored in favor of `devEngines` today, aligning it to 11.20.0 codifies current behavior with zero change.

Verified locally with the exact CI command: `pnpm vp run check:types` passes all four programs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)