### PR TITLE
Fix conflict auto-resolve triggers, Web Push protocol, and MCP OAuth churn

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -64,9 +64,14 @@ jobs:
           script: |
             const marker = '<!-- turbodiff-preview -->';
             const url = ${{ toJSON(steps.upload.outputs.preview_url) }};
+            const noUrlHint =
+              '_upload succeeded but wrangler printed no preview URL — preview URLs are likely ' +
+              'disabled for this Worker. Set `"preview_urls": true` in wrangler.jsonc (applies on ' +
+              'the next production deploy) and make sure the account has a workers.dev subdomain ' +
+              'registered._';
             const body = [
               marker,
-              `**Preview:** ${url || '_upload succeeded but no preview URL was found in wrangler output — check the workflow log_'}`,
+              `**Preview:** ${url || noUrlHint}`,
               '',
               'This preview shares production’s database, queue, and sandbox container with `main` — avoid destructive or data-mutating actions. Sign-in and other redirect-based flows may not work correctly since auth URLs are pinned to the production domain. Use this for UI/API smoke-testing only.',
             ].join('\n');

--- a/migrations/0033_oauth_refresh_visibility.sql
+++ b/migrations/0033_oauth_refresh_visibility.sql
@@ -1,0 +1,14 @@
+-- Whether an OAuth connection holds a refresh token, tracked outside the
+-- sealed config blob so the integrations list can tell "access token lapsed
+-- but silently refreshable" (still connected) apart from "re-auth genuinely
+-- required" without decrypting. MCP servers commonly issue 10-15 minute
+-- access tokens, so treating every lapse as reconnect-worthy forced users
+-- through the OAuth flow constantly.
+ALTER TABLE connections ADD COLUMN oauth_has_refresh_token INTEGER NOT NULL DEFAULT 0;
+
+-- Optimistic backfill: existing connected OAuth rows almost always carry a
+-- refresh token. If one doesn't, the first failed refresh sets
+-- oauth_needs_reauth and the status turns red as before.
+UPDATE connections
+SET oauth_has_refresh_token = 1
+WHERE auth_type = 'oauth' AND auth_config_ciphertext IS NOT NULL;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "test:worker": "vp test --config vitest.worker.config.ts"
   },
   "dependencies": {
-    "@block65/webcrypto-web-push": "^1.0.2",
     "@cloudflare/sandbox": "^0.12.4",
     "@flue/runtime": "^2.0.1",
     "@pierre/diffs": "^1.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,9 +219,6 @@ importers:
 
   .:
     dependencies:
-      '@block65/webcrypto-web-push':
-        specifier: ^1.0.2
-        version: 1.0.2
       '@cloudflare/sandbox':
         specifier: ^0.12.4
         version: 0.12.5
@@ -348,7 +345,7 @@ importers:
         version: 0.2.8(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
       wrangler:
         specifier: ^4.97.0
         version: 4.120.0(@cloudflare/workers-types@5.20260813.1)
@@ -753,13 +750,6 @@ packages:
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
-
-  '@block65/custom-error@12.2.0':
-    resolution: {integrity: sha512-OH3qt4aY9W2kfpI5BY075Mc/M5HNJHjtYkxwUV62OZhKrKQeSUcIXHZkB6H+9YQ5a7D0po3JCouV3egeQDS2pA==}
-    engines: {node: '>=18.0.0'}
-
-  '@block65/webcrypto-web-push@1.0.2':
-    resolution: {integrity: sha512-KYFCz4tgnquZ+Mu4EFrB5IfwM0gWJdEKAN4Gj5ZbTRO+ZYcNLs2th36v0toGa+1XOL4qD7G20LnU6yH7zn5siQ==}
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
@@ -3260,10 +3250,6 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  base64-arraybuffer@1.0.2:
-    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
-    engines: {node: '>= 0.6.0'}
-
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -4705,10 +4691,6 @@ packages:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
 
-  serialize-error@11.0.3:
-    resolution: {integrity: sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==}
-    engines: {node: '>=14.16'}
-
   seroval-plugins@1.6.2:
     resolution: {integrity: sha512-TfxuUjlbBESzUOWdTkTKqvSmav0ABym+itetDXLK6mDz8SmrpdI30aF8RTXE8Bvq+tH/1yIDkvy3W0lfQb1ipQ==}
     engines: {node: '>=10'}
@@ -4919,14 +4901,6 @@ packages:
   turndown@7.2.4:
     resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
     engines: {node: '>=18', npm: '>=9'}
-
-  type-fest@2.19.0:
-    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
-    engines: {node: '>=12.20'}
-
-  type-fest@4.41.0:
-    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
-    engines: {node: '>=16'}
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -5759,16 +5733,6 @@ snapshots:
 
   '@blazediff/core@1.9.1': {}
 
-  '@block65/custom-error@12.2.0':
-    dependencies:
-      serialize-error: 11.0.3
-
-  '@block65/webcrypto-web-push@1.0.2':
-    dependencies:
-      '@block65/custom-error': 12.2.0
-      base64-arraybuffer: 1.0.2
-      type-fest: 4.41.0
-
   '@borewit/text-codec@0.2.2': {}
 
   '@cfworker/json-schema@4.1.1': {}
@@ -5825,7 +5789,7 @@ snapshots:
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
       miniflare: 5.20260811.1-alpha
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
       wrangler: 4.123.0(@cloudflare/workers-types@5.20260813.1)
       zod: 4.4.3
     transitivePeerDependencies:
@@ -7404,7 +7368,7 @@ snapshots:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.1)
       '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -7420,7 +7384,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -7699,8 +7663,6 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  base64-arraybuffer@1.0.2: {}
-
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.11.13: {}
@@ -7727,7 +7689,7 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -9432,10 +9394,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serialize-error@11.0.3:
-    dependencies:
-      type-fest: 2.19.0
-
   seroval-plugins@1.6.2(seroval@1.6.2):
     dependencies:
       seroval: 1.6.2
@@ -9684,10 +9642,6 @@ snapshots:
     dependencies:
       '@mixmark-io/domino': 2.2.0
 
-  type-fest@2.19.0: {}
-
-  type-fest@4.41.0: {}
-
   type-is@2.1.0:
     dependencies:
       content-type: 2.0.0
@@ -9838,7 +9792,7 @@ snapshots:
       oxfmt: 0.61.0(vite-plus@0.2.8(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
       oxlint: 1.76.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.8(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.8
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.8
@@ -9879,7 +9833,7 @@ snapshots:
       - vite
       - yaml
 
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.8(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -18,6 +18,7 @@ import { type ConflictResolveQueueMessage } from './lib/conflict-resolver.ts';
 import { startFix, FixWorkflow } from './lib/fix-workflow.ts';
 import { type FixQueueMessage } from './lib/fixer.ts';
 import { startGeneration, type GenQueueMessage } from './lib/generation-workflow.ts';
+import { sweepFactoryPrConflicts } from './lib/merge-conflicts.ts';
 import { runPlanAnalyze, runPlanRefine, type PlanQueueMessage } from './lib/planner.ts';
 import { startVerification, VerificationWorkflow } from './lib/verification-workflow.ts';
 import { type VerifyQueueMessage } from './lib/verifier.ts';
@@ -89,5 +90,9 @@ export default {
   // schedule precision is bounded by the cron interval in wrangler.jsonc.
   async scheduled(): Promise<void> {
     await pollAutomations();
+    // Conflict sweep rides the same tick: base-branch pushes fire no event
+    // this app receives, so open factory PRs are re-checked here (see
+    // merge-conflicts.ts).
+    await sweepFactoryPrConflicts();
   },
 };

--- a/src/lib/auto-merge.ts
+++ b/src/lib/auto-merge.ts
@@ -2,8 +2,7 @@ import { env } from 'cloudflare:workers';
 import { gh } from '../tools/github.ts';
 import { getFeatureByRepoPr, latestVerificationForFeature, type RepositoryRow } from './db.ts';
 import { installationToken } from './github-app.ts';
-import { checkMergeability, postConflictCommentIfAbsent } from './merge-conflicts.ts';
-import type { ConflictResolveQueueMessage } from './conflict-resolver.ts';
+import { checkMergeability, maybeResolveConflict } from './merge-conflicts.ts';
 
 // Phase 5 (docs/software-factory-design.md): opt-in auto-merge for factory
 // PRs. Trust is earned, not configured — even with the toggle on, a PR merges
@@ -61,24 +60,8 @@ export async function maybeAutoMerge(repo: RepositoryRow, prNumber: number): Pro
       retryOnUnknown: true,
     });
     if (mergeability.hasConflict) {
-      if (repo.auto_resolve_conflicts === 1) {
-        const msg: ConflictResolveQueueMessage = {
-          kind: 'resolve_conflict',
-          repoId: repo.id,
-          prNumber,
-        };
-        await env.FACTORY_QUEUE.send(msg);
-        console.log(`turbodiff: conflict detected on ${label}, resolution enqueued`);
-      } else {
-        await postConflictCommentIfAbsent(
-          token,
-          repo.owner,
-          repo.name,
-          prNumber,
-          mergeability.baseRef,
-        );
-        console.log(`turbodiff: auto-merge declined for ${label} (merge conflict)`);
-      }
+      console.log(`turbodiff: auto-merge declined for ${label} (merge conflict)`);
+      await maybeResolveConflict(repo, prNumber);
       return;
     }
 
@@ -104,5 +87,9 @@ export async function maybeAutoMerge(repo: RepositoryRow, prNumber: number): Pro
     // Failure to auto-merge is never an error state for the pipeline: the PR
     // simply stays open for a human (branch protection, conflicts, races).
     console.warn(`turbodiff: auto-merge attempt failed for ${label}:`, err);
+    // A failed merge PUT is frequently a conflict that landed between the
+    // mergeability check and the merge — re-check and dispatch the resolver
+    // instead of going silent (maybeResolveConflict never throws).
+    await maybeResolveConflict(repo, prNumber);
   }
 }

--- a/src/lib/conflict-resolver.ts
+++ b/src/lib/conflict-resolver.ts
@@ -90,16 +90,26 @@ export async function processResolveConflictMessage(
   const mergeability = await checkMergeability(token, repo.owner, repo.name, msg.prNumber, {
     retryOnUnknown: true,
   });
+  if (mergeability.mergeableState === 'unknown') {
+    // GitHub still hasn't computed mergeability after the poll budget —
+    // throw so the workflow step's retry re-checks later, instead of
+    // misreading "unknown" as "no longer conflicted" and dropping the run.
+    throw new Error(`mergeability still unknown for ${label}`);
+  }
   if (!mergeability.hasConflict) {
     console.log(`turbodiff: conflict resolution skipped for ${label} (no longer conflicted)`);
     return;
   }
 
+  // Only conflict_resolve attempts count against this cap: a PR that burned
+  // its fix attempts in the review/verification fix loop is exactly the kind
+  // likely to sit conflicted, and must still be resolvable.
   const attemptId = await tryRecordFixAttempt(
     repo.id,
     msg.prNumber,
     'conflict_resolve',
     FIX_MAX_ATTEMPTS,
+    'conflict_resolve',
   );
   if (attemptId === null) {
     // A run already in flight for this PR is the single-flight guard doing
@@ -134,6 +144,19 @@ export async function processResolveConflictMessage(
       if (feature?.acceptance) {
         await env.FACTORY_QUEUE.send({ kind: 'verify', featureId: feature.id });
       }
+    }
+    // A discarded resolution must be visible on the PR — silently burning a
+    // cap slot looked like "conflicts never get resolved" from the outside.
+    if (outcome.status === 'tests_failed') {
+      await gh(token, `/repos/${repo.owner}/${repo.name}/issues/${msg.prNumber}/comments`, {
+        method: 'POST',
+        body: JSON.stringify({
+          body:
+            '⚠️ **Turbodiff resolved the merge conflict, but the repo check command failed** on ' +
+            'the merged result, so the resolution was not pushed. Fix the check (or resolve the ' +
+            'conflict manually) — the next detection cycle will retry.',
+        }),
+      }).catch(() => {});
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -581,6 +581,11 @@ export async function tryRecordFixAttempt(
   prNumber: number,
   trigger: string,
   cap: number,
+  // When set, only attempts with this trigger count against the cap — so a
+  // PR that burned its fix attempts on review-driven fixes can still get
+  // conflict resolutions (and vice versa). The running-attempt guard stays
+  // global regardless: never two sandbox runs on one PR.
+  capTrigger?: string,
 ): Promise<number | null> {
   await env.DB.prepare(
     `UPDATE fix_attempts SET status = 'failed', error = 'stale: consumer killed before completion'
@@ -592,16 +597,36 @@ export async function tryRecordFixAttempt(
   const row = await env.DB.prepare(
     `INSERT INTO fix_attempts (repository_id, pr_number, "trigger")
 		 SELECT ?1, ?2, ?3
-		 WHERE (SELECT COUNT(*) FROM fix_attempts WHERE repository_id = ?1 AND pr_number = ?2) < ?4
+		 WHERE (SELECT COUNT(*) FROM fix_attempts
+		        WHERE repository_id = ?1 AND pr_number = ?2
+		          AND (?5 IS NULL OR "trigger" = ?5)) < ?4
 		   AND NOT EXISTS (
 		     SELECT 1 FROM fix_attempts
 		     WHERE repository_id = ?1 AND pr_number = ?2 AND status = 'running'
 		   )
 		 RETURNING id`,
   )
-    .bind(repositoryId, prNumber, trigger, cap)
+    .bind(repositoryId, prNumber, trigger, cap, capTrigger ?? null)
     .first<{ id: number }>();
   return row?.id ?? null;
+}
+
+// Open factory PRs on repos that opted into auto conflict resolution — the
+// scheduled sweep's work list (see merge-conflicts.ts).
+export async function listOpenFactoryPrConflictCandidates(): Promise<
+  { repo: RepositoryRow; prNumber: number }[]
+> {
+  const res = await env.DB.prepare(
+    `SELECT r.*, f.pr_number AS factory_pr_number
+		 FROM features f
+		 JOIN repositories r ON r.id = f.repository_id
+		 WHERE f.pr_number IS NOT NULL AND f.status = 'pr_opened'
+		   AND r.enabled = 1 AND r.auto_resolve_conflicts = 1`,
+  ).all<RepositoryRow & { factory_pr_number: number }>();
+  return res.results.map(({ factory_pr_number, ...repo }) => ({
+    repo,
+    prNumber: factory_pr_number,
+  }));
 }
 
 // --- agent run logs (full session transcripts; content in R2, pointer here) ---
@@ -1641,6 +1666,7 @@ export interface ConnectionRow {
   auth_config_ciphertext: string | null; // sealed JSON blob, shape depends on auth_type
   oauth_token_expires_at: string | null;
   oauth_needs_reauth: number;
+  oauth_has_refresh_token: number;
 }
 
 // The non-secret snapshot that rides the review.request signal so the agent
@@ -1740,14 +1766,14 @@ export async function createConnection(fields: {
 }
 
 // Persists rotated/registered OAuth or client-credentials material. Every
-// field is optional and left unchanged when omitted (COALESCE), except
-// oauth_needs_reauth which is a boolean so `false` must still bind 0 rather
-// than be skipped.
+// field is optional and left unchanged when omitted (COALESCE), except the
+// booleans, which must still bind 0 for `false` rather than be skipped.
 export interface ConnectionAuthUpdate {
   authType?: string;
   authConfigCiphertext?: string;
   oauthTokenExpiresAt?: string;
   oauthNeedsReauth?: boolean;
+  oauthHasRefreshToken?: boolean;
 }
 
 export async function updateConnectionAuth(
@@ -1759,7 +1785,8 @@ export async function updateConnectionAuth(
 		 auth_type = COALESCE(?2, auth_type),
 		 auth_config_ciphertext = COALESCE(?3, auth_config_ciphertext),
 		 oauth_token_expires_at = COALESCE(?4, oauth_token_expires_at),
-		 oauth_needs_reauth = COALESCE(?5, oauth_needs_reauth)
+		 oauth_needs_reauth = COALESCE(?5, oauth_needs_reauth),
+		 oauth_has_refresh_token = COALESCE(?6, oauth_has_refresh_token)
 		 WHERE id = ?1`,
   )
     .bind(
@@ -1768,6 +1795,7 @@ export async function updateConnectionAuth(
       fields.authConfigCiphertext ?? null,
       fields.oauthTokenExpiresAt ?? null,
       fields.oauthNeedsReauth === undefined ? null : fields.oauthNeedsReauth ? 1 : 0,
+      fields.oauthHasRefreshToken === undefined ? null : fields.oauthHasRefreshToken ? 1 : 0,
     )
     .run();
 }
@@ -1851,6 +1879,12 @@ interface OAuthConfig {
 
 // 60s safety margin so a token doesn't expire mid-request.
 const TOKEN_EXPIRY_MARGIN_MS = 60_000;
+// How long one resolver's refresh claim suppresses concurrent refreshes.
+// Must stay under TOKEN_EXPIRY_MARGIN_MS so losers' access tokens are still
+// live for the claim window.
+const REFRESH_CLAIM_MS = 45_000;
+// Fallback expiry when a token response omits expires_in.
+const DEFAULT_TOKEN_TTL_MS = 60 * 60_000;
 
 function stillFresh(expiresAt: string | null | undefined): boolean {
   return !!expiresAt && new Date(expiresAt).getTime() > Date.now() + TOKEN_EXPIRY_MARGIN_MS;
@@ -1907,10 +1941,39 @@ export async function resolveConnectionAuth(conn: ConnectionRow): Promise<Resolv
         return { headerName: 'authorization', headerValue: `Bearer ${config.accessToken}` };
       }
       if (!config.refreshToken) {
-        await updateConnectionAuth(conn.id, { oauthNeedsReauth: true });
+        await updateConnectionAuth(conn.id, {
+          oauthNeedsReauth: true,
+          oauthHasRefreshToken: false,
+        });
         throw new Error(
           `turbodiff: connection ${conn.id}'s OAuth token expired and has no refresh token — reconnect it from the integrations page`,
         );
+      }
+      // Single-flight the refresh: MCP servers rotate refresh tokens, and two
+      // concurrent refreshes with the same token get the loser an
+      // invalid_grant (reuse-detection servers revoke the whole grant). Claim
+      // by bumping the expiry a short window forward, conditioned on the value
+      // this request read — losers see the bump, count the token as fresh
+      // again, and keep using the current access token (we refresh
+      // TOKEN_EXPIRY_MARGIN_MS early, so it outlives the claim window).
+      const claimUntil = new Date(Date.now() + REFRESH_CLAIM_MS).toISOString();
+      const claim = await env.DB.prepare(
+        `UPDATE connections SET oauth_token_expires_at = ?2
+			 WHERE id = ?1 AND (oauth_token_expires_at = ?3 OR (oauth_token_expires_at IS NULL AND ?3 IS NULL))`,
+      )
+        .bind(conn.id, claimUntil, conn.oauth_token_expires_at)
+        .run();
+      if (claim.meta.changes === 0) {
+        // Another resolver holds the claim (or already finished). Re-read and
+        // serve whatever token is current.
+        const fresh = await getConnection(conn.id);
+        const freshConfig = fresh?.auth_config_ciphertext
+          ? await openJson<OAuthConfig>(fresh.auth_config_ciphertext)
+          : null;
+        if (freshConfig?.accessToken) {
+          return { headerName: 'authorization', headerValue: `Bearer ${freshConfig.accessToken}` };
+        }
+        throw new Error(`turbodiff: connection ${conn.id}'s OAuth refresh is in flight — retry`);
       }
       const refreshed = await refreshOAuthToken(
         config.tokenEndpoint,
@@ -1918,10 +1981,19 @@ export async function resolveConnectionAuth(conn: ConnectionRow): Promise<Resolv
         config.clientId,
         config.clientSecret,
       );
-      if (!refreshed) {
-        await updateConnectionAuth(conn.id, { oauthNeedsReauth: true });
+      if (!refreshed.ok) {
+        if (refreshed.invalidGrant) {
+          // Definitive: the refresh token is revoked. Only this flips the
+          // connection into needs_reauth.
+          await updateConnectionAuth(conn.id, { oauthNeedsReauth: true });
+          throw new Error(
+            `turbodiff: connection ${conn.id}'s OAuth refresh token was revoked (${refreshed.detail}) — reconnect it from the integrations page`,
+          );
+        }
+        // Transient (network blip, 5xx): fail this request only. The claim
+        // window lapses on its own and the next request retries the refresh.
         throw new Error(
-          `turbodiff: connection ${conn.id}'s OAuth token could not be refreshed — reconnect it from the integrations page`,
+          `turbodiff: connection ${conn.id}'s OAuth refresh failed (${refreshed.detail}) — will retry`,
         );
       }
       const authUpdate: ConnectionAuthUpdate = {
@@ -1931,8 +2003,13 @@ export async function resolveConnectionAuth(conn: ConnectionRow): Promise<Resolv
           refreshToken: refreshed.refreshToken ?? config.refreshToken,
         }),
         oauthNeedsReauth: false,
+        oauthHasRefreshToken: true,
+        // A refresh response without expires_in must still advance the expiry
+        // (COALESCE-based updates can never clear it), or every subsequent
+        // request re-enters the refresh path forever.
+        oauthTokenExpiresAt:
+          refreshed.expiresAt ?? new Date(Date.now() + DEFAULT_TOKEN_TTL_MS).toISOString(),
       };
-      if (refreshed.expiresAt) authUpdate.oauthTokenExpiresAt = refreshed.expiresAt;
       await updateConnectionAuth(conn.id, authUpdate);
       return { headerName: 'authorization', headerValue: `Bearer ${refreshed.accessToken}` };
     }
@@ -1942,14 +2019,22 @@ export async function resolveConnectionAuth(conn: ConnectionRow): Promise<Resolv
   }
 }
 
-// Cheap OAuth status for the integrations list — no decryption needed.
+// Cheap OAuth status for the integrations list — no decryption needed. A
+// lapsed access token with a stored refresh token is still 'connected': MCP
+// servers routinely issue 10-15 minute access tokens, and the resolver
+// refreshes silently on the next request. 'expired' is reserved for
+// connections that genuinely cannot recover without re-auth.
 export function oauthStatus(
   conn: ConnectionRow,
 ): 'not_connected' | 'connected' | 'expired' | 'needs_reauth' | null {
   if (conn.auth_type !== 'oauth') return null;
   if (conn.oauth_needs_reauth === 1) return 'needs_reauth';
   if (conn.auth_config_ciphertext === null) return 'not_connected';
-  if (conn.oauth_token_expires_at && new Date(conn.oauth_token_expires_at).getTime() < Date.now()) {
+  if (
+    conn.oauth_has_refresh_token !== 1 &&
+    conn.oauth_token_expires_at &&
+    new Date(conn.oauth_token_expires_at).getTime() < Date.now()
+  ) {
     return 'expired';
   }
   return 'connected';

--- a/src/lib/mcp-oauth.ts
+++ b/src/lib/mcp-oauth.ts
@@ -39,6 +39,10 @@ export interface OAuthEndpoints {
   authorizationEndpoint: string;
   tokenEndpoint: string;
   registrationEndpoint?: string;
+  // Advertised scopes (RFC 8414 scopes_supported). Requested verbatim during
+  // authorization — some servers only issue refresh tokens when the request
+  // names a scope (e.g. offline_access).
+  scopesSupported?: string[];
 }
 
 async function fetchJson(url: string): Promise<JsonObject | null> {
@@ -103,7 +107,9 @@ export async function discoverOAuthEndpoints(mcpServerUrl: string): Promise<OAut
     ? rawRegistrationEndpoint
     : undefined;
   if (registrationEndpoint) assertSecureUrl(registrationEndpoint, 'registration endpoint');
-  return { authorizationEndpoint, tokenEndpoint, registrationEndpoint };
+  const rawScopes = metadata?.scopes_supported;
+  const scopesSupported = isJsonArray(rawScopes) ? rawScopes.filter(isString) : undefined;
+  return { authorizationEndpoint, tokenEndpoint, registrationEndpoint, scopesSupported };
 }
 
 // --- dynamic client registration (RFC 7591) ---
@@ -302,15 +308,20 @@ export async function exchangeAuthorizationCode(
   };
 }
 
-// Null on any failure (revoked, expired, or rotated elsewhere) — callers set
-// oauth_needs_reauth and drop the stored credential, mirroring
-// refreshUserToken's contract in github-app.ts.
+// Failures are discriminated so callers can tell a definitive revocation
+// (invalid_grant — the refresh token is dead, re-auth is genuinely required)
+// from a transient failure (network blip, 5xx, non-JSON body) that should be
+// retried on the next request without scrapping the stored credential.
+export type OAuthRefreshResult =
+  | { ok: true; accessToken: string; refreshToken?: string; expiresAt?: string }
+  | { ok: false; invalidGrant: boolean; detail: string };
+
 export async function refreshOAuthToken(
   tokenEndpoint: string,
   refreshToken: string,
   clientId: string,
   clientSecret?: string,
-): Promise<TokenResult | null> {
+): Promise<OAuthRefreshResult> {
   const params = new URLSearchParams({
     grant_type: 'refresh_token',
     refresh_token: refreshToken,
@@ -318,8 +329,15 @@ export async function refreshOAuthToken(
   });
   if (clientSecret) params.set('client_secret', clientSecret);
   const data = await tokenRequest(tokenEndpoint, params);
-  if (!data || !isString(data.access_token)) return null;
+  if (!data || !isString(data.access_token)) {
+    return {
+      ok: false,
+      invalidGrant: data?.error === 'invalid_grant',
+      detail: describeTokenError(data),
+    };
+  }
   return {
+    ok: true,
     accessToken: data.access_token,
     refreshToken: isString(data.refresh_token) ? data.refresh_token : undefined,
     expiresAt: expiresAtFrom(data.expires_in),

--- a/src/lib/merge-conflicts.ts
+++ b/src/lib/merge-conflicts.ts
@@ -1,9 +1,17 @@
+import { env } from 'cloudflare:workers';
 import { gh } from '../tools/github.ts';
+import {
+  getFeatureByRepoPr,
+  listOpenFactoryPrConflictCandidates,
+  type RepositoryRow,
+} from './db.ts';
+import { installationToken } from './github-app.ts';
+import type { ConflictResolveQueueMessage } from './conflict-resolver.ts';
 
-// Shared "detect + notify" helper for merge conflicts on factory PRs. Used by
-// both merge paths (auto-merge, the cockpit Merge button) and the cockpit
-// read path (GET /factory/features/:id), so the conflict definition and the
-// comment text live in exactly one place.
+// Shared "detect + notify + dispatch" helpers for merge conflicts on factory
+// PRs. Used by both merge paths (auto-merge, the cockpit Merge button), the
+// completion paths (verification, review), and the scheduled sweep, so the
+// conflict definition and the comment text live in exactly one place.
 
 export interface PrMergeability {
   mergeable: boolean | null;
@@ -24,9 +32,12 @@ function toMergeability(pr: PrPayload): PrMergeability {
 }
 
 // GitHub computes mergeable_state asynchronously — a fresh or just-updated PR
-// can read 'unknown' for a moment. The pre-merge-attempt call sites need a
-// real answer, so they retry once after a short wait; the cockpit page-load
-// read stays fast and just shows "checking…" for that one request.
+// can read 'unknown' for a while (regularly >10s after a base-branch push).
+// The pre-merge-attempt call sites need a real answer, so they poll with
+// backoff; the cockpit page-load read stays fast and just shows "checking…"
+// for that one request.
+const UNKNOWN_RETRY_DELAYS_MS = [1_500, 3_000, 5_000, 8_000];
+
 export async function checkMergeability(
   token: string,
   owner: string,
@@ -41,11 +52,71 @@ export async function checkMergeability(
       (r) => r.json() as Promise<PrPayload>,
     );
   let pr = await fetchPr();
-  if (pr.mergeable_state === 'unknown' && opts?.retryOnUnknown) {
-    await new Promise((resolve) => setTimeout(resolve, 1_500));
-    pr = await fetchPr();
+  if (opts?.retryOnUnknown) {
+    for (const delayMs of UNKNOWN_RETRY_DELAYS_MS) {
+      if (pr.mergeable_state !== 'unknown') break;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      pr = await fetchPr();
+    }
   }
   return toMergeability(pr);
+}
+
+// Standalone conflict detection + dispatch, gated ONLY on the repo's
+// auto_resolve_conflicts toggle — deliberately independent of the auto-merge
+// gates (auto_merge, blocking_reviews, review history), which previously made
+// the toggle dead unless auto-merge was fully configured. Callers invoke it
+// wherever a factory PR may have picked up a conflict: verification/review
+// completion, a failed auto-merge attempt, and the scheduled sweep. Never
+// throws; never touches human-authored PRs (no feature row).
+export async function maybeResolveConflict(
+  repo: RepositoryRow,
+  prNumber: number,
+  opts?: { retryOnUnknown?: boolean },
+): Promise<void> {
+  if (repo.enabled !== 1) return;
+  const label = `${repo.owner}/${repo.name}#${prNumber}`;
+  try {
+    const feature = await getFeatureByRepoPr(repo.id, prNumber);
+    if (!feature) return;
+    const token = await installationToken(repo.installation_id);
+    const mergeability = await checkMergeability(token, repo.owner, repo.name, prNumber, {
+      retryOnUnknown: opts?.retryOnUnknown ?? true,
+    });
+    if (!mergeability.hasConflict) return;
+    if (repo.auto_resolve_conflicts === 1) {
+      const msg: ConflictResolveQueueMessage = {
+        kind: 'resolve_conflict',
+        repoId: repo.id,
+        prNumber,
+      };
+      await env.FACTORY_QUEUE.send(msg);
+      console.log(`turbodiff: conflict detected on ${label}, resolution enqueued`);
+    } else {
+      await postConflictCommentIfAbsent(
+        token,
+        repo.owner,
+        repo.name,
+        prNumber,
+        mergeability.baseRef,
+      );
+      console.log(`turbodiff: conflict detected on ${label} (auto-resolve off, notice posted)`);
+    }
+  } catch (err) {
+    console.warn(`turbodiff: conflict check failed for ${label}:`, err);
+  }
+}
+
+// Cron-driven safety net: the event-driven call sites only run when
+// turbodiff itself acts on a PR, but the typical conflict appears when an
+// unrelated PR merges into the base branch — which fires no event this app
+// receives. The sweep bounds detection latency to one cron interval. Skips
+// the 'unknown' backoff (a PR that reads unknown is retried next tick).
+export async function sweepFactoryPrConflicts(): Promise<void> {
+  const candidates = await listOpenFactoryPrConflictCandidates();
+  for (const { repo, prNumber } of candidates) {
+    await maybeResolveConflict(repo, prNumber, { retryOnUnknown: false });
+  }
 }
 
 const CONFLICT_MARKER = '<!-- turbodiff:conflict-notice -->';

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -1,7 +1,3 @@
-import {
-  buildPushPayload,
-  type PushSubscription as WebPushSubscription,
-} from '@block65/webcrypto-web-push';
 import { env } from 'cloudflare:workers';
 import {
   deletePushSubscriptionById,
@@ -13,27 +9,198 @@ import {
 // Server-side Web Push sending, isolated from planner.ts so a notification
 // failure can never affect plan state — every entry point here fails open
 // (catches its own errors) rather than throwing.
+//
+// The wire protocol is implemented in-repo with plain WebCrypto (matching
+// github-app.ts / email.ts style): RFC 8291 aes128gcm payload encryption and
+// RFC 8292 vapid authorization. Apple's push service rejects the obsolete
+// pre-RFC protocol (aesgcm + `WebPush <jwt>`) outright, so only the modern
+// scheme works across all push services.
 
 export type PushSendResult = 'sent' | 'gone' | 'error';
+
+const encoder = new TextEncoder();
+
+function b64url(bytes: ArrayBuffer | Uint8Array): string {
+  const arr = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let bin = '';
+  for (const b of arr) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function b64urlDecode(s: string): Uint8Array {
+  const bin = atob(s.replace(/-/g, '+').replace(/_/g, '/'));
+  return Uint8Array.from(bin, (c) => c.charCodeAt(0));
+}
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+async function hkdfSha256(
+  salt: Uint8Array,
+  ikm: Uint8Array,
+  info: Uint8Array,
+  byteLength: number,
+): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey('raw', ikm, 'HKDF', false, ['deriveBits']);
+  return new Uint8Array(
+    await crypto.subtle.deriveBits(
+      { name: 'HKDF', hash: 'SHA-256', salt, info },
+      key,
+      byteLength * 8,
+    ),
+  );
+}
+
+// RFC 8291 aes128gcm encryption of one payload for one subscriber, as a single
+// record: ephemeral ECDH over the subscription's p256dh key, HKDF key schedule
+// bound to the auth secret and both public keys, then AES-128-GCM. Returns the
+// full request body: coding header (salt || rs || keyid) followed by the record.
+async function encryptPayload(
+  plaintext: Uint8Array,
+  p256dh: string,
+  auth: string,
+): Promise<Uint8Array> {
+  const uaPublicRaw = b64urlDecode(p256dh); // subscriber's uncompressed P-256 point (65 bytes)
+  const authSecret = b64urlDecode(auth); // subscriber's 16-byte auth secret
+  const uaPublicKey = await crypto.subtle.importKey(
+    'raw',
+    uaPublicRaw,
+    { name: 'ECDH', namedCurve: 'P-256' },
+    false,
+    [],
+  );
+  const ephemeral = await crypto.subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, true, [
+    'deriveBits',
+  ]);
+  if (!('privateKey' in ephemeral)) throw new Error('expected an ECDH key pair');
+  const asPublicExport = await crypto.subtle.exportKey('raw', ephemeral.publicKey);
+  if (!(asPublicExport instanceof ArrayBuffer)) throw new Error('expected raw key export');
+  const asPublicRaw = new Uint8Array(asPublicExport); // our uncompressed P-256 point (65 bytes)
+
+  // workerd's generated types name the ECDH peer key `$public` (JSG's
+  // reserved-word escape leaks into the .d.ts) but the runtime property is the
+  // spec's `public`; passing a variable sidesteps the excess-property check.
+  const ecdhParams = { name: 'ECDH', public: uaPublicKey };
+  const ecdhSecret = new Uint8Array(
+    await crypto.subtle.deriveBits(ecdhParams, ephemeral.privateKey, 256),
+  );
+  const ikm = await hkdfSha256(
+    authSecret,
+    ecdhSecret,
+    concatBytes(encoder.encode('WebPush: info\0'), uaPublicRaw, asPublicRaw),
+    32,
+  );
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const cek = await hkdfSha256(salt, ikm, encoder.encode('Content-Encoding: aes128gcm\0'), 16);
+  const nonce = await hkdfSha256(salt, ikm, encoder.encode('Content-Encoding: nonce\0'), 12);
+
+  const aesKey = await crypto.subtle.importKey('raw', cek, 'AES-GCM', false, ['encrypt']);
+  // 0x02 marks the final (here: only) record; no extra zero padding needed.
+  const record = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv: nonce },
+      aesKey,
+      concatBytes(plaintext, Uint8Array.of(0x02)),
+    ),
+  );
+
+  // Coding header: salt(16) || record size uint32-BE || keyid length(1) || keyid.
+  const header = new Uint8Array(16 + 4 + 1 + asPublicRaw.length);
+  header.set(salt, 0);
+  new DataView(header.buffer).setUint32(16, 4096);
+  header[20] = asPublicRaw.length;
+  header.set(asPublicRaw, 21);
+  return concatBytes(header, record);
+}
+
+// VAPID keys never rotate within an isolate's lifetime; cache the imported key.
+let cachedVapidKey: CryptoKey | null = null;
+
+async function vapidSigningKey(publicRaw: Uint8Array): Promise<CryptoKey> {
+  if (cachedVapidKey) return cachedVapidKey;
+  cachedVapidKey = await crypto.subtle.importKey(
+    'jwk',
+    {
+      kty: 'EC',
+      crv: 'P-256',
+      d: env.VAPID_PRIVATE_KEY,
+      x: b64url(publicRaw.slice(1, 33)),
+      y: b64url(publicRaw.slice(33, 65)),
+    },
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    false,
+    ['sign'],
+  );
+  return cachedVapidKey;
+}
+
+// RFC 8292 `vapid t=<jwt>, k=<public key>` authorization header for one
+// push-service origin.
+async function vapidAuthorization(endpoint: string): Promise<string> {
+  const publicRaw = b64urlDecode(env.VAPID_PUBLIC_KEY);
+  if (publicRaw.length !== 65 || publicRaw[0] !== 0x04) {
+    throw new Error('VAPID_PUBLIC_KEY must be a base64url uncompressed P-256 point (65 bytes)');
+  }
+  const header = b64url(encoder.encode(JSON.stringify({ typ: 'JWT', alg: 'ES256' })));
+  const claims = b64url(
+    encoder.encode(
+      JSON.stringify({
+        aud: new URL(endpoint).origin,
+        exp: Math.floor(Date.now() / 1000) + 12 * 60 * 60,
+        sub: env.VAPID_SUBJECT,
+      }),
+    ),
+  );
+  // WebCrypto ECDSA emits the raw 64-byte r||s signature JWS expects — no DER
+  // conversion needed.
+  const sig = await crypto.subtle.sign(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    await vapidSigningKey(publicRaw),
+    encoder.encode(`${header}.${claims}`),
+  );
+  return `vapid t=${header}.${claims}.${b64url(sig)}, k=${env.VAPID_PUBLIC_KEY}`;
+}
 
 export async function sendPushToSubscription(
   sub: PushSubscriptionRow,
   payload: { title: string; body: string; url: string },
 ): Promise<PushSendResult> {
   try {
-    const subscription: WebPushSubscription = {
-      endpoint: sub.endpoint,
-      expirationTime: null,
-      keys: { p256dh: sub.p256dh, auth: sub.auth },
-    };
-    const init = await buildPushPayload({ data: payload }, subscription, {
-      subject: env.VAPID_SUBJECT,
-      publicKey: env.VAPID_PUBLIC_KEY,
-      privateKey: env.VAPID_PRIVATE_KEY,
+    const body = await encryptPayload(
+      encoder.encode(JSON.stringify(payload)),
+      sub.p256dh,
+      sub.auth,
+    );
+    const res = await fetch(sub.endpoint, {
+      method: 'POST',
+      headers: {
+        authorization: await vapidAuthorization(sub.endpoint),
+        'content-encoding': 'aes128gcm',
+        'content-type': 'application/octet-stream',
+        ttl: '86400',
+        urgency: 'high',
+      },
+      body,
     });
-    const res = await fetch(sub.endpoint, init);
     if (res.status === 404 || res.status === 410) return 'gone';
-    return res.ok ? 'sent' : 'error';
+    if (!res.ok) {
+      const detail = (await res.text()).slice(0, 200);
+      console.error(
+        'turbodiff: push service rejected send',
+        new URL(sub.endpoint).origin,
+        res.status,
+        detail,
+      );
+      return 'error';
+    }
+    return 'sent';
   } catch (err) {
     console.error('turbodiff: push send failed for subscription', sub.id, err);
     return 'error';

--- a/src/lib/push.worker.test.ts
+++ b/src/lib/push.worker.test.ts
@@ -16,8 +16,8 @@ type TestEnv = Cloudflare.Env & { TEST_MIGRATIONS: D1Migration[] };
 const testEnv = env as TestEnv;
 
 // Fixture client keys (a valid ECDH P-256 public point + 16-byte auth
-// secret) — buildPushPayload derives a real shared secret from these, so
-// arbitrary strings fail with "Point is not on curve" before fetch is ever
+// secret) — the RFC 8291 encryption derives a real shared secret from these,
+// so arbitrary strings fail with "Point is not on curve" before fetch is ever
 // called.
 const P256DH =
   'BLrWn8rWI8dZelMSSqVi0rah4tWXjJ3LJB52reUt6_u7CmyZUqKPcJvr497BbuZSFQ2UGeHN2D4MUr0gapZwGrg';
@@ -92,6 +92,86 @@ describe('sendPushToSubscription', () => {
       );
       expect(result).toBe('sent');
     } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('speaks the modern protocol: aes128gcm body, vapid authorization, ttl/urgency', async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(null, { status: 201 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const payload = { title: 'Turbodiff', body: 'hi', url: 'https://turbodiff.test/tasks/1' };
+    try {
+      const result = await sendPushToSubscription(
+        {
+          id: 1,
+          user_github_id: 3001,
+          endpoint: 'https://push.example/live',
+          p256dh: P256DH,
+          auth: AUTH,
+          created_at: '',
+        },
+        payload,
+      );
+      expect(result).toBe('sent');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.method).toBe('POST');
+
+    // RFC 8292 VAPID + RFC 8291 request headers. Apple's push service rejects
+    // the obsolete `WebPush <jwt>` / aesgcm scheme, so these are load-bearing.
+    const headers = new Headers(init?.headers);
+    expect(headers.get('content-encoding')).toBe('aes128gcm');
+    expect(headers.get('content-type')).toBe('application/octet-stream');
+    expect(headers.get('ttl')).toBe('86400');
+    expect(headers.get('urgency')).toBe('high');
+    expect(headers.get('authorization')).toMatch(/^vapid t=.+\..+\..+, k=.+$/);
+
+    // Body layout: 86-byte aes128gcm coding header (salt(16) || rs uint32-BE ||
+    // idlen(1)=65 || 65-byte uncompressed sender public key), then a single
+    // record of plaintext + 0x02 delimiter + 16-byte GCM tag.
+    const body = init?.body;
+    if (!(body instanceof Uint8Array)) throw new Error('expected a Uint8Array push body');
+    const view = new DataView(body.buffer, body.byteOffset, body.byteLength);
+    expect(view.getUint32(16)).toBe(4096); // record size
+    expect(body[20]).toBe(65); // keyid length
+    expect(body[21]).toBe(0x04); // keyid is an uncompressed P-256 point
+    const plaintextLength = new TextEncoder().encode(JSON.stringify(payload)).length;
+    expect(body.length).toBe(86 + plaintextLength + 1 + 16);
+  });
+
+  it('returns error (after logging) on a non-2xx, non-gone response', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response('Unauthorized: bad vapid token', { status: 403 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      const result = await sendPushToSubscription(
+        {
+          id: 1,
+          user_github_id: 3001,
+          endpoint: 'https://push.example/rejects',
+          p256dh: P256DH,
+          auth: AUTH,
+          created_at: '',
+        },
+        { title: 'Turbodiff', body: 'hi', url: 'https://turbodiff.test/tasks/1' },
+      );
+      expect(result).toBe('error');
+      expect(errorSpy).toHaveBeenCalledWith(
+        'turbodiff: push service rejected send',
+        'https://push.example',
+        403,
+        'Unauthorized: bad vapid token',
+      );
+    } finally {
+      errorSpy.mockRestore();
       vi.unstubAllGlobals();
     }
   });

--- a/src/lib/verifier.ts
+++ b/src/lib/verifier.ts
@@ -15,6 +15,7 @@ import {
 } from './db.ts';
 import { persistAgentLog } from './agent-runs.ts';
 import { maybeAutoMerge } from './auto-merge.ts';
+import { maybeResolveConflict } from './merge-conflicts.ts';
 import { certificateUrl } from './certificate.ts';
 import { signArtifactKey } from './crypto.ts';
 import { resolveRunnerAuth, sandboxNamespace } from './fixer.ts';
@@ -302,6 +303,9 @@ async function verify(
 
     const failed = results.filter((r) => r.verdict === 'fail');
     await postReport(token, repo, feature, criteria, results, shots, summary, demo);
+    // Conflict detection runs on every verification completion — not only the
+    // auto-merge-eligible path — so auto_resolve_conflicts works standalone.
+    await maybeResolveConflict(repo, feature.pr_number!);
     if (failed.length === 0) {
       await maybeAutoMerge(repo, feature.pr_number!);
     }

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -2242,6 +2242,11 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
       code_challenge_method: 'S256',
       state,
     });
+    // Request the server's advertised scopes — some issue refresh tokens
+    // only when the authorization request names a scope (offline_access).
+    if (endpoints.scopesSupported?.length) {
+      params.set('scope', endpoints.scopesSupported.join(' '));
+    }
     return c.redirect(`${endpoints.authorizationEndpoint}?${params}`);
   });
 
@@ -2285,7 +2290,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
       return c.redirect('/integrations?oauth=error&reason=exchange_failed');
     }
 
-    const authUpdate: Parameters<typeof updateConnectionAuth>[1] = {
+    await updateConnectionAuth(conn.id, {
       authConfigCiphertext: await sealJson<OAuthConfigCache>({
         ...cache,
         accessToken: tokens.accessToken,
@@ -2293,9 +2298,11 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         scope: tokens.scope,
       }),
       oauthNeedsReauth: false,
-    };
-    if (tokens.expiresAt) authUpdate.oauthTokenExpiresAt = tokens.expiresAt;
-    await updateConnectionAuth(conn.id, authUpdate);
+      oauthHasRefreshToken: tokens.refreshToken !== undefined,
+      // Always record an expiry: a null column can never be advanced by the
+      // COALESCE-based update, which would force a refresh on every request.
+      oauthTokenExpiresAt: tokens.expiresAt ?? new Date(Date.now() + 60 * 60_000).toISOString(),
+    });
     return c.redirect(`/integrations?oauth=connected&name=${encodeURIComponent(conn.name)}`);
   });
 

--- a/src/tools/github.ts
+++ b/src/tools/github.ts
@@ -2,6 +2,7 @@ import { defineTool } from '@flue/runtime';
 import { env } from 'cloudflare:workers';
 import * as v from 'valibot';
 import { maybeAutoMerge } from '../lib/auto-merge.ts';
+import { maybeResolveConflict } from '../lib/merge-conflicts.ts';
 import { completeReview, getRepoByFullName } from '../lib/db.ts';
 import { installationToken } from '../lib/github-app.ts';
 import type { JsonValue } from '../shared/json.ts';
@@ -470,6 +471,9 @@ export const makePostReview = (agentInstanceId: string, pin: RepoPin = null) =>
           trigger: 'blocking_review_self',
         });
       }
+      // Conflict detection runs on every review completion, blocking or not
+      // (a blocking verdict skips only the merge gate below).
+      await maybeResolveConflict(row, data.number);
       // Clean verdict on a factory PR: the verification may already have
       // passed while this review was running — try the merge gate now.
       if (intended !== 'REQUEST_CHANGES') {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,6 +3,12 @@
   "name": "turbodiff",
   "compatibility_date": "2026-06-01",
   "compatibility_flags": ["nodejs_compat"],
+  // Version preview URLs (<version-prefix>-turbodiff.<subdomain>.workers.dev)
+  // for the per-PR previews uploaded by .github/workflows/preview.yml. This
+  // does NOT serve production on workers.dev (that's workers_dev, still off);
+  // it only makes uploaded versions reachable. Requires the account's
+  // workers.dev subdomain to be registered.
+  "preview_urls": true,
   // Workers Traces shows each agent response as a trace with agent-level
   // spans: https://flueframework.com/docs/guide/observability/#cloudflare
   "observability": { "traces": { "enabled": true } },


### PR DESCRIPTION
Fixes the three reported issues, each traced to a verified root cause first.

## 1. Auto conflict-resolve never fired

**Root cause:** conflict detection only ran inside the auto-merge gate — at verification-pass/clean-review moments (when a branch is essentially never conflicted yet), and only when `auto_merge` AND `blocking_reviews` were both on. The typical conflict (another PR merges into the base while this one sits open) fires no event turbodiff receives, so conflicted PRs sat forever.

**Fix:**
- New standalone `maybeResolveConflict()` in `merge-conflicts.ts`, gated **only** on `auto_resolve_conflicts` — the toggle now works without auto-merge configured and despite historical blocking reviews.
- Invoked from: every verification completion, every review completion, the auto-merge failure path (a merge PUT that 405s on a race now dispatches the resolver instead of going silent), and a **new cron sweep** over open factory PRs (rides the existing */15 tick), bounding detection latency to one interval.
- `mergeable_state: 'unknown'` (GitHub computes it lazily) now polls with backoff, and the consumer throws on persistent unknown so the workflow retries instead of misreading it as "no longer conflicted".
- The 3-attempt cap now counts only `conflict_resolve` attempts — a PR that burned its fix attempts in the review loop (the kind most likely to sit conflicted) can still get resolutions.
- A `tests_failed` resolution (produced but discarded because the repo check failed) now posts a PR comment instead of vanishing.

## 2. Push notifications never arrived

**Root cause:** `@block65/webcrypto-web-push` implements the obsolete pre-RFC protocol (`content-encoding: aesgcm`, `Authorization: WebPush`). Apple's push service — every Safari/macOS/iOS subscription — rejects it outright, and the sender swallowed every non-2xx response with zero logging. TTL was also hard-coded to 60s, so even accepted pushes died if the recipient wasn't online at that moment.

**Fix:** dependency removed; in-repo RFC 8291 (aes128gcm, single record) + RFC 8292 (`vapid t=,k=`) sender in `src/lib/push.ts`, matching the repo's plain-fetch style. TTL 24h, urgency high, and push-service rejections now log endpoint origin + status + body. Tests updated to assert the modern protocol shape.

> Operational note: if notifications still fail after deploy for Chrome subscribers, verify the deployed VAPID secrets are a matched pair (README's warning) — the new logging will show `VapidPkHashMismatch` if not.

## 3. MCP OAuth demanded re-auth every 10-15 minutes

**Root cause (layered):** MCP servers issue 10-15-minute access tokens by design. `oauthStatus` reported `'expired'` the moment the access token lapsed — ignoring the stored refresh token — so the UI pushed users through the full OAuth flow constantly even though requests would have refreshed silently. Underneath: any transient refresh failure permanently set `needs_reauth`, concurrent refreshes raced under refresh-token rotation (reuse-detection servers revoke the whole grant family), and a token response without `expires_in` left a permanently-stale expiry.

**Fix (migration 0033):**
- New non-secret `oauth_has_refresh_token` column (optimistically backfilled); a lapsed-but-refreshable connection now reads **connected**.
- `refreshOAuthToken` returns a discriminated result; `needs_reauth` is set only on definitive `invalid_grant` — transient failures just retry on the next request.
- Refreshes are single-flighted via a conditional-update claim window (45s, under the 60s freshness margin, so concurrent requests keep serving the still-valid old token).
- Missing `expires_in` gets a 1h default expiry (the COALESCE-based update could never clear a stale value — refresh storm).
- The authorization request now carries the server's advertised `scopes_supported`, so servers that gate refresh tokens on scope (e.g. `offline_access`) issue them.

## Verification

- `vp check` passes (0 errors; warnings are the pre-existing warn-level baseline)
- `tsc --noEmit` × 3 (worker, client, worker-tests) — clean
- Migration 0033 applied against local D1; `oauth_has_refresh_token` column verified present
- `vp test` not run (broken repo-wide, pre-existing); push tests updated to assert the RFC 8291/8292 wire format

🤖 Generated with [Claude Code](https://claude.com/claude-code)