### PR TITLE
Scope MCP connections to repositories instead of agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,108 @@ Agent runs execute inside Cloudflare Containers (the sandbox) and can spend
 either your existing Claude subscription (`claude setup-token`) or API credits
 through your AI Gateway.
 
+## Architecture
+
+Everything runs in one Cloudflare Worker deployment: an HTTP layer (Hono)
+in front of Durable Objects for the long-lived pieces (the per-PR review
+agent, the sandbox container), Cloudflare Workflows for the multi-minute
+factory runs, a queue to decouple intake from execution, and D1/R2 for state
+and artifacts.
+
+```mermaid
+flowchart TB
+  subgraph external ["External"]
+    GH["GitHub<br/>App webhooks · REST API · pull requests"]
+    BROWSER["Browser<br/>React SPA"]
+    MCPS["External MCP servers"]
+    LLM["Anthropic API<br/>(subscription or AI Gateway)"]
+  end
+
+  subgraph worker ["Cloudflare Worker (Hono — src/app.ts)"]
+    WEBHOOKS["/webhooks<br/>HMAC-verified GitHub events"]
+    API["/api<br/>session-cookie JSON for the SPA"]
+    AUTHR["/api/auth<br/>better-auth · GitHub OAuth"]
+    SHELL["/ SPA shell · landing"]
+    ART["/artifacts · /b/:id<br/>signed capability URLs"]
+    PROXY["/mcp-proxy/:id<br/>sealed-grant MCP relay"]
+    CRON["cron (*/15)<br/>automation poll"]
+    CONSUMER["queue consumer<br/>(src/cloudflare.ts)"]
+  end
+
+  subgraph durable ["Durable Objects"]
+    REVIEWER["PrReviewer (Flue agent)<br/>one instance per PR"]
+    SANDBOX["Sandbox (container)<br/>runs Claude CLI"]
+  end
+
+  subgraph wf ["Cloudflare Workflows"]
+    GEN["Generation"]
+    VERIFY["Verification"]
+    FIX["Fix"]
+    CONFLICT["Conflict resolve"]
+    AUTO["Automation"]
+  end
+
+  subgraph storage ["State"]
+    D1[("D1<br/>installations · repos · reviews · features/plans<br/>connections · repo_connections · automations<br/>(secrets AES-GCM sealed)")]
+    R2[("R2<br/>screenshots · demo videos")]
+    Q[["Queue<br/>turbodiff-factory"]]
+  end
+
+  BROWSER --> SHELL & API & AUTHR
+  GH -->|"PR / push / installation events"| WEBHOOKS
+  WEBHOOKS -->|"review.request signal"| REVIEWER
+  WEBHOOKS -->|"auto-fix · conflict messages"| Q
+  API -->|"feature intake · plan approve<br/>automation CRUD"| Q
+  CRON -->|"due automations"| Q
+  Q --> CONSUMER
+  CONSUMER -->|"plan analyze/refine (inline)"| SANDBOX
+  CONSUMER -->|"creates instances"| wf
+  wf -->|"exec: clone · edit · check"| SANDBOX
+  SANDBOX -->|"git push · open PRs"| GH
+  SANDBOX -->|"Claude CLI"| LLM
+  SANDBOX -->|"JSON-RPC + sealed grant"| PROXY
+  PROXY -->|"inject decrypted credential"| MCPS
+  REVIEWER -->|"fetch PR · post review"| GH
+  REVIEWER --> LLM
+  REVIEWER -->|"streamable HTTP<br/>per-request auth resolver"| MCPS
+  VERIFY -->|"evidence"| R2
+  ART --> R2
+  worker <--> D1
+```
+
+### MCP connections (repo-scoped)
+
+MCP servers are registered once per installation on the integrations page and
+attached to **repositories** (`repo_connections`), with independent toggles
+for the two mount contexts: hosted PR reviews and sandbox automation runs.
+Credentials are sealed (AES-256-GCM) in D1 and never leave the Worker
+boundary. Hosted reviews mount connections directly — the agent's auth
+resolver decrypts per request. Sandbox runs can't be trusted with
+credentials (they execute repo-influenced code), so they get a relay instead:
+
+```mermaid
+sequenceDiagram
+  participant WF as Automation workflow
+  participant SB as Sandbox (Claude CLI)
+  participant PX as Worker /mcp-proxy/:id
+  participant D1
+  participant MCP as External MCP server
+
+  WF->>D1: listRepoConnections(repo, 'automations')
+  WF->>WF: mint sealed grant (AES-GCM, 1 h TTL,<br/>bound to connection + repo)
+  WF->>SB: write --mcp-config (proxy URL + grant — no credentials)
+  SB->>PX: JSON-RPC request (Bearer grant)
+  PX->>PX: verify grant · enforce tool allowlist on tools/call
+  PX->>D1: resolve + decrypt connection credential
+  PX->>MCP: forward request with real auth header
+  MCP-->>SB: response (streamed back through the proxy)
+```
+
+A prompt-injected repository can therefore at worst _use_ an attached
+connection for the lifetime of one run's grant — it can never read the
+credential itself, and calls outside the connection's tool allowlist are
+rejected at the proxy.
+
 ## Code map
 
 - [src/agents/pr-reviewer.ts](src/agents/pr-reviewer.ts) — the review agent.

--- a/migrations/0032_repo_connections.sql
+++ b/migrations/0032_repo_connections.sql
@@ -1,0 +1,27 @@
+-- Repo-scoped MCP attachment, replacing the per-agent model: a connection in
+-- the installation-level registry is attached to a repository, and every
+-- action on that repository mounts it — hosted PR reviews and sandbox
+-- automation runs, each behind its own toggle so a connection can be limited
+-- to one context.
+CREATE TABLE repo_connections (
+	repository_id INTEGER NOT NULL,
+	connection_id INTEGER NOT NULL,
+	reviews INTEGER NOT NULL DEFAULT 1, -- mount into hosted PR reviews
+	automations INTEGER NOT NULL DEFAULT 1, -- mount into sandbox automation runs
+	PRIMARY KEY (repository_id, connection_id)
+);
+CREATE INDEX idx_repo_connections_connection ON repo_connections(connection_id);
+
+-- Seed from the per-agent model. Agents run on every repo by default
+-- (repo_agents rows are explicit overrides only), so the faithful mapping for
+-- "this connection was mounted wherever its agents ran" is: every MCP
+-- connection with at least one agent link attaches to every enabled repo of
+-- its installation.
+INSERT OR IGNORE INTO repo_connections (repository_id, connection_id)
+SELECT r.id, c.id
+FROM connections c
+JOIN repositories r ON r.installation_id = c.installation_id AND r.enabled = 1
+WHERE c.kind = 'mcp'
+	AND EXISTS (SELECT 1 FROM agent_connection_links l WHERE l.connection_id = c.id);
+
+DROP TABLE agent_connection_links;

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,7 +20,7 @@ import {
   setRepoRunCommand,
   updateFeature,
   updatePlan,
-  listAgentConnections,
+  listRepoConnections,
   markReviewFailed,
   tryRecordReview,
   type AgentRow,
@@ -28,6 +28,7 @@ import {
 } from './lib/db.ts';
 import { auth } from './lib/better-auth.ts';
 import { runFix, sandboxSmoke, type FixAuthMode } from './lib/fixer.ts';
+import { handleMcpProxy } from './lib/mcp-proxy.ts';
 import { approvePlan } from './lib/planner.ts';
 import { registerReviewMetering } from './lib/metering.ts';
 import { isString } from './shared/json.ts';
@@ -154,9 +155,9 @@ export async function dispatchReviewAgent(
   );
   if (reviewId === null) return false;
 
-  // Snapshot the agent's external MCP connections (non-secret fields only;
+  // Snapshot the repo's external MCP connections (non-secret fields only;
   // tokens are resolved from D1 at request time by the agent's auth resolver).
-  const connections = (await listAgentConnections(agent.id)).map(connectionSnapshot);
+  const connections = (await listRepoConnections(repo.id, 'reviews')).map(connectionSnapshot);
   const baseAttributes = {
     agent_slug: agent.slug,
     agent_name: agent.name,
@@ -196,6 +197,10 @@ export async function dispatchReviewAgent(
 
 // GitHub App webhooks — authenticated by HMAC signature, not the bearer secret.
 app.route('/webhooks', createWebhookRoutes(dispatchReviewAgent));
+
+// MCP relay for sandbox runs — authenticated by a short-lived sealed grant
+// minted per run, not by session or bearer secret (see lib/mcp-proxy.ts).
+app.on(['GET', 'POST', 'DELETE'], '/mcp-proxy/:id', handleMcpProxy);
 
 // better-auth (sessions, OAuth callback, sign-out). Registered before the
 // /api data plane so it owns the /api/auth prefix.

--- a/src/client/pages/agent-edit.tsx
+++ b/src/client/pages/agent-edit.tsx
@@ -1,12 +1,12 @@
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
-import { Link, useNavigate, useParams } from '@tanstack/react-router';
+import { useNavigate, useParams } from '@tanstack/react-router';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { api, ApiError } from '../lib/api.ts';
 import { agentQuery } from '../lib/queries.ts';
 import { AgentForm, type AgentFormValues } from '../components/agent-form.tsx';
 import { ConfirmButton } from '../components/confirm-button.tsx';
-import { Muted, PageTitle, SectionHeading } from '../components/section.tsx';
+import { PageTitle } from '../components/section.tsx';
 import { Pill } from '../components/ui/pill.tsx';
 
 function onApiError<T>(err: T) {
@@ -75,23 +75,6 @@ export function AgentEditPage() {
           </ConfirmButton>
         </div>
       ) : null}
-      <SectionHeading aside={<Muted>MCP</Muted>}>Attached integrations</SectionHeading>
-      {data.connections.length === 0 ? (
-        <Muted className="block">None attached.</Muted>
-      ) : (
-        <div className="flex flex-wrap gap-1.5">
-          {data.connections.map((conn) => (
-            <Pill key={conn.id}>{conn.name}</Pill>
-          ))}
-        </div>
-      )}
-      <p className="mt-2 text-xs text-mute">
-        Connections are managed centrally on the{' '}
-        <Link to="/integrations" className="text-accent-bright hover:underline">
-          MCP &amp; integrations
-        </Link>{' '}
-        page — attach or detach this agent there.
-      </p>
     </>
   );
 }

--- a/src/client/pages/integrations.tsx
+++ b/src/client/pages/integrations.tsx
@@ -5,7 +5,7 @@ import { toast } from 'sonner';
 import type {
   ApiConnectionTest,
   ApiIntegration,
-  ApiIntegrationAgent,
+  ApiIntegrationRepo,
 } from '../../shared/api-types.ts';
 import { api, ApiError } from '../lib/api.ts';
 import { integrationsQuery } from '../lib/queries.ts';
@@ -19,9 +19,10 @@ import { Field, Input, Select } from '../components/ui/input.tsx';
 import { Pill } from '../components/ui/pill.tsx';
 import { Table, Td, Th } from '../components/ui/table.tsx';
 
-// Central integrations registry: MCP servers (mountable as agent tools) and
+// Central integrations registry: MCP servers (mountable as run tools) and
 // bearer-auth APIs, added once per installation. MCP integrations attach to
-// review agents with the toggles on each card.
+// factory-enabled repos with the toggles on each card, with per-context
+// switches for reviews and automations.
 
 const AUTH_TYPES = ['none', 'bearer', 'api_key', 'client_credentials', 'oauth'] as const;
 type AuthType = (typeof AUTH_TYPES)[number];
@@ -132,13 +133,45 @@ function AuthPill({ conn }: { conn: ApiIntegration }) {
   }
 }
 
-function IntegrationCard({
-  conn,
-  agents,
+// One small secondary pill toggle for a per-context mount switch (Reviews /
+// Automations) on an attached repo.
+function ContextToggle({
+  label,
+  on,
+  repoLabel,
+  onToggle,
 }: {
-  conn: ApiIntegration;
-  agents: ApiIntegrationAgent[];
+  label: string;
+  on: boolean;
+  repoLabel: string;
+  onToggle: () => void;
 }) {
+  return (
+    <button
+      type="button"
+      aria-pressed={on}
+      title={`${on ? 'Disable' : 'Enable'} ${label.toLowerCase()} for ${repoLabel}`}
+      onClick={onToggle}
+      className={cn(
+        'cursor-pointer rounded-full border px-2 py-0.5 font-mono text-[10px] whitespace-nowrap transition-colors max-sm:px-3 max-sm:py-1.5',
+        on
+          ? 'border-accent/40 bg-accent/10 text-accent-bright'
+          : 'border-line-2/70 text-mute hover:border-line-2 hover:bg-raised hover:text-ink-dim',
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+interface RepoLinkUpdate {
+  repoId: number;
+  attached: boolean;
+  reviews?: boolean;
+  automations?: boolean;
+}
+
+function IntegrationCard({ conn, repos }: { conn: ApiIntegration; repos: ApiIntegrationRepo[] }) {
   const queryClient = useQueryClient();
   const refresh = () => {
     void queryClient.invalidateQueries({ queryKey: ['integrations'] });
@@ -158,16 +191,18 @@ function IntegrationCard({
     },
     onError: onApiError,
   });
-  const toggleAgent = useMutation({
-    mutationFn: ({ agentId, attached }: { agentId: number; attached: boolean }) =>
-      api.put(`/api/integrations/${conn.id}/agents/${agentId}`, { attached }),
+  const toggleRepo = useMutation({
+    mutationFn: ({ repoId, attached, reviews, automations }: RepoLinkUpdate) =>
+      api.put(`/api/integrations/${conn.id}/repos/${repoId}`, { attached, reviews, automations }),
     onSuccess: refresh,
     onError: onApiError,
   });
 
   const needsOAuthConnect =
     conn.kind === 'mcp' && conn.auth_type === 'oauth' && conn.oauth_status !== 'connected';
-  const attachedCount = agents.filter((a) => conn.agent_ids.includes(a.id)).length;
+  const attachedCount = repos.filter((r) =>
+    conn.repo_links.some((l) => l.repository_id === r.id),
+  ).length;
 
   return (
     <Card className="p-3.5 sm:p-4">
@@ -204,7 +239,7 @@ function IntegrationCard({
             variant="secondary"
             className="max-sm:flex-1"
             title="Remove this integration?"
-            description={`Agents lose access to "${conn.name}" on their next run. The stored credential is deleted.`}
+            description={`Attached repos lose access to "${conn.name}" on their next run. The stored credential is deleted.`}
             confirmLabel="Remove"
             onConfirm={() => remove.mutate()}
             busy={remove.isPending}
@@ -234,44 +269,77 @@ function IntegrationCard({
 
       {conn.auth_type === 'api_key' && conn.kind === 'mcp' ? (
         <p className="mt-2.5 text-xs text-mute/80">
-          Mounted into review agents only when the header name is exactly "Authorization" —
-          otherwise this credential is verified by Test but not used at review time (a @flue/runtime
-          limitation).
+          Mounted into reviews only when the header name is exactly "Authorization" — otherwise this
+          credential is verified by Test but not used at review time (a @flue/runtime limitation).
         </p>
       ) : null}
 
       {conn.kind === 'mcp' ? (
         <div className="mt-3 border-t border-line/70 pt-3">
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <Placard>Attached agents</Placard>
+            <Placard>Attached repos</Placard>
             <span className="font-mono text-[10px] text-mute/70 tabular-nums">
-              {attachedCount}/{agents.length}
+              {attachedCount}/{repos.length}
             </span>
           </div>
-          {agents.length === 0 ? (
+          {repos.length === 0 ? (
             <Muted className="mt-2 block text-xs">
-              This installation has no agents yet — create one first.
+              This installation has no factory-enabled repos yet — enable one in settings first.
             </Muted>
           ) : (
-            <div className="mt-2 flex flex-wrap gap-1.5">
-              {agents.map((a) => {
-                const attached = conn.agent_ids.includes(a.id);
+            <div className="mt-2 flex flex-col gap-1.5">
+              {repos.map((r) => {
+                const repoLabel = `${r.owner}/${r.name}`;
+                const link = conn.repo_links.find((l) => l.repository_id === r.id);
                 return (
-                  <button
-                    key={a.id}
-                    type="button"
-                    aria-pressed={attached}
-                    title={`${attached ? 'Detach from' : 'Attach to'} ${a.name}`}
-                    onClick={() => toggleAgent.mutate({ agentId: a.id, attached: !attached })}
-                    className={cn(
-                      'cursor-pointer rounded-full border px-2.5 py-1 font-mono text-xs whitespace-nowrap transition-colors max-sm:px-3.5 max-sm:py-2',
-                      attached
-                        ? 'border-accent/40 bg-accent/10 text-accent-bright'
-                        : 'border-line-2/70 text-mute hover:border-line-2 hover:bg-raised hover:text-ink-dim',
-                    )}
-                  >
-                    {a.slug}
-                  </button>
+                  <div key={r.id} className="flex flex-wrap items-center gap-1.5">
+                    <button
+                      type="button"
+                      aria-pressed={link !== undefined}
+                      title={`${link ? 'Detach from' : 'Attach to'} ${repoLabel}`}
+                      onClick={() =>
+                        toggleRepo.mutate({ repoId: r.id, attached: link === undefined })
+                      }
+                      className={cn(
+                        'cursor-pointer rounded-full border px-2.5 py-1 font-mono text-xs whitespace-nowrap transition-colors max-sm:px-3.5 max-sm:py-2',
+                        link
+                          ? 'border-accent/40 bg-accent/10 text-accent-bright'
+                          : 'border-line-2/70 text-mute hover:border-line-2 hover:bg-raised hover:text-ink-dim',
+                      )}
+                    >
+                      {repoLabel}
+                    </button>
+                    {link ? (
+                      <>
+                        <ContextToggle
+                          label="Reviews"
+                          on={link.reviews}
+                          repoLabel={repoLabel}
+                          onToggle={() =>
+                            toggleRepo.mutate({
+                              repoId: r.id,
+                              attached: true,
+                              reviews: !link.reviews,
+                              automations: link.automations,
+                            })
+                          }
+                        />
+                        <ContextToggle
+                          label="Automations"
+                          on={link.automations}
+                          repoLabel={repoLabel}
+                          onToggle={() =>
+                            toggleRepo.mutate({
+                              repoId: r.id,
+                              attached: true,
+                              reviews: link.reviews,
+                              automations: !link.automations,
+                            })
+                          }
+                        />
+                      </>
+                    ) : null}
+                  </div>
                 );
               })}
             </div>
@@ -279,7 +347,7 @@ function IntegrationCard({
         </div>
       ) : (
         <p className="mt-3 border-t border-line/70 pt-3 text-xs text-mute">
-          Stored API credential — not mounted to agents (MCP integrations are).
+          Stored API credential — not mounted into runs (MCP integrations are).
         </p>
       )}
       {test ? <TestDialog name={conn.name} result={test} onClose={() => setTest(null)} /> : null}
@@ -422,7 +490,7 @@ function AddForm() {
             label="Type"
             value={form.kind}
             options={[
-              { value: 'mcp', label: 'MCP server', hint: 'mounts tools on agents' },
+              { value: 'mcp', label: 'MCP server', hint: 'mounts tools on repo runs' },
               { value: 'api', label: 'API', hint: 'stored-credential endpoint' },
             ]}
             onChange={(kind) =>
@@ -608,8 +676,8 @@ function AddForm() {
         <div className="flex flex-wrap items-center justify-between gap-3 border-t border-line/70 pt-4">
           <Muted className="text-xs">
             {form.kind === 'mcp'
-              ? 'Attach it to agents on its card once added.'
-              : 'Stored for use by the API tools — not mounted to agents.'}
+              ? 'Attach it to repos on its card once added.'
+              : 'Stored for use by the API tools — not mounted into runs.'}
           </Muted>
           <Button type="submit" loading={add.isPending} className="max-sm:w-full">
             Add integration
@@ -647,14 +715,14 @@ export function IntegrationsPage() {
   const { data } = useSuspenseQuery(integrationsQuery);
   useOAuthCallbackToast();
 
-  // Connections and agents are both per-installation, and a connection may
-  // only attach to its own installation's agent rows — so group the list and
-  // hand each card just that installation's agents.
+  // Connections and repos are both per-installation, and a connection may
+  // only attach to its own installation's repos — so group the list and hand
+  // each card just that installation's factory-enabled repos.
   const groups = data.installations
     .map((inst) => ({
       installation: inst,
       connections: data.connections.filter((c) => c.installation_id === inst.id),
-      agents: data.agents.filter((a) => a.installation_id === inst.id),
+      repos: data.repos.filter((r) => r.installation_id === inst.id),
     }))
     .filter((g) => g.connections.length > 0);
   const multiInstall = data.installations.length > 1;
@@ -669,8 +737,8 @@ export function IntegrationsPage() {
         MCP &amp; integrations
       </PageTitle>
       <p className="mt-3 max-w-2xl text-[0.85rem] text-mute">
-        Connect MCP servers and APIs once, then attach MCP integrations to the agents that should
-        use their tools.
+        Connect MCP servers and APIs once, then attach MCP integrations to the repositories whose
+        reviews and automations should use their tools.
       </p>
       <Notes />
 
@@ -679,13 +747,13 @@ export function IntegrationsPage() {
         <EmptyState>No integrations yet — add one below.</EmptyState>
       ) : (
         <div className="flex flex-col gap-4">
-          {groups.map(({ installation, connections, agents }) => (
+          {groups.map(({ installation, connections, repos }) => (
             <section key={installation.id} className="flex flex-col gap-2">
               {multiInstall ? (
                 <Placard className="px-0.5">{installation.account_login}</Placard>
               ) : null}
               {connections.map((conn) => (
-                <IntegrationCard key={conn.id} conn={conn} agents={agents} />
+                <IntegrationCard key={conn.id} conn={conn} repos={repos} />
               ))}
             </section>
           ))}

--- a/src/lib/automation-workflow.ts
+++ b/src/lib/automation-workflow.ts
@@ -9,9 +9,11 @@ import {
   getAutomationById,
   getRepoById,
   listEnabledSkillsForRepo,
+  listRepoConnections,
   tryRecordAutomationRun,
   type AutomationRow,
 } from './db.ts';
+import { buildSandboxMcpConfig } from './mcp-proxy.ts';
 import { resolveRunnerAuth } from './fixer.ts';
 import { NPM_CACHE_ENV } from './generation-workflow.ts';
 import {
@@ -39,6 +41,7 @@ const CACHE_DIR = '/workspace/repo-cache';
 const workDir = (runId: number) => `/workspace/automation-${runId}`;
 const specFile = (runId: number) => `/workspace/automation-spec-${runId}.md`;
 const prFile = (runId: number) => `/workspace/automation-pr-${runId}.md`;
+const mcpFile = (runId: number) => `/workspace/automation-mcp-${runId}.json`;
 const AGENT_TIMEOUT_MS = 20 * 60_000;
 const CHECK_TIMEOUT_MS = 12 * 60_000;
 
@@ -208,8 +211,6 @@ export class AutomationWorkflow extends WorkflowEntrypoint<unknown, AutomationPa
         { retries: { limit: 1, delay: '5 minutes' }, timeout: '23 minutes' },
         async (): Promise<{ changed: boolean; usage: CliUsage | null }> => {
           const auth = resolveRunnerAuth();
-          const scrub = (s: string) =>
-            Object.values(auth.vars).reduce((acc, v) => acc.replaceAll(v, '***'), s);
           const sandbox = sandboxFor(ctx);
           const skills = await listEnabledSkillsForRepo(ctx.repositoryId);
           for (const skill of skills) {
@@ -217,9 +218,21 @@ export class AutomationWorkflow extends WorkflowEntrypoint<unknown, AutomationPa
             await sandbox.exec(`mkdir -p ${dir}`);
             await sandbox.writeFile(`${dir}/SKILL.md`, skillMarkdown(skill));
           }
+          // Mount the repo's MCP connections through the Worker's relay:
+          // the sandbox only ever holds run-scoped grants, never connection
+          // credentials (see lib/mcp-proxy.ts).
+          const connections = await listRepoConnections(ctx.repositoryId, 'automations');
+          const mcp = await buildSandboxMcpConfig(connections, ctx.repositoryId);
+          let mcpFlags = '';
+          if (mcp) {
+            await sandbox.writeFile(mcpFile(ctx.runId), mcp.configJson);
+            mcpFlags = ` --mcp-config ${mcpFile(ctx.runId)} --strict-mcp-config`;
+          }
+          const scrubValues = [...Object.values(auth.vars), ...(mcp?.secrets ?? [])];
+          const scrub = (s: string) => scrubValues.reduce((acc, v) => acc.replaceAll(v, '***'), s);
           await sandbox.writeFile(specFile(ctx.runId), automationPrompt(ctx));
           const agent = await sandbox.exec(
-            `claude -p --dangerously-skip-permissions --output-format json < ${specFile(ctx.runId)}`,
+            `claude -p --dangerously-skip-permissions${mcpFlags} --output-format json < ${specFile(ctx.runId)}`,
             {
               cwd: WORK,
               timeout: AGENT_TIMEOUT_MS,
@@ -369,7 +382,9 @@ export class AutomationWorkflow extends WorkflowEntrypoint<unknown, AutomationPa
         { retries: { limit: 1, delay: '10 seconds' }, timeout: '2 minutes' },
         async () => {
           await sandboxFor(ctx)
-            .exec(`rm -rf ${WORK} ${specFile(ctx.runId)} ${prFile(ctx.runId)}`)
+            .exec(
+              `rm -rf ${WORK} ${specFile(ctx.runId)} ${prFile(ctx.runId)} ${mcpFile(ctx.runId)}`,
+            )
             .catch(() => {});
         },
       );

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1573,11 +1573,13 @@ export async function listEnabledSkillsForRepo(repositoryId: number): Promise<Sk
   return res.results;
 }
 
-// --- External MCP tool connections per agent (migration 0005) ---
+// --- External MCP tool connections per repository (migration 0032) ---
 
-// Installation-level integrations registry (kanban-era model): connections
-// are added once per installation on the integrations page; MCP-kind
-// connections are attached to agents via agent_connection_links.
+// Installation-level integrations registry: connections are added once per
+// installation on the integrations page; MCP-kind connections are attached to
+// repositories via repo_connections, and every action on an attached repo
+// (hosted PR reviews, sandbox automation runs) mounts them per its context
+// toggle.
 export interface ConnectionRow {
   id: number;
   installation_id: number;
@@ -1629,15 +1631,20 @@ export function connectionSnapshot(row: ConnectionRow): ConnectionSnapshot {
   return snapshot;
 }
 
-// MCP connections attached to one agent, via the registry links.
-export async function listAgentConnections(agentId: number): Promise<ConnectionRow[]> {
+// MCP connections attached to one repository and enabled for the given
+// mount context.
+export async function listRepoConnections(
+  repositoryId: number,
+  context: 'reviews' | 'automations',
+): Promise<ConnectionRow[]> {
+  const contextColumn = context === 'reviews' ? 'l.reviews' : 'l.automations';
   const res = await env.DB.prepare(
     `SELECT c.* FROM connections c
-		 JOIN agent_connection_links l ON l.connection_id = c.id
-		 WHERE l.agent_id = ?1 AND c.kind = 'mcp'
+		 JOIN repo_connections l ON l.connection_id = c.id
+		 WHERE l.repository_id = ?1 AND ${contextColumn} = 1 AND c.kind = 'mcp'
 		 ORDER BY c.name`,
   )
-    .bind(agentId)
+    .bind(repositoryId)
     .all<ConnectionRow>();
   return res.results;
 }
@@ -1719,48 +1726,53 @@ export async function updateConnectionAuth(
 }
 
 export async function deleteConnection(id: number): Promise<void> {
-  await env.DB.prepare('DELETE FROM agent_connection_links WHERE connection_id = ?1')
-    .bind(id)
-    .run();
+  await env.DB.prepare('DELETE FROM repo_connections WHERE connection_id = ?1').bind(id).run();
   await env.DB.prepare('DELETE FROM connections WHERE id = ?1').bind(id).run();
 }
 
-export interface AgentConnectionLink {
-  agent_id: number;
+export interface RepoConnectionLink {
+  repository_id: number;
   connection_id: number;
+  reviews: number;
+  automations: number;
 }
 
-export async function listConnectionLinks(
+export async function listRepoConnectionLinks(
   installationIds: number[],
-): Promise<AgentConnectionLink[]> {
+): Promise<RepoConnectionLink[]> {
   if (installationIds.length === 0) return [];
   const placeholders = installationIds.map((_, i) => `?${i + 1}`).join(', ');
   const res = await env.DB.prepare(
-    `SELECT l.agent_id, l.connection_id FROM agent_connection_links l
+    `SELECT l.repository_id, l.connection_id, l.reviews, l.automations FROM repo_connections l
 		 JOIN connections c ON c.id = l.connection_id
 		 WHERE c.installation_id IN (${placeholders})`,
   )
     .bind(...installationIds)
-    .all<AgentConnectionLink>();
+    .all<RepoConnectionLink>();
   return res.results;
 }
 
-export async function setAgentConnectionLink(
-  agentId: number,
+// Attach/detach one connection on one repository. Attaching upserts so the
+// context toggles can be changed on an existing link with the same call.
+export async function setRepoConnectionLink(
+  repositoryId: number,
   connectionId: number,
-  attached: boolean,
+  link: { attached: boolean; reviews: boolean; automations: boolean },
 ): Promise<void> {
-  if (attached) {
+  if (link.attached) {
     await env.DB.prepare(
-      'INSERT OR IGNORE INTO agent_connection_links (agent_id, connection_id) VALUES (?1, ?2)',
+      `INSERT INTO repo_connections (repository_id, connection_id, reviews, automations)
+			 VALUES (?1, ?2, ?3, ?4)
+			 ON CONFLICT (repository_id, connection_id)
+			 DO UPDATE SET reviews = ?3, automations = ?4`,
     )
-      .bind(agentId, connectionId)
+      .bind(repositoryId, connectionId, link.reviews ? 1 : 0, link.automations ? 1 : 0)
       .run();
   } else {
     await env.DB.prepare(
-      'DELETE FROM agent_connection_links WHERE agent_id = ?1 AND connection_id = ?2',
+      'DELETE FROM repo_connections WHERE repository_id = ?1 AND connection_id = ?2',
     )
-      .bind(agentId, connectionId)
+      .bind(repositoryId, connectionId)
       .run();
   }
 }

--- a/src/lib/db.worker.test.ts
+++ b/src/lib/db.worker.test.ts
@@ -62,7 +62,7 @@ beforeEach(async () => {
     'automations',
     'repo_agents',
     'repo_skills',
-    'agent_connection_links',
+    'repo_connections',
     'connections',
     'skills',
     'agents',

--- a/src/lib/mcp-proxy.ts
+++ b/src/lib/mcp-proxy.ts
@@ -1,0 +1,180 @@
+import { env } from 'cloudflare:workers';
+import { isJsonObject, isNumber, isString, parseJson, type JsonValue } from '../shared/json.ts';
+import { encryptionConfigured, openJson, sealJson } from './crypto.ts';
+import { connectionSnapshot, getConnection, resolveConnectionAuth } from './db.ts';
+
+import type { ConnectionRow } from './db.ts';
+import type { Context } from 'hono';
+
+// MCP relay for sandbox runs: the sandbox agent's MCP config points every
+// server at /mcp-proxy/:id with a short-lived sealed grant as its bearer
+// token, and this handler injects the connection's real credential per
+// request. Auth material keeps the same property as hosted review mounts —
+// it never leaves the Worker/D1 boundary, so a prompt-injected repo can at
+// worst use the connection for the grant's lifetime, never exfiltrate its
+// credential.
+
+interface McpProxyGrant {
+  connectionId: number;
+  repositoryId: number;
+  exp: number; // epoch ms
+}
+
+// Outlives the automation agent step timeout (23 minutes) with margin for a
+// retried step reusing the same config file.
+export const MCP_PROXY_GRANT_TTL_MS = 60 * 60_000;
+
+export async function mintMcpProxyGrant(
+  connectionId: number,
+  repositoryId: number,
+): Promise<string> {
+  return sealJson<McpProxyGrant>({
+    connectionId,
+    repositoryId,
+    exp: Date.now() + MCP_PROXY_GRANT_TTL_MS,
+  });
+}
+
+async function verifyGrant(token: string, connectionId: number): Promise<boolean> {
+  try {
+    const grant = await openJson<McpProxyGrant>(token);
+    return grant.connectionId === connectionId && grant.exp > Date.now();
+  } catch {
+    // Forged or truncated tokens fail AES-GCM authentication and land here.
+    return false;
+  }
+}
+
+// Streamable-HTTP MCP requests/responses carry framing state in these
+// headers; everything else (cookies, the sandbox's grant) stops at the proxy.
+const FORWARDED_REQUEST_HEADERS = [
+  'content-type',
+  'accept',
+  'mcp-session-id',
+  'mcp-protocol-version',
+  'last-event-id',
+];
+const FORWARDED_RESPONSE_HEADERS = ['content-type', 'mcp-session-id', 'mcp-protocol-version'];
+
+function jsonRpcError(id: JsonValue, message: string): Response {
+  const rpcId = isString(id) || isNumber(id) ? id : null;
+  return Response.json({
+    jsonrpc: '2.0',
+    id: rpcId,
+    error: { code: -32602, message },
+  });
+}
+
+// Enforce the connection's tool allowlist at the only place the sandbox can
+// invoke a tool. tools/list responses are relayed unfiltered (streaming SSE
+// makes rewriting them fragile), so a disallowed tool may be visible but any
+// call to it is rejected here. Legacy JSON-RPC batches are checked entry by
+// entry so a batched call cannot slip past the gate.
+function blockedToolResponse(conn: ConnectionRow, body: string): Response | null {
+  const allowed = connectionSnapshot(conn).tools;
+  if (!allowed) return null;
+  let rpc: JsonValue;
+  try {
+    rpc = parseJson(body);
+  } catch {
+    return null; // not JSON — let the upstream server reject it
+  }
+  const requests = Array.isArray(rpc) ? rpc : [rpc];
+  for (const entry of requests) {
+    if (!isJsonObject(entry) || entry.method !== 'tools/call' || !isJsonObject(entry.params)) {
+      continue;
+    }
+    const tool = entry.params.name;
+    if (isString(tool) && !allowed.includes(tool)) {
+      return jsonRpcError(entry.id ?? null, `tool "${tool}" is not in this connection's allowlist`);
+    }
+  }
+  return null;
+}
+
+export async function handleMcpProxy(c: Context): Promise<Response> {
+  const connectionId = Number(c.req.param('id'));
+  if (!Number.isInteger(connectionId) || connectionId <= 0) return c.notFound();
+  const authorization = c.req.header('authorization') ?? '';
+  const token = authorization.startsWith('Bearer ') ? authorization.slice('Bearer '.length) : '';
+  if (!token || !(await verifyGrant(token, connectionId))) {
+    return c.json({ error: 'invalid or expired grant' }, 401);
+  }
+  const conn = await getConnection(connectionId);
+  if (!conn || conn.kind !== 'mcp') return c.notFound();
+
+  let body: string | undefined;
+  if (c.req.method === 'POST') {
+    body = await c.req.text();
+    const blocked = blockedToolResponse(conn, body);
+    if (blocked) return blocked;
+  }
+
+  let auth: Awaited<ReturnType<typeof resolveConnectionAuth>>;
+  try {
+    auth = await resolveConnectionAuth(conn);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : 'could not resolve credentials';
+    return c.json({ error: detail }, 502);
+  }
+
+  const headers = new Headers();
+  for (const name of FORWARDED_REQUEST_HEADERS) {
+    const value = c.req.header(name);
+    if (value) headers.set(name, value);
+  }
+  if (auth) headers.set(auth.headerName, auth.headerValue);
+
+  const upstream = await fetch(conn.url, { method: c.req.method, headers, body });
+  const responseHeaders = new Headers();
+  for (const name of FORWARDED_RESPONSE_HEADERS) {
+    const value = upstream.headers.get(name);
+    if (value) responseHeaders.set(name, value);
+  }
+  // Pass the body stream through untouched so SSE responses keep streaming.
+  return new Response(upstream.body, { status: upstream.status, headers: responseHeaders });
+}
+
+// The MCP config for one sandbox run: every attached connection routed
+// through the proxy with its own grant. Returns null when there is nothing to
+// mount, or when no TOKEN_ENCRYPTION_KEY is configured (grants cannot be
+// minted without it). `secrets` lists the grants for log scrubbing.
+export interface SandboxMcpConfig {
+  configJson: string;
+  secrets: string[];
+}
+
+function serverName(conn: ConnectionRow): string {
+  const slug = conn.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || `connection-${conn.id}`;
+}
+
+export async function buildSandboxMcpConfig(
+  connections: ConnectionRow[],
+  repositoryId: number,
+): Promise<SandboxMcpConfig | null> {
+  if (connections.length === 0) return null;
+  if (!encryptionConfigured()) {
+    console.warn(
+      'turbodiff: skipping MCP mounts for sandbox run — TOKEN_ENCRYPTION_KEY is not configured',
+    );
+    return null;
+  }
+  const servers: {
+    [name: string]: { type: 'http'; url: string; headers: { [h: string]: string } };
+  } = {};
+  const secrets: string[] = [];
+  for (const conn of connections) {
+    const grant = await mintMcpProxyGrant(conn.id, repositoryId);
+    secrets.push(grant);
+    servers[serverName(conn)] = {
+      type: 'http',
+      url: `${env.PUBLIC_BASE_URL}/mcp-proxy/${conn.id}`,
+      headers: { Authorization: `Bearer ${grant}` },
+    };
+  }
+  return { configJson: JSON.stringify({ mcpServers: servers }), secrets };
+}

--- a/src/lib/migrations.worker.test.ts
+++ b/src/lib/migrations.worker.test.ts
@@ -81,6 +81,10 @@ describe('D1 migrations', () => {
 		 VALUES (11, 1001, 'review', 'Review', 'Review the change')`,
       ),
       db.prepare(
+        `INSERT INTO repositories (id, installation_id, owner, name)
+		 VALUES (31, 1001, 'acme', 'web')`,
+      ),
+      db.prepare(
         `INSERT INTO agent_connections
 		 (id, agent_id, name, url, tool_allowlist, auth_ciphertext, optional)
 		 VALUES (21, 11, 'catalog', 'https://mcp.example.test', '["search"]', 'sealed', 0)`,
@@ -89,17 +93,28 @@ describe('D1 migrations', () => {
 
     await applyD1Migrations(db, testEnv.TEST_MIGRATIONS.slice(start));
 
+    // 0022 moves the per-agent row into the registry; 0032 re-scopes the
+    // attachment onto every enabled repo of the connection's installation.
     const connection = await db
       .prepare(
-        `SELECT c.*, l.agent_id FROM connections c
-		 JOIN agent_connection_links l ON l.connection_id = c.id`,
+        `SELECT c.*, l.repository_id, l.reviews, l.automations FROM connections c
+		 JOIN repo_connections l ON l.connection_id = c.id`,
       )
-      .first<{ name: string; auth_ciphertext: string; optional: number; agent_id: number }>();
+      .first<{
+        name: string;
+        auth_ciphertext: string;
+        optional: number;
+        repository_id: number;
+        reviews: number;
+        automations: number;
+      }>();
     expect(connection).toMatchObject({
       name: 'catalog',
       auth_ciphertext: 'sealed',
       optional: 0,
-      agent_id: 11,
+      repository_id: 31,
+      reviews: 1,
+      automations: 1,
     });
   });
 

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -39,7 +39,6 @@ import {
   getPlanByFeatureId,
   getRepoById,
   latestVerificationForFeature,
-  listAgentConnections,
   listAgentRunsForAutomationRun,
   listAgentRunsForFeature,
   listAgentRunsForPlan,
@@ -47,7 +46,7 @@ import {
   listAutomationRuns,
   listAutomationsForInstallations,
   listCockpitComments,
-  listConnectionLinks,
+  listRepoConnectionLinks,
   listConnections,
   listFixAttemptsForRepoPrs,
   listInstallationsWithRepos,
@@ -68,7 +67,7 @@ import {
   resolveAgentEnabled,
   resolveConnectionAuth,
   resolveSkillEnabled,
-  setAgentConnectionLink,
+  setRepoConnectionLink,
   setPlanArchived,
   setRepoAgentEnabled,
   setRepoAutoFix,
@@ -1591,7 +1590,6 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
   app.get('/agents/:id', async (c) => {
     const agent = await authorizedAgent(c);
     if (!agent) return c.json({ error: 'unknown agent' }, 404);
-    const connections = await listAgentConnections(agent.id);
     return c.json<ApiAgentDetail>({
       agent: {
         id: agent.id,
@@ -1603,17 +1601,6 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         instructions: agent.instructions,
         installation_id: agent.installation_id,
       },
-      connections: connections.map((conn) => {
-        const snap = connectionSnapshot(conn);
-        return {
-          id: conn.id,
-          name: conn.name,
-          url: conn.url,
-          tools: snap.tools ?? null,
-          has_auth: conn.auth_type !== 'none',
-        };
-      }),
-      encryption_configured: encryptionConfigured(),
       default_model: DEFAULT_MODEL,
     });
   });
@@ -1917,12 +1904,10 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
 
   app.get('/integrations', async (c) => {
     const { installationIds } = c.get('user');
-    await Promise.all(installationIds.map((id) => ensureBuiltinAgents(id)));
-    const [groups, agents, connections, links] = await Promise.all([
+    const [groups, connections, links] = await Promise.all([
       listInstallationsWithRepos(installationIds),
-      listAgents(installationIds),
       listConnections(installationIds),
-      listConnectionLinks(installationIds),
+      listRepoConnectionLinks(installationIds),
     ]);
     return c.json<ApiIntegrations>({
       encryption_configured: encryptionConfigured(),
@@ -1930,18 +1915,18 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         id: installation.id,
         account_login: installation.account_login,
       })),
-      // Not deduped by slug (unlike GET /agents): every installation has its
-      // own agent rows, and a connection may only link to the rows belonging
-      // to its installation — the client filters on installation_id.
-      agents: agents.map((a) => ({
-        id: a.id,
-        installation_id: a.installation_id,
-        slug: a.slug,
-        name: a.name,
-        description: a.description,
-        model: a.model,
-        is_builtin: a.is_builtin === 1,
-      })),
+      // A connection may only attach to repos of its own installation — the
+      // client filters on installation_id.
+      repos: groups.flatMap(({ repos }) =>
+        repos
+          .filter((r) => r.enabled === 1)
+          .map((r) => ({
+            id: r.id,
+            installation_id: r.installation_id,
+            owner: r.owner,
+            name: r.name,
+          })),
+      ),
       connections: connections.map((conn) => {
         const snap = connectionSnapshot(conn);
         return {
@@ -1954,7 +1939,13 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
           has_auth: conn.auth_type !== 'none',
           auth_type: conn.auth_type,
           oauth_status: oauthStatus(conn),
-          agent_ids: links.filter((l) => l.connection_id === conn.id).map((l) => l.agent_id),
+          repo_links: links
+            .filter((l) => l.connection_id === conn.id)
+            .map((l) => ({
+              repository_id: l.repository_id,
+              reviews: l.reviews === 1,
+              automations: l.automations === 1,
+            })),
         };
       }),
     });
@@ -2225,22 +2216,35 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
   });
 
   // Attach/detach an MCP integration to an agent.
-  app.put('/integrations/:id/agents/:agentId', async (c) => {
+  app.put('/integrations/:id/repos/:repoId', async (c) => {
     const conn = await authorizedConnection(c);
     if (!conn) return c.json({ error: 'unknown integration' }, 404);
-    if (conn.kind !== 'mcp')
-      return c.json({ error: 'only MCP integrations attach to agents' }, 400);
-    const agentId = Number(c.req.param('agentId'));
-    const agent = Number.isInteger(agentId) ? await getAgentById(agentId) : null;
-    if (!agent || agent.installation_id !== conn.installation_id) {
-      return c.json({ error: 'unknown agent' }, 404);
+    if (conn.kind !== 'mcp') return c.json({ error: 'only MCP integrations attach to repos' }, 400);
+    const repoId = Number(c.req.param('repoId'));
+    const repo = Number.isInteger(repoId) ? await getRepoById(repoId) : null;
+    if (!repo || repo.installation_id !== conn.installation_id) {
+      return c.json({ error: 'unknown repository' }, 404);
     }
-    const body = await c.req.json<{ attached?: boolean }>().catch(() => null);
+    const body = await c.req
+      .json<{ attached?: boolean; reviews?: boolean; automations?: boolean }>()
+      .catch(() => null);
     const attached = body?.attached;
     if (!isBoolean(attached)) {
-      return c.json({ error: 'body must be {"attached": true|false}' }, 400);
+      return c.json({ error: 'body must be {"attached": true|false, ...}' }, 400);
     }
-    await setAgentConnectionLink(agent.id, conn.id, attached);
+    const reviews = body?.reviews;
+    const automations = body?.automations;
+    if (
+      (reviews !== undefined && !isBoolean(reviews)) ||
+      (automations !== undefined && !isBoolean(automations))
+    ) {
+      return c.json({ error: '"reviews" and "automations" must be booleans when present' }, 400);
+    }
+    await setRepoConnectionLink(repo.id, conn.id, {
+      attached,
+      reviews: reviews ?? true,
+      automations: automations ?? true,
+    });
     return c.json({ ok: true });
   });
 

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -258,18 +258,8 @@ export interface ApiAgentsList {
   agents: ApiAgentSummary[];
 }
 
-export interface ApiConnection {
-  id: number;
-  name: string;
-  url: string;
-  tools: string[] | null; // null = all tools
-  has_auth: boolean;
-}
-
 export interface ApiAgentDetail {
   agent: ApiAgentSummary & { instructions: string; installation_id: number };
-  connections: ApiConnection[];
-  encryption_configured: boolean;
   default_model: string;
 }
 
@@ -360,20 +350,30 @@ export interface ApiIntegration {
   has_auth: boolean;
   auth_type: string; // 'none' | 'bearer' | 'api_key' | 'client_credentials' | 'oauth'
   oauth_status: 'not_connected' | 'connected' | 'expired' | 'needs_reauth' | null;
-  agent_ids: number[]; // agents this MCP connection is attached to
+  repo_links: ApiRepoConnectionLink[]; // repos this MCP connection is attached to
 }
 
-// Agent rows here are NOT deduped by slug the way /agents does it: an
-// integration belongs to one installation and only attaches to that
-// installation's own agent rows, so each row carries its installation.
-export interface ApiIntegrationAgent extends ApiAgentSummary {
+// One repo attachment of an MCP connection, with its per-context mount
+// toggles: reviews = hosted PR reviews, automations = sandbox automation runs.
+export interface ApiRepoConnectionLink {
+  repository_id: number;
+  reviews: boolean;
+  automations: boolean;
+}
+
+// A connection belongs to one installation and only attaches to that
+// installation's own repos — the client filters on installation_id.
+export interface ApiIntegrationRepo {
+  id: number;
   installation_id: number;
+  owner: string;
+  name: string;
 }
 
 export interface ApiIntegrations {
   encryption_configured: boolean;
   installations: { id: number; account_login: string }[];
-  agents: ApiIntegrationAgent[];
+  repos: ApiIntegrationRepo[];
   connections: ApiIntegration[];
 }
 


### PR DESCRIPTION
## Summary

Rethinks the MCP attachment model: connections still live in the installation-level integrations registry, but they now attach to **repositories** instead of agents — so every action on a repo can mount them, including scheduled automations, which previously had no MCP access at all.

### Schema (migration 0032)

- New `repo_connections (repository_id, connection_id, reviews, automations)` link table, following the `repo_agents`/`repo_skills` house pattern, with per-context mount toggles.
- Seeds from the old model: since agents run on every repo by default, any MCP connection with at least one agent link attaches to every enabled repo of its installation. `agent_connection_links` is dropped.
- Verified locally: full migration chain applies, schema confirmed via `PRAGMA table_info`, and the 0022 migration test now asserts the whole legacy → registry → repo-scoped chain.

### Hosted PR reviews

`dispatchReviewAgent` snapshots `listRepoConnections(repo.id, 'reviews')` instead of the agent's links. The signal/snapshot shape is unchanged, so the pr-reviewer agent needed no changes.

### Automations (new capability)

Automation runs now mount the repo's `automations`-enabled connections into the sandboxed Claude CLI via `--mcp-config --strict-mcp-config`. Crucially, **connection credentials never enter the sandbox**:

- The sandbox config points every server at a new `/mcp-proxy/:id` Worker route, authenticated by a short-lived AES-GCM-sealed grant (1h TTL, connection- and repo-bound) minted per run.
- The proxy injects the real credential per request using the existing `resolveConnectionAuth` resolver — same security property as hosted review mounts. A prompt-injected repo can at worst *use* a connection during the run, never exfiltrate its credential.
- The proxy enforces the connection's tool allowlist at `tools/call` time (including legacy JSON-RPC batches), and grants are added to the agent-log scrub list.
- This path also lifts the old `api_key` custom-header limitation, since the proxy can set any header.

### API + UI

- `PUT /integrations/:id/agents/:agentId` → `PUT /integrations/:id/repos/:repoId` with `{ attached, reviews?, automations? }` (upsert, so toggles update in place).
- `GET /integrations` returns `repos` + per-connection `repo_links` instead of agents/agent_ids; agent detail no longer carries connections.
- Integrations page: connection cards attach to repos (`owner/name` chips) with inline Reviews/Automations toggles; the agent-edit page's connections section is removed.

## Verification

- `vp check` passes (0 errors; only the 21 pre-existing out-of-scope warnings)
- `tsc --noEmit` (worker), `tsc -p tsconfig.client.json`, `tsc -p tsconfig.worker-tests.json` — all clean
- Migration applied against local D1 and schema inspected
- `vp test` not run (broken repo-wide, pre-existing); migration/db tests updated to the new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)