### PR TITLE
Git provider seam + Artifacts-hosted projects (Phase 1)

### DIFF
--- a/docs/artifacts-provider.md
+++ b/docs/artifacts-provider.md
@@ -1,0 +1,82 @@
+# Git provider seam + Artifacts-hosted projects (Phase 1)
+
+Production groundwork for turbodiff as its own forge (`docs/artifacts-vision.md`):
+repos can now live on Cloudflare Artifacts in turbodiff's account instead of
+GitHub, with the whole runtime reaching them through one provider seam. The
+Phase-0/0.5 spikes that de-risked this live on the (unmerged) `artifacts-phase0-spike`
+branch; everything here is production code.
+
+## What ships in Phase 1
+
+- **Provider seam** — `src/integrations/git/remotes.ts` (pure remote shapes)
+  and `provider.ts` (credential minting + dispatch). Every sandbox git
+  operation goes through a `WorkspaceRemote`; no call site builds a forge URL
+  anymore. GitHub's command shapes are byte-identical to before.
+- **Synthetic tenancy** — Artifacts projects reuse the installation-scoped
+  access model via installation/repository rows in the **negative id range**
+  (GitHub ids are positive, so the spaces cannot collide). Migration
+  `0035_git_providers.sql`; allocation in `src/data/repositories.ts`.
+- **Provisioning** — `POST /internal/projects {owner, name, description?}`
+  creates the Artifacts repo (collision-suffixed name `owner--name`), seeds an
+  initial commit from the sandbox, and records the D1 rows. Compensating
+  deletes on failure; no row ever points at a broken remote.
+- **Clone credentials** — `POST /internal/repos/clone-token {repo, scope?, ttl_seconds?}`
+  mints a repo-scoped token so a user clones/pushes with plain git:
+  `git clone` the returned `remote` with header `Authorization: Bearer <token>`
+  (or a credential helper). This is the deploy-key replacement.
+- **Event ingestion** — declarative `triggers.events` entries in
+  `wrangler.jsonc` start one `ArtifactsEventsWorkflow` instance per
+  `repo.pushed` / `repo.deleted` event in the namespace. No per-repo
+  subscription provisioning, no API tokens; a repo created tomorrow is
+  covered by today's config. Pushes stamp `repositories.last_push_at`;
+  deletes drop the stale row.
+- **Capability gating** — every factory intake that ends in a GitHub PR
+  (features, plans, automations, fix runs) rejects Artifacts repos with an
+  explicit "needs the native change-request layer (Phase 2)" error instead of
+  stranding a run at the PR step. GitHub repos are untouched.
+
+## Design decisions
+
+- **Auth mechanics differ per provider and that's fine.** GitHub keeps
+  `https://x-access-token:$GIT_TOKEN@github.com/...` (token via env);
+  Artifacts uses `-c http.extraHeader="Authorization: Bearer $GIT_TOKEN"`
+  because its tokens can carry `?expires=` — URL-hostile. Both shapes live in
+  `remotes.ts` only.
+- **Negative synthetic ids over a schema rewrite.** `installation_id` drives
+  scoping, budgets, and org mapping across dozens of query sites. Synthetic
+  rows preserve every invariant with zero query changes; `mintToken` and
+  `syncInstallationRepos` hard-guard against a negative id ever reaching
+  GitHub.
+- **PR-head flows stay GitHub-constructed.** Fix and conflict-resolution
+  operate on a PR's head repo (possibly a fork), so they build a GitHub
+  remote for that slug directly rather than resolving from the repo row.
+
+## Operational setup (one-time)
+
+1. Artifacts closed beta enabled on the account (the `GIT_ARTIFACTS` binding
+   fails to provision otherwise).
+2. Namespace `turbodiff-repos` — must match `ARTIFACTS_NAMESPACE` in
+   `src/integrations/git/remotes.ts` and the `triggers.events` filters.
+3. Migrations + deploy ride the normal CI path (migrations applied before
+   deploy, `wrangler deploy --dry-run` validates the new config in PR CI).
+
+Smoke test after deploy:
+
+```sh
+AUTH="Authorization: Bearer $REVIEW_SECRET"
+curl -sX POST https://turbodiff.dev/internal/projects -H "$AUTH" \
+  -d '{"owner": "nico", "name": "hello-artifacts", "description": "first hosted project"}' | jq
+curl -sX POST https://turbodiff.dev/internal/repos/clone-token -H "$AUTH" \
+  -d '{"repo": "nico/hello-artifacts", "scope": "read"}' | jq
+# then: git -c http.extraHeader="Authorization: Bearer <token>" clone <remote>
+# push something; ~a minute later the repo row's last_push_at is stamped.
+```
+
+## What Phase 2 builds on this
+
+Native change requests: CR tables in D1, diff compute/cache via the sandbox
+engine prototyped in Phase 0.5, cockpit CR view (the app already ships
+`@pierre/diffs`), reviews/checks/merges — at which point the
+`factoryUnsupportedReason` gates lift one flow at a time. Multi-installation
+organizations (a GitHub org that _also_ hosts Artifacts projects under the
+same cockpit org) are deferred with them.

--- a/docs/artifacts-vision.md
+++ b/docs/artifacts-vision.md
@@ -1,0 +1,101 @@
+# Artifacts as a GitHub alternative — the end state
+
+The Phase 0 spike (`docs/artifacts-spike.md`) proves plumbing. This doc is the
+reason the plumbing matters: what turbodiff looks like when a project never
+touches GitHub, and how each spike primitive becomes a leg of that product.
+
+## The litmus test
+
+A user creates a project in turbodiff. No GitHub account, no App install, no
+Cloudflare account. The factory generates features, opens change requests,
+reviews them, merges them, and issues build certificates — and the user can
+`git clone` their repo with a turbodiff-issued token at any point. If we
+deleted the GitHub App tomorrow, this project would not notice.
+
+That is the end state. GitHub becomes one of two providers — the
+import-your-existing-repo path — instead of the substrate everything stands on.
+
+## The honest split: what Artifacts gives us vs what we build
+
+Artifacts (closed beta) is a git remote with an API. It provides:
+
+- repos under namespaces, created from a Worker binding (`create`, `fork`,
+  `import`)
+- git smart-HTTP for clone/push
+- repo-scoped, short-TTL tokens (mint, list, revoke)
+- push/lifecycle events delivered to a Queue
+
+It has **no** pull requests, no reviews, no merge API, no diff endpoint, no
+CI, no statuses. Everything users associate with "GitHub" above the git layer
+does not exist.
+
+That gap is not a problem — it is the product. turbodiff already owns the
+agents, the review policy, the cockpit, and the sandbox with a full git CLI in
+it. We build the forge layer natively, shaped for a factory rather than for
+humans-emulating-a-factory:
+
+| GitHub concept    | Native replacement                                          |
+| ----------------- | ----------------------------------------------------------- |
+| Pull request      | Change request: D1 row (repo, source/target branch, status) |
+| PR diff           | Sandbox `git diff target...source`, cached in R2            |
+| Review comments   | D1 rows anchored to file+line, same shape as cockpit today  |
+| Merge button      | Sandbox `git merge` + push, driven by `auto-merge.ts` logic |
+| Conflict badge    | Sandbox `git merge --no-commit` dry-run                     |
+| Webhooks          | Queue event subscriptions (already on the factory queue)    |
+| CI checks         | turbodiff's own checks in the sandbox, statuses in D1       |
+| Deploy keys / PAT | Repo-scoped Artifacts tokens minted per job and per user    |
+
+## The loop, end to end
+
+1. **Create project** → `GIT_ARTIFACTS.create('org-slug/repo')`, namespace
+   per org. The spike's create step is this, minus the D1 bookkeeping.
+2. **Agent works** → sandbox clones with a short-TTL write token (spike:
+   mint → push → revoke), commits to `turbodiff/feat-N`, pushes.
+3. **Push event** arrives on the factory queue (spike: event capture) →
+   opens or refreshes the change request row, computes the diff in the
+   sandbox, caches it to R2.
+4. **Review** → Flue reviews the cached diff natively — no
+   `github-webhooks.ts` hop — comments stored like `cockpit_comments`,
+   verdict via the existing `review-policy.ts`.
+5. **Checks** → the sandbox runs the project's build/tests; results are
+   status rows on the CR. This is _better_ than the GitHub path, where CI
+   findings were a capability we consumed rather than owned.
+6. **Merge** → dry-run conflict check, then merge + push from the sandbox
+   (`merge-conflicts.ts` and `auto-merge.ts` logic pointed at a new
+   transport). Certificate issued as today.
+7. **User access** → the cockpit offers "clone this repo": a user-scoped
+   read (or write) token minted on demand — the same primitive the spike
+   revokes in its last step.
+
+Every step above is either already proven by the spike (1, 2, 3-ingest, 7)
+or is existing turbodiff logic re-pointed at a `GitProvider` interface
+(4, 5, 6). Nothing in the loop requires a capability Artifacts lacks.
+
+## Why this beats wrapping GitHub
+
+- **The factory owns its forge.** Review policy, merge rules, and checks are
+  turbodiff decisions executed directly, not encoded as webhook reactions to
+  a third-party state machine we don't control.
+- **Zero-friction onboarding.** Repos live in turbodiff's account
+  (turbodiff-hosted tenancy, decided 2026-08-20); users bring nothing.
+- **Migration is nearly free both ways.** `import()` pulls any public HTTPS
+  remote in; the repo is standard git, so users can push it back to GitHub
+  whenever they want. No lock-in story to defend.
+- **`fork()` enables cheap per-feature workspaces** — an isolation primitive
+  GitHub-based flow never had.
+
+## Build-out order
+
+- **Phase 0 / 0.5 (spikes, unmerged `artifacts-phase0-spike` branch)**:
+  binding, tokens, sandbox git, events — proven; plus the working CR
+  prototype (native change requests, sandbox-git diffs, dry-run
+  mergeability, inline comments, merge with conflict ripple). Reference
+  implementations, deliberately never merged.
+- **Phase 1 (this PR)**: the provider seam (`src/integrations/git/`),
+  synthetic tenancy in D1, Artifacts project provisioning + clone tokens,
+  declarative push/delete event ingestion, and capability gates on every
+  PR-bound factory intake — `docs/artifacts-provider.md`.
+- **Phase 2**: native CR layer in production (D1 schema, diff cache from the
+  Phase-0.5 engine, cockpit CR view via `@pierre/diffs`).
+- **Phase 3**: reviews, checks, merges on native CRs; the Phase-1 gates lift
+  flow by flow and GitHub becomes import-only.

--- a/migrations/0035_git_providers.sql
+++ b/migrations/0035_git_providers.sql
@@ -1,0 +1,22 @@
+-- Git provider seam (docs/artifacts-provider.md): installations and
+-- repositories gain a provider discriminator so Cloudflare Artifacts-hosted
+-- projects (turbodiff-tenanted, no GitHub App) reuse the installation-scoped
+-- access model unchanged. Artifacts rows use negative synthetic ids: GitHub
+-- ids are always positive, so the two spaces can never collide.
+ALTER TABLE installations ADD COLUMN provider TEXT NOT NULL DEFAULT 'github';
+ALTER TABLE repositories ADD COLUMN provider TEXT NOT NULL DEFAULT 'github';
+
+-- Repo name inside turbodiff's Artifacts namespace (wrangler.jsonc binding).
+ALTER TABLE repositories ADD COLUMN artifacts_repo TEXT;
+
+-- Stored for Artifacts repos at provisioning; GitHub rows keep NULL (their
+-- default branch is fetched live from the API as before).
+ALTER TABLE repositories ADD COLUMN default_branch TEXT;
+
+-- Last observed push, maintained by Artifacts event ingestion
+-- (src/ai/workflows/artifacts-events.ts).
+ALTER TABLE repositories ADD COLUMN last_push_at TEXT;
+
+CREATE UNIQUE INDEX idx_repositories_artifacts_repo
+	ON repositories (artifacts_repo)
+	WHERE artifacts_repo IS NOT NULL;

--- a/src/ai/runners/conflict-resolver.ts
+++ b/src/ai/runners/conflict-resolver.ts
@@ -18,7 +18,8 @@ import {
 import { resolveRunnerAuth, runnerEnvironment } from '../runtime/runner-auth.ts';
 import { runnerSandbox } from '../runtime/sandbox.ts';
 import { redactSecrets } from '../runtime/redaction.ts';
-import { prepareFreshClone } from '../runtime/repository-workspace.ts';
+import { prepareFreshClone, pushHeadCommand } from '../runtime/repository-workspace.ts';
+import { githubWorkspaceRemote } from '../../integrations/git/provider.ts';
 import { mountSkills } from '../runtime/skills.ts';
 import {
   describePushFailure,
@@ -194,13 +195,15 @@ async function runConflictResolve(
     { sleepAfter: '20m' },
   );
 
-  const gitEnv = { GIT_TOKEN: gitToken, FIX_BRANCH: headRef, BASE_REF: baseRef };
+  // Conflict resolution is a GitHub-only flow (PR head may live on a fork),
+  // so the remote is constructed for the head repo directly.
+  const remote = githubWorkspaceRemote(headRepo, gitToken);
+  const gitEnv = { ...remote.env, FIX_BRANCH: headRef, BASE_REF: baseRef };
   const pushMerge = async (): Promise<string> => {
-    const push = await sandbox.exec(
-      `git -C ${CLONE_DIR} push ` +
-        `"https://x-access-token:$GIT_TOKEN@github.com/${headRepo}.git" HEAD:"$FIX_BRANCH"`,
-      { env: gitEnv, timeout: 2 * 60_000 },
-    );
+    const push = await sandbox.exec(pushHeadCommand(remote, CLONE_DIR), {
+      env: { ...gitEnv, PUSH_BRANCH: headRef },
+      timeout: 2 * 60_000,
+    });
     if (!push.success) {
       throw new Error(describePushFailure(scrub(push.stderr).slice(0, 500)));
     }
@@ -211,9 +214,8 @@ async function runConflictResolve(
   await prepareFreshClone({
     sandbox,
     cloneDir: CLONE_DIR,
-    repository: headRepo,
+    remote,
     branch: headRef,
-    gitToken,
     secrets: [token],
   });
 
@@ -221,8 +223,7 @@ async function runConflictResolve(
     // Explicit refspec into refs/remotes/origin so `merge origin/<base>`
     // resolves regardless of the single-branch clone's configured refspec.
     const fetchBase = await sandbox.exec(
-      `git -C ${CLONE_DIR} fetch --depth 50 ` +
-        `"https://x-access-token:$GIT_TOKEN@github.com/${headRepo}.git" ` +
+      `git ${remote.configFlags} -C ${CLONE_DIR} fetch --depth 50 "${remote.authUrl}" ` +
         `"+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"`,
       { env: gitEnv, timeout: 3 * 60_000 },
     );
@@ -318,9 +319,7 @@ async function runConflictResolve(
     // Belt and braces: the remote was already scrubbed right after clone,
     // but an idle sandbox (sleepAfter keeps it warm) must never hold a
     // usable credential, so re-assert it on every exit path.
-    await sandbox.exec(
-      `git -C ${CLONE_DIR} remote set-url origin "https://github.com/${headRepo}.git"`,
-    );
+    await sandbox.exec(`git -C ${CLONE_DIR} remote set-url origin "${remote.cleanUrl}"`);
   }
 }
 

--- a/src/ai/runners/fixer.ts
+++ b/src/ai/runners/fixer.ts
@@ -35,7 +35,8 @@ import {
 } from '../runtime/runner-auth.ts';
 import { runnerSandbox } from '../runtime/sandbox.ts';
 import { redactSecrets } from '../runtime/redaction.ts';
-import { prepareFreshClone } from '../runtime/repository-workspace.ts';
+import { prepareFreshClone, pushHeadCommand } from '../runtime/repository-workspace.ts';
+import { githubWorkspaceRemote } from '../../integrations/git/provider.ts';
 import { mountSkills } from '../runtime/skills.ts';
 import {
   fetchPushablePrHead,
@@ -279,14 +280,17 @@ export async function runFix(params: FixParams): Promise<FixOutcome> {
   // Fresh checkout per run; the branch name and token travel via env so the
   // command string stays free of secrets and shell-hostile ref names. The
   // push below supplies the token via env to an explicit-URL command.
-  const gitEnv = { GIT_TOKEN: gitToken, FIX_BRANCH: headRef };
+  // PR fixes are a GitHub-only flow (PR head may live on a fork), so the
+  // remote is constructed for the head repo directly rather than resolved
+  // from the repo row.
+  const remote = githubWorkspaceRemote(headRepo, gitToken);
+  const gitEnv = { ...remote.env, FIX_BRANCH: headRef };
   await sandbox.exec(`rm -rf ${NOTES_FILE} /workspace/fix-repair-*.md`);
   await prepareFreshClone({
     sandbox,
     cloneDir: CLONE_DIR,
-    repository: headRepo,
+    remote,
     branch: headRef,
-    gitToken,
     secrets: [token],
   });
 
@@ -448,11 +452,10 @@ export async function runFix(params: FixParams): Promise<FixOutcome> {
       }
     }
 
-    const push = await sandbox.exec(
-      `git -C ${CLONE_DIR} push ` +
-        `"https://x-access-token:$GIT_TOKEN@github.com/${headRepo}.git" HEAD:"$FIX_BRANCH"`,
-      { env: gitEnv, timeout: 2 * 60_000 },
-    );
+    const push = await sandbox.exec(pushHeadCommand(remote, CLONE_DIR), {
+      env: { ...gitEnv, PUSH_BRANCH: headRef },
+      timeout: 2 * 60_000,
+    });
     if (!push.success) {
       throw new Error(describePushFailure(scrub(push.stderr).slice(0, 500)));
     }
@@ -478,9 +481,7 @@ export async function runFix(params: FixParams): Promise<FixOutcome> {
     // Belt and braces: the remote was already scrubbed right after clone,
     // but an idle sandbox (sleepAfter keeps it warm) must never hold a
     // usable credential, so re-assert it on every exit path.
-    await sandbox.exec(
-      `git -C ${CLONE_DIR} remote set-url origin "https://github.com/${headRepo}.git"`,
-    );
+    await sandbox.exec(`git -C ${CLONE_DIR} remote set-url origin "${remote.cleanUrl}"`);
   }
 }
 

--- a/src/ai/runners/planner.ts
+++ b/src/ai/runners/planner.ts
@@ -16,7 +16,8 @@ import { persistAgentLog } from '../runtime/agent-runs.ts';
 import { resolveRunnerAuth, runnerEnvironment } from '../runtime/runner-auth.ts';
 import { runnerSandbox } from '../runtime/sandbox.ts';
 import { redactSecrets } from '../runtime/redaction.ts';
-import { installationToken, sandboxGitToken } from '../../integrations/github/app.ts';
+import { installationToken } from '../../integrations/github/app.ts';
+import { resolveWorkspaceRemote } from '../../integrations/git/provider.ts';
 import { UNTRUSTED_CONTENT_RULES } from '../../domain/prompt-security.ts';
 import { notifyPlanUsers } from '../../services/push-notifications.ts';
 
@@ -42,7 +43,7 @@ async function clonePlanRepos(
 ): Promise<{
   sandbox: Sandbox;
   scrub: (s: string) => string;
-  dirs: { repo: RepositoryRow; dir: string }[];
+  dirs: { repo: RepositoryRow; dir: string; cleanUrl: string }[];
 }> {
   const tokens: string[] = [];
   const scrub = (s: string) => redactSecrets(s, tokens);
@@ -50,12 +51,12 @@ async function clonePlanRepos(
   const sandbox = runnerSandbox(`plan--${planId}`, { sleepAfter: '10m' });
   await sandbox.exec(`rm -rf ${CLONE_DIR} ${OUT_DIR} && mkdir -p ${OUT_DIR}`);
 
-  const dirs: { repo: RepositoryRow; dir: string }[] = [];
+  const dirs: { repo: RepositoryRow; dir: string; cleanUrl: string }[] = [];
   for (const repo of repos) {
     const token = await installationToken(repo.installation_id);
     // Planner sandboxes never push: contents READ-ONLY token.
-    const gitToken = await sandboxGitToken(repo.installation_id, repo.name, 'read');
-    tokens.push(token, gitToken);
+    const remote = await resolveWorkspaceRemote(repo, 'read');
+    tokens.push(token, remote.token);
     const full = `${repo.owner}/${repo.name}`;
     // SAFETY: GitHub's GET /repos/:owner/:repo REST schema always includes
     // default_branch.
@@ -63,14 +64,14 @@ async function clonePlanRepos(
     const dir = repos.length === 1 ? CLONE_DIR : `${CLONE_DIR}/${repo.owner}--${repo.name}`;
     if (repos.length > 1) await sandbox.exec(`mkdir -p ${dir}`);
     const clone = await sandbox.exec(
-      `git clone --depth 50 --single-branch --branch "$GEN_BASE" ` +
-        `"https://x-access-token:$GIT_TOKEN@github.com/${full}.git" ${dir}`,
-      { env: { GIT_TOKEN: gitToken, GEN_BASE: info.default_branch }, timeout: 3 * 60_000 },
+      `git ${remote.configFlags} clone --depth 50 --single-branch --branch "$GEN_BASE" ` +
+        `"${remote.authUrl}" ${dir}`,
+      { env: { ...remote.env, GEN_BASE: info.default_branch }, timeout: 3 * 60_000 },
     );
     if (!clone.success) {
       throw new Error(`git clone failed for ${full}: ${scrub(clone.stderr).slice(0, 500)}`);
     }
-    dirs.push({ repo, dir });
+    dirs.push({ repo, dir, cleanUrl: remote.cleanUrl });
   }
   return { sandbox, scrub, dirs };
 }
@@ -354,7 +355,7 @@ export async function runPlanAnalyze(planId: number): Promise<void> {
   }
   const full = repos.map((r) => `${r.owner}/${r.name}`).join(', ');
   let sandbox: Sandbox | undefined;
-  let dirs: { repo: RepositoryRow; dir: string }[] = [];
+  let dirs: { repo: RepositoryRow; dir: string; cleanUrl: string }[] = [];
   try {
     const booted = await clonePlanRepos(repos, planId);
     sandbox = booted.sandbox;
@@ -418,12 +419,8 @@ export async function runPlanAnalyze(planId: number): Promise<void> {
   } finally {
     if (sandbox) {
       await Promise.all(
-        dirs.map(({ repo, dir }) =>
-          sandbox!
-            .exec(
-              `git -C ${dir} remote set-url origin "https://github.com/${repo.owner}/${repo.name}.git"`,
-            )
-            .catch(() => {}),
+        dirs.map(({ dir, cleanUrl }) =>
+          sandbox!.exec(`git -C ${dir} remote set-url origin "${cleanUrl}"`).catch(() => {}),
         ),
       );
     }
@@ -465,7 +462,7 @@ export async function runPlanRefine(planId: number): Promise<void> {
       : '';
 
   let sandbox: Sandbox | undefined;
-  let dirs: { repo: RepositoryRow; dir: string }[] = [];
+  let dirs: { repo: RepositoryRow; dir: string; cleanUrl: string }[] = [];
   try {
     const booted = await clonePlanRepos(repos, planId);
     sandbox = booted.sandbox;
@@ -501,12 +498,8 @@ export async function runPlanRefine(planId: number): Promise<void> {
   } finally {
     if (sandbox) {
       await Promise.all(
-        dirs.map(({ repo, dir }) =>
-          sandbox!
-            .exec(
-              `git -C ${dir} remote set-url origin "https://github.com/${repo.owner}/${repo.name}.git"`,
-            )
-            .catch(() => {}),
+        dirs.map(({ dir, cleanUrl }) =>
+          sandbox!.exec(`git -C ${dir} remote set-url origin "${cleanUrl}"`).catch(() => {}),
         ),
       );
     }

--- a/src/ai/runners/verifier.ts
+++ b/src/ai/runners/verifier.ts
@@ -29,7 +29,8 @@ import { resolveRunnerAuth, runnerEnvironment } from '../runtime/runner-auth.ts'
 import { runnerSandbox } from '../runtime/sandbox.ts';
 import { redactSecrets } from '../runtime/redaction.ts';
 import { prepareCachedWorktree } from '../runtime/repository-workspace.ts';
-import { installationToken, sandboxGitToken } from '../../integrations/github/app.ts';
+import { installationToken } from '../../integrations/github/app.ts';
+import { resolveWorkspaceRemote } from '../../integrations/git/provider.ts';
 import { NPM_CACHE_ENV } from '../runtime/sandbox-deps.ts';
 import { UNTRUSTED_CONTENT_RULES } from '../../domain/prompt-security.ts';
 
@@ -209,8 +210,8 @@ async function verify(
   const token = await installationToken(repo.installation_id);
   const auth = resolveRunnerAuth();
   // Verifier sandboxes never push: single-repo, contents READ-ONLY token.
-  const gitToken = await sandboxGitToken(repo.installation_id, repo.name, 'read');
-  const scrub = (s: string) => redactSecrets(s, [token, gitToken]);
+  const remote = await resolveWorkspaceRemote(repo, 'read');
+  const scrub = (s: string) => redactSecrets(s, [token, remote.token]);
   const full = `${repo.owner}/${repo.name}`;
 
   // Same container id as generation: verify usually follows a generation on
@@ -230,9 +231,8 @@ async function verify(
       sandbox,
       cacheDir: CACHE_DIR,
       workDir: WORK,
-      repository: full,
+      remote,
       base: feature.branch!,
-      gitToken,
       secrets: [token],
     });
 

--- a/src/ai/runtime/repository-workspace.ts
+++ b/src/ai/runtime/repository-workspace.ts
@@ -1,10 +1,13 @@
 import type { Sandbox } from '@cloudflare/sandbox';
+import type { WorkspaceRemote } from '../../integrations/git/remotes.ts';
 import { redactSecrets } from './redaction.ts';
 
 // Every runner's workspace prep lives here so the credential rules hold in
 // exactly one place: tokens only ever travel via env to explicit-URL
 // commands, cache remotes are rewritten to credential-free URLs, and a
 // corrupted warm cache is dropped rather than allowed to wedge future runs.
+// Which forge the repo lives on is the remote's concern (git/provider.ts);
+// this module only shapes commands around it.
 
 function botIdentity(dir: string): string {
   return (
@@ -17,7 +20,7 @@ interface PrepareCachedWorktreeOptions {
   sandbox: Sandbox;
   cacheDir: string;
   workDir: string;
-  repository: string;
+  remote: WorkspaceRemote;
   base: string;
   // With `branch` set, a fresh work branch is created off base's FETCH_HEAD
   // (generation/automation). Without it, `base` is an existing remote branch:
@@ -25,8 +28,7 @@ interface PrepareCachedWorktreeOptions {
   // checked-out branch (so runs sharing the cache aren't disturbed) and the
   // worktree is cloned directly onto it (verification).
   branch?: string;
-  gitToken: string;
-  // Extra secrets to scrub from surfaced git errors, beyond the git token.
+  // Extra secrets to scrub from surfaced git errors, beyond the remote token.
   secrets?: string[];
 }
 
@@ -36,24 +38,24 @@ export async function prepareCachedWorktree({
   sandbox,
   cacheDir,
   workDir,
-  repository,
+  remote,
   base,
   branch,
-  gitToken,
   secrets = [],
 }: PrepareCachedWorktreeOptions): Promise<void> {
-  const scrub = (s: string) => redactSecrets(s, [gitToken, ...secrets]);
+  const scrub = (s: string) => redactSecrets(s, [remote.token, ...secrets]);
+  const git = `git ${remote.configFlags}`;
   const warmFetch = branch
-    ? `git -C ${cacheDir} fetch --depth 50 "https://x-access-token:$GIT_TOKEN@github.com/${repository}.git" "$BASE_REF" && ` +
+    ? `${git} -C ${cacheDir} fetch --depth 50 "${remote.authUrl}" "$BASE_REF" && ` +
       `git -C ${cacheDir} checkout -q -B "$BASE_REF" FETCH_HEAD; `
-    : `git -C ${cacheDir} fetch --depth 50 "https://x-access-token:$GIT_TOKEN@github.com/${repository}.git" "+refs/heads/$BASE_REF:refs/heads/$BASE_REF"; `;
+    : `${git} -C ${cacheDir} fetch --depth 50 "${remote.authUrl}" "+refs/heads/$BASE_REF:refs/heads/$BASE_REF"; `;
   const sync = await sandbox.exec(
     `if [ -d ${cacheDir}/.git ]; then ` +
       warmFetch +
-      `else git clone --depth 50 --single-branch --branch "$BASE_REF" ` +
-      `"https://x-access-token:$GIT_TOKEN@github.com/${repository}.git" ${cacheDir} && ` +
-      `git -C ${cacheDir} remote set-url origin "https://github.com/${repository}.git"; fi`,
-    { env: { GIT_TOKEN: gitToken, BASE_REF: base }, timeout: 5 * 60_000 },
+      `else ${git} clone --depth 50 --single-branch --branch "$BASE_REF" ` +
+      `"${remote.authUrl}" ${cacheDir} && ` +
+      `git -C ${cacheDir} remote set-url origin "${remote.cleanUrl}"; fi`,
+    { env: { ...remote.env, BASE_REF: base }, timeout: 5 * 60_000 },
   );
   if (!sync.success) {
     // Never let one corrupted warm cache wedge future runs.
@@ -78,40 +80,43 @@ export async function prepareCachedWorktree({
 interface PrepareFreshCloneOptions {
   sandbox: Sandbox;
   cloneDir: string;
-  repository: string;
+  remote: WorkspaceRemote;
   branch: string;
-  gitToken: string;
   secrets?: string[];
 }
 
 // Fresh shallow single-branch checkout for runs that work directly on an
-// existing PR branch (fix, conflict resolution). The clone URL (token
-// included) lands in .git/config — it is stripped before anything else runs
-// in the checkout, because the agent and the repo's own check command both
-// execute untrusted repo content with network egress; later fetches/pushes
-// supply the token via env to explicit-URL commands instead.
+// existing PR branch (fix, conflict resolution). Whatever the clone left in
+// .git/config (GitHub's URL embeds the token) is stripped before anything
+// else runs in the checkout, because the agent and the repo's own check
+// command both execute untrusted repo content with network egress; later
+// fetches/pushes supply the token via env to explicit-URL commands instead.
 export async function prepareFreshClone({
   sandbox,
   cloneDir,
-  repository,
+  remote,
   branch,
-  gitToken,
   secrets = [],
 }: PrepareFreshCloneOptions): Promise<void> {
   const clone = await sandbox.exec(
-    `rm -rf ${cloneDir} && git clone --depth 50 --single-branch --branch "$WORK_BRANCH" ` +
-      `"https://x-access-token:$GIT_TOKEN@github.com/${repository}.git" ${cloneDir}`,
-    { env: { GIT_TOKEN: gitToken, WORK_BRANCH: branch }, timeout: 5 * 60_000 },
+    `rm -rf ${cloneDir} && git ${remote.configFlags} clone --depth 50 --single-branch ` +
+      `--branch "$WORK_BRANCH" "${remote.authUrl}" ${cloneDir}`,
+    { env: { ...remote.env, WORK_BRANCH: branch }, timeout: 5 * 60_000 },
   );
   if (!clone.success) {
     throw new Error(
-      `git clone failed: ${redactSecrets(clone.stderr, [gitToken, ...secrets]).slice(0, 500)}`,
+      `git clone failed: ${redactSecrets(clone.stderr, [remote.token, ...secrets]).slice(0, 500)}`,
     );
   }
   await sandbox.exec(
-    `git -C ${cloneDir} remote set-url origin "https://github.com/${repository}.git" && ` +
-      botIdentity(cloneDir),
+    `git -C ${cloneDir} remote set-url origin "${remote.cleanUrl}" && ` + botIdentity(cloneDir),
   );
+}
+
+// The push counterpart of the prepare helpers: HEAD of `dir` to the branch
+// named by `$PUSH_BRANCH` (env-supplied by the caller alongside remote.env).
+export function pushHeadCommand(remote: WorkspaceRemote, dir: string): string {
+  return `git ${remote.configFlags} -C ${dir} push "${remote.authUrl}" HEAD:"$PUSH_BRANCH"`;
 }
 
 export async function worktreeChanged(sandbox: Sandbox, workDir: string): Promise<boolean> {

--- a/src/ai/workflows/artifacts-events.ts
+++ b/src/ai/workflows/artifacts-events.ts
@@ -1,0 +1,31 @@
+import { WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from 'cloudflare:workers';
+import { ARTIFACTS_NAMESPACE } from '../../integrations/git/provider.ts';
+import { applyArtifactsEvent } from '../../services/artifacts.ts';
+import { parseArtifactsEvent } from '../../shared/artifacts-events.ts';
+
+// Artifacts event ingestion (docs/artifacts-provider.md). The platform
+// starts one instance per event via the `triggers.events` entries in
+// wrangler.jsonc — the native replacement for GitHub webhooks: declarative,
+// per-namespace (no per-repo subscription provisioning), delivered with
+// Workflow durability. Unparseable or foreign events return instead of
+// throwing so the engine never retry-loops on them.
+export class ArtifactsEventsWorkflow extends WorkflowEntrypoint<unknown, unknown> {
+  async run(event: WorkflowEvent<unknown>, step: WorkflowStep): Promise<string> {
+    const parsed = parseArtifactsEvent(event.payload);
+    if (!parsed) {
+      console.warn(
+        'turbodiff: unparseable artifacts event:',
+        JSON.stringify(event.payload).slice(0, 500),
+      );
+      return 'unparseable';
+    }
+    // Belt and braces with the config-level namespace filter.
+    if (parsed.namespace !== ARTIFACTS_NAMESPACE) return 'foreign namespace';
+
+    return await step.do(
+      `apply ${parsed.type} for ${parsed.repoName}`,
+      { retries: { limit: 3, delay: '10 seconds', backoff: 'exponential' }, timeout: '1 minute' },
+      () => applyArtifactsEvent(parsed),
+    );
+  }
+}

--- a/src/ai/workflows/automation.ts
+++ b/src/ai/workflows/automation.ts
@@ -18,13 +18,21 @@ import { resolveRunnerAuth, runnerEnvironment } from '../runtime/runner-auth.ts'
 import { runnerSandbox } from '../runtime/sandbox.ts';
 import { redactSecrets } from '../runtime/redaction.ts';
 import { mountSkills } from '../runtime/skills.ts';
-import { prepareCachedWorktree, worktreeChanged } from '../runtime/repository-workspace.ts';
+import {
+  prepareCachedWorktree,
+  pushHeadCommand,
+  worktreeChanged,
+} from '../runtime/repository-workspace.ts';
+import {
+  remoteSourceOf,
+  resolveWorkspaceRemote,
+  type RemoteSource,
+} from '../../integrations/git/provider.ts';
 import { NPM_CACHE_ENV } from '../runtime/sandbox-deps.ts';
 import {
   authorizesWorkflowFiles,
   describePushFailure,
   installationToken,
-  sandboxGitToken,
 } from '../../integrations/github/app.ts';
 import { UNTRUSTED_CONTENT_RULES } from '../../domain/prompt-security.ts';
 
@@ -106,6 +114,9 @@ type RunContext = {
   // The user-authored prompt mentions .github/workflows — the push token may
   // carry the App's workflows permission (see sandboxGitToken).
   workflows: boolean;
+  // Provider-resolved git identity (git/provider.ts) so steps can mint
+  // run-scoped credentials without re-reading the repo row.
+  remoteSource: RemoteSource;
 };
 
 const QUICK = {
@@ -153,6 +164,7 @@ export class AutomationWorkflow extends WorkflowEntrypoint<unknown, AutomationPa
             automationName: automation.name,
             prompt: automation.prompt,
             workflows: authorizesWorkflowFiles(automation.prompt),
+            remoteSource: remoteSourceOf(repo),
           };
         },
       );
@@ -166,16 +178,15 @@ export class AutomationWorkflow extends WorkflowEntrypoint<unknown, AutomationPa
         'prepare working copy',
         { retries: { limit: 3, delay: '1 minute', backoff: 'exponential' }, timeout: '8 minutes' },
         async () => {
-          const gitToken = await sandboxGitToken(ctx.installationId, ctx.name, 'write');
+          const remote = await resolveWorkspaceRemote(ctx.remoteSource, 'write');
           const sandbox = sandboxFor(ctx);
           await prepareCachedWorktree({
             sandbox,
             cacheDir: CACHE_DIR,
             workDir: WORK,
-            repository: full,
+            remote,
             base: ctx.base,
             branch: ctx.branch,
-            gitToken,
           });
         },
       );
@@ -284,17 +295,17 @@ export class AutomationWorkflow extends WorkflowEntrypoint<unknown, AutomationPa
       }
 
       await step.do('push branch', QUICK, async () => {
-        const gitToken = await sandboxGitToken(ctx.installationId, ctx.name, 'write', {
+        const remote = await resolveWorkspaceRemote(ctx.remoteSource, 'write', {
           workflows: ctx.workflows,
         });
         const sandbox = sandboxFor(ctx);
-        const push = await sandbox.exec(
-          `git -C ${WORK} push "https://x-access-token:$GIT_TOKEN@github.com/${full}.git" HEAD:"$AUTOMATION_BRANCH"`,
-          { env: { GIT_TOKEN: gitToken, AUTOMATION_BRANCH: ctx.branch }, timeout: 3 * 60_000 },
-        );
+        const push = await sandbox.exec(pushHeadCommand(remote, WORK), {
+          env: { ...remote.env, PUSH_BRANCH: ctx.branch },
+          timeout: 3 * 60_000,
+        });
         if (!push.success) {
           throw new Error(
-            describePushFailure(redactSecrets(push.stderr, [gitToken]).slice(0, 500)),
+            describePushFailure(redactSecrets(push.stderr, [remote.token]).slice(0, 500)),
           );
         }
       });

--- a/src/ai/workflows/generation.ts
+++ b/src/ai/workflows/generation.ts
@@ -24,12 +24,20 @@ import { resolveRunnerAuth, runnerEnvironment } from '../runtime/runner-auth.ts'
 import { runnerSandbox } from '../runtime/sandbox.ts';
 import { redactSecrets } from '../runtime/redaction.ts';
 import { mountSkills } from '../runtime/skills.ts';
-import { prepareCachedWorktree, worktreeChanged } from '../runtime/repository-workspace.ts';
+import {
+  prepareCachedWorktree,
+  pushHeadCommand,
+  worktreeChanged,
+} from '../runtime/repository-workspace.ts';
+import {
+  remoteSourceOf,
+  resolveWorkspaceRemote,
+  type RemoteSource,
+} from '../../integrations/git/provider.ts';
 import {
   authorizesWorkflowFiles,
   describePushFailure,
   installationToken,
-  sandboxGitToken,
 } from '../../integrations/github/app.ts';
 import { UNTRUSTED_CONTENT_RULES } from '../../domain/prompt-security.ts';
 import { installDependencies, NPM_CACHE_ENV } from '../runtime/sandbox-deps.ts';
@@ -186,6 +194,9 @@ type RunContext = {
   // The approved spec mentions .github/workflows — the push token may carry
   // the App's workflows permission (see sandboxGitToken).
   workflows: boolean;
+  // Provider-resolved git identity (git/provider.ts) so steps can mint
+  // run-scoped credentials without re-reading the repo row.
+  remoteSource: RemoteSource;
 };
 
 const QUICK = {
@@ -243,6 +254,7 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
             tier: feature.tier === 'trivial' ? 'trivial' : 'standard',
             skills,
             workflows: authorizesWorkflowFiles(feature.spec),
+            remoteSource: remoteSourceOf(repo),
           };
         },
       );
@@ -256,16 +268,15 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
         { retries: { limit: 3, delay: '1 minute', backoff: 'exponential' }, timeout: '8 minutes' },
         async () => {
           await updateFeature(featureId, { runStartedAt: 'now' }); // heartbeat for the strand sweep
-          const gitToken = await sandboxGitToken(ctx.installationId, ctx.name, 'write');
+          const remote = await resolveWorkspaceRemote(ctx.remoteSource, 'write');
           const sandbox = sandboxFor(ctx);
           await prepareCachedWorktree({
             sandbox,
             cacheDir: CACHE_DIR,
             workDir: WORK,
-            repository: full,
+            remote,
             base: ctx.base,
             branch: ctx.branch,
-            gitToken,
           });
         },
       );
@@ -500,17 +511,17 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
       }
 
       await step.do('push branch', QUICK, async () => {
-        const gitToken = await sandboxGitToken(ctx.installationId, ctx.name, 'write', {
+        const remote = await resolveWorkspaceRemote(ctx.remoteSource, 'write', {
           workflows: ctx.workflows,
         });
         const sandbox = sandboxFor(ctx);
-        const push = await sandbox.exec(
-          `git -C ${WORK} push "https://x-access-token:$GIT_TOKEN@github.com/${full}.git" HEAD:"$GEN_BRANCH"`,
-          { env: { GIT_TOKEN: gitToken, GEN_BRANCH: ctx.branch }, timeout: 3 * 60_000 },
-        );
+        const push = await sandbox.exec(pushHeadCommand(remote, WORK), {
+          env: { ...remote.env, PUSH_BRANCH: ctx.branch },
+          timeout: 3 * 60_000,
+        });
         if (!push.success) {
           throw new Error(
-            describePushFailure(redactSecrets(push.stderr, [gitToken]).slice(0, 500)),
+            describePushFailure(redactSecrets(push.stderr, [remote.token]).slice(0, 500)),
           );
         }
       });

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -28,6 +28,9 @@ export { Sandbox } from '@cloudflare/sandbox';
 // (bindings GEN_WORKFLOW / VERIFY_WORKFLOW / AUTOMATION_WORKFLOW in
 // wrangler.jsonc): memoized steps, bounded retries, no wall-clock kills.
 export { GenerationWorkflow } from './ai/workflows/generation.ts';
+// Started by the platform itself on Artifacts events — see the
+// `triggers.events` entries in wrangler.jsonc (docs/artifacts-provider.md).
+export { ArtifactsEventsWorkflow } from './ai/workflows/artifacts-events.ts';
 export { VerificationWorkflow };
 export { FixWorkflow };
 export { AutomationWorkflow };

--- a/src/data/repositories.ts
+++ b/src/data/repositories.ts
@@ -9,6 +9,7 @@ export interface InstallationRow {
   account_id: number;
   account_type: string;
   suspended: number;
+  provider: string; // 'github' | 'artifacts' (synthetic tenancy rows)
 }
 
 export interface RepositoryRow {
@@ -16,6 +17,10 @@ export interface RepositoryRow {
   installation_id: number;
   owner: string;
   name: string;
+  provider: string; // 'github' | 'artifacts'
+  artifacts_repo: string | null; // repo name in turbodiff's Artifacts namespace
+  default_branch: string | null; // stored for Artifacts repos; NULL for GitHub
+  last_push_at: string | null; // maintained by Artifacts event ingestion
   enabled: number;
   review_on_push: number; // re-dispatch tiered agents on pushes to open PRs
   blocking_reviews: number; // P1 → REQUEST_CHANGES, clean → APPROVE
@@ -108,6 +113,71 @@ export async function getInstallation(id: number): Promise<InstallationRow | nul
   return env.DB.prepare('SELECT * FROM installations WHERE id = ?1')
     .bind(id)
     .first<InstallationRow>();
+}
+
+// ── Artifacts-hosted projects (docs/artifacts-provider.md) ─────────────────
+// Artifacts rows reuse the installation-scoped access model via synthetic
+// rows allocated in the negative id range: GitHub installation and repo ids
+// are always positive, so the spaces can never collide. Allocation is a
+// single INSERT..SELECT so no separate read can race the id choice.
+
+export async function getArtifactsInstallationByLogin(
+  accountLogin: string,
+): Promise<InstallationRow | null> {
+  return env.DB.prepare(
+    `SELECT * FROM installations WHERE account_login = ?1 AND provider = 'artifacts'`,
+  )
+    .bind(accountLogin)
+    .first<InstallationRow>();
+}
+
+export async function createArtifactsInstallation(accountLogin: string): Promise<InstallationRow> {
+  const row = await env.DB.prepare(
+    `INSERT INTO installations (id, account_login, account_id, account_type, provider)
+		 SELECT COALESCE(MIN(id), 0) - 1, ?1, COALESCE(MIN(id), 0) - 1, 'Organization', 'artifacts'
+		 FROM installations WHERE id < 0
+		 RETURNING *`,
+  )
+    .bind(accountLogin)
+    .first<InstallationRow>();
+  if (!row) throw new Error('artifacts installation insert returned no row');
+  return row;
+}
+
+export async function createArtifactsRepository(input: {
+  installationId: number;
+  owner: string;
+  name: string;
+  artifactsRepo: string;
+  defaultBranch: string;
+}): Promise<RepositoryRow> {
+  const row = await env.DB.prepare(
+    `INSERT INTO repositories (id, installation_id, owner, name, provider, artifacts_repo, default_branch)
+		 SELECT COALESCE(MIN(id), 0) - 1, ?1, ?2, ?3, 'artifacts', ?4, ?5
+		 FROM repositories WHERE id < 0
+		 RETURNING *`,
+  )
+    .bind(input.installationId, input.owner, input.name, input.artifactsRepo, input.defaultBranch)
+    .first<RepositoryRow>();
+  if (!row) throw new Error('artifacts repository insert returned no row');
+  return row;
+}
+
+export async function getRepoByArtifactsName(artifactsRepo: string): Promise<RepositoryRow | null> {
+  return env.DB.prepare('SELECT * FROM repositories WHERE artifacts_repo = ?1')
+    .bind(artifactsRepo)
+    .first<RepositoryRow>();
+}
+
+export async function recordArtifactsPush(
+  artifactsRepo: string,
+  pushedAt: string,
+): Promise<RepositoryRow | null> {
+  return env.DB.prepare(
+    'UPDATE repositories SET last_push_at = ?2 WHERE artifacts_repo = ?1 RETURNING *',
+  )
+    .bind(artifactsRepo, pushedAt)
+    .first<RepositoryRow>();
 }
 
 export async function listInstallationsWithRepos(

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -1,6 +1,7 @@
 import { env } from 'cloudflare:workers';
 // HTTP JSON transport for the signed-in SPA.
 import { Hono, type Context } from 'hono';
+import { factoryUnsupportedReason } from '../integrations/git/provider.ts';
 import {
   agentUsageForMonth,
   automationUsageForMonth,
@@ -521,6 +522,8 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
     if (repos.length === 0) {
       return c.json({ error: 'select at least one repository first' }, 400);
     }
+    const unsupported = repos.map(factoryUnsupportedReason).find(Boolean);
+    if (unsupported) return c.json({ error: unsupported }, 409);
     const body = await c.req
       .json<{
         title?: string;
@@ -1427,6 +1430,8 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
     if (!repo || !installationIds.includes(repo.installation_id) || repo.enabled !== 1) {
       return c.json({ error: 'unknown or disabled repository' }, 404);
     }
+    const automationUnsupported = factoryUnsupportedReason(repo);
+    if (automationUnsupported) return c.json({ error: automationUnsupported }, 409);
     const deniedCapability = await requireCapability(c, repo.installation_id, 'settings', orgAdmin);
     if (deniedCapability) return deniedCapability;
     const nextRunAt = computeNextRunAt(

--- a/src/http/internal.ts
+++ b/src/http/internal.ts
@@ -20,6 +20,12 @@ import {
 import { timingSafeEqual } from '../integrations/security/crypto.ts';
 import { isString } from '../shared/json.ts';
 import { enqueueFactoryMessage, enqueueFactoryMessages } from '../services/factory-queue.ts';
+import { factoryUnsupportedReason } from '../integrations/git/provider.ts';
+import {
+  createArtifactsProject,
+  mintArtifactsCloneToken,
+  PROJECT_SEGMENT,
+} from '../services/artifacts.ts';
 
 // Shared-secret operator surface. This transport owns validation and queue
 // admission; durable AI work remains in runners/workflows.
@@ -40,6 +46,75 @@ export function createInternalRoutes() {
   routes.use('/*', requireSecret);
 
   routes.route('/pr-reviewer', reviewer);
+
+  // Artifacts-hosted project provisioning (docs/artifacts-provider.md):
+  //   POST /projects { "owner": "...", "name": "...", "description"?: "..." }
+  // Creates the Artifacts repo in turbodiff's namespace, seeds an initial
+  // commit, and records the synthetic-tenancy D1 rows. The request stays
+  // open for the provisioning (first call pays a container boot).
+  routes.post('/projects', async (c) => {
+    const payload = await c.req
+      .json<{ owner?: string; name?: string; description?: string }>()
+      .catch(() => null);
+    if (
+      !payload ||
+      !isString(payload.owner) ||
+      !PROJECT_SEGMENT.test(payload.owner) ||
+      !isString(payload.name) ||
+      !PROJECT_SEGMENT.test(payload.name)
+    ) {
+      return c.json(
+        { error: 'body must be {"owner": "...", "name": "...", "description"?: "..."}' },
+        400,
+      );
+    }
+    const existing = await getRepoByFullName(payload.owner, payload.name);
+    if (existing) return c.json({ error: `${payload.owner}/${payload.name} already exists` }, 409);
+    try {
+      const project = await createArtifactsProject({
+        owner: payload.owner,
+        name: payload.name,
+        description: isString(payload.description) ? payload.description : undefined,
+      });
+      return c.json({
+        ok: true,
+        repository_id: project.repo.id,
+        repo: `${project.repo.owner}/${project.repo.name}`,
+        provider: project.repo.provider,
+        artifacts_repo: project.repo.artifacts_repo,
+        default_branch: project.repo.default_branch,
+        remote: project.remote,
+      });
+    } catch (err) {
+      console.error('turbodiff: project provisioning failed:', err);
+      return c.json({ error: err instanceof Error ? err.message : 'provisioning failed' }, 502);
+    }
+  });
+
+  // Clone credential for an Artifacts-hosted repo — the deploy-key
+  // replacement that lets a user clone/push with plain git:
+  //   POST /repos/clone-token { "repo": "<owner>/<name>", "scope"?: "read" | "write", "ttl_seconds"?: n }
+  routes.post('/repos/clone-token', async (c) => {
+    const payload = await c.req
+      .json<{ repo?: string; scope?: string; ttl_seconds?: number }>()
+      .catch(() => null);
+    const match = payload?.repo?.match(/^([\w.-]+)\/([\w.-]+)$/);
+    if (!match) return c.json({ error: 'body must be {"repo": "<owner>/<name>", ...}' }, 400);
+    const scope = payload?.scope === 'write' ? 'write' : 'read';
+    const requestedTtl = payload?.ttl_seconds;
+    const ttl =
+      requestedTtl !== undefined && Number.isInteger(requestedTtl)
+        ? Math.min(Math.max(requestedTtl, 60), 30 * 24 * 3600)
+        : 24 * 3600;
+    const repo = await getRepoByFullName(match[1], match[2]);
+    if (!repo) return c.json({ error: `unknown repository ${payload?.repo}` }, 404);
+    try {
+      return c.json(await mintArtifactsCloneToken(repo, scope, ttl));
+    } catch (err) {
+      console.error('turbodiff: clone-token mint failed:', err);
+      return c.json({ error: err instanceof Error ? err.message : 'token mint failed' }, 502);
+    }
+  });
 
   // Software-factory fix loop, Phase 1 spike (docs/software-factory-design.md):
   //   POST /fix { "pr_url": "...", "findings"?: "...", "auth_mode"?: "...", "test_command"?: "..." }
@@ -77,6 +152,8 @@ export function createInternalRoutes() {
     const repo = await getRepoByFullName(match[1], match[2]);
     if (!repo) return c.json({ error: `Turbodiff is not installed on ${payload.repo}` }, 404);
     if (!repo.enabled) return c.json({ error: 'reviews are disabled for this repository' }, 409);
+    const generateUnsupported = factoryUnsupportedReason(repo);
+    if (generateUnsupported) return c.json({ error: generateUnsupported }, 409);
 
     const featureId = await createFeature(repo.id, payload.title.trim(), payload.spec.trim());
     await enqueueFactoryMessage({ kind: 'generate', featureId });
@@ -106,6 +183,8 @@ export function createInternalRoutes() {
     const repo = await getRepoByFullName(match[1], match[2]);
     if (!repo) return c.json({ error: `Turbodiff is not installed on ${payload.repo}` }, 404);
     if (!repo.enabled) return c.json({ error: 'reviews are disabled for this repository' }, 409);
+    const planUnsupported = factoryUnsupportedReason(repo);
+    if (planUnsupported) return c.json({ error: planUnsupported }, 409);
 
     const planId = await createPlan([repo.id], payload.title.trim(), payload.requirements.trim());
     await enqueueFactoryMessage({ kind: 'plan_analyze', planId });
@@ -275,6 +354,8 @@ export function createInternalRoutes() {
     if (!repo) {
       return c.json({ error: `Turbodiff is not installed on ${owner}/${repoName}` }, 404);
     }
+    const fixUnsupported = factoryUnsupportedReason(repo);
+    if (fixUnsupported) return c.json({ error: fixUnsupported }, 409);
     try {
       const outcome = await runFix({
         owner: repo.owner,

--- a/src/integrations/git/provider.ts
+++ b/src/integrations/git/provider.ts
@@ -1,0 +1,65 @@
+import { env } from 'cloudflare:workers';
+import type { RepositoryRow } from '../../data/db.ts';
+import { sandboxGitToken } from '../github/app.ts';
+import {
+  artifactsWorkspaceRemote,
+  githubWorkspaceRemote,
+  type WorkspaceRemote,
+} from './remotes.ts';
+
+// Runtime half of the git-provider seam (docs/artifacts-provider.md): mints
+// run-scoped credentials and dispatches on the repo row's provider. The pure
+// remote builders live in ./remotes.ts.
+
+export {
+  ARTIFACTS_NAMESPACE,
+  artifactsWorkspaceRemote,
+  deriveArtifactsRepoName,
+  factoryUnsupportedReason,
+  githubWorkspaceRemote,
+  type GitProviderKind,
+  type WorkspaceRemote,
+} from './remotes.ts';
+
+// TTL for per-run sandbox credentials. Generous enough for a long agent run
+// that pushes at the end; far below the 24h default.
+const ARTIFACTS_TOKEN_TTL_SECONDS = 4 * 3600;
+
+// The subset of RepositoryRow the resolver needs; workflow RunContexts carry
+// this shape so a step can resolve a remote without re-reading the repo row.
+export interface RemoteSource {
+  provider: string;
+  installation_id: number;
+  owner: string;
+  name: string;
+  artifacts_repo: string | null;
+}
+
+// Mints a run-scoped credential and returns the remote for the repo's
+// provider. GitHub `workflows` widening only applies to GitHub tokens.
+export async function resolveWorkspaceRemote(
+  repo: RemoteSource,
+  scope: 'read' | 'write',
+  opts?: { workflows?: boolean },
+): Promise<WorkspaceRemote> {
+  if (repo.provider === 'artifacts') {
+    if (!repo.artifacts_repo) {
+      throw new Error(`${repo.owner}/${repo.name} is an artifacts repo without artifacts_repo set`);
+    }
+    const handle = await env.GIT_ARTIFACTS.get(repo.artifacts_repo);
+    const token = await handle.createToken(scope, ARTIFACTS_TOKEN_TTL_SECONDS);
+    return artifactsWorkspaceRemote(handle.remote, token.plaintext);
+  }
+  const token = await sandboxGitToken(repo.installation_id, repo.name, scope, opts);
+  return githubWorkspaceRemote(`${repo.owner}/${repo.name}`, token);
+}
+
+export function remoteSourceOf(repo: RepositoryRow): RemoteSource {
+  return {
+    provider: repo.provider,
+    installation_id: repo.installation_id,
+    owner: repo.owner,
+    name: repo.name,
+    artifacts_repo: repo.artifacts_repo,
+  };
+}

--- a/src/integrations/git/remotes.test.ts
+++ b/src/integrations/git/remotes.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  artifactsWorkspaceRemote,
+  deriveArtifactsRepoName,
+  factoryUnsupportedReason,
+  githubWorkspaceRemote,
+} from './remotes.ts';
+
+describe('githubWorkspaceRemote', () => {
+  it('keeps the historical command shape with the token only in env', () => {
+    const remote = githubWorkspaceRemote('acme/api', 'tok-123');
+    expect(remote.authUrl).toBe('https://x-access-token:$GIT_TOKEN@github.com/acme/api.git');
+    expect(remote.cleanUrl).toBe('https://github.com/acme/api.git');
+    expect(remote.configFlags).toBe('');
+    expect(remote.env).toEqual({ GIT_TOKEN: 'tok-123' });
+    // The credential must never appear in a command-embeddable field.
+    expect(remote.authUrl).not.toContain('tok-123');
+  });
+});
+
+describe('artifactsWorkspaceRemote', () => {
+  it('routes auth through a header and keeps the URL credential-free', () => {
+    const remote = artifactsWorkspaceRemote(
+      'https://acct.artifacts.cloudflare.net/git/turbodiff-repos/acme--api.git',
+      'art_v1_secret?expires=1760000000',
+    );
+    expect(remote.authUrl).toBe('$GIT_REMOTE');
+    expect(remote.cleanUrl).toContain('acme--api.git');
+    expect(remote.configFlags).toContain('Authorization: Bearer $GIT_TOKEN');
+    expect(remote.env.GIT_TOKEN).toBe('art_v1_secret?expires=1760000000');
+    expect(remote.env.GIT_REMOTE).toBe(remote.cleanUrl);
+    expect(remote.configFlags).not.toContain('art_v1_secret');
+  });
+});
+
+describe('deriveArtifactsRepoName', () => {
+  it('joins owner and name with a double dash', () => {
+    expect(deriveArtifactsRepoName('acme', 'api')).toBe('acme--api');
+  });
+
+  it('sanitizes characters outside the Artifacts grammar', () => {
+    expect(deriveArtifactsRepoName('acme co', 'my repo!')).toBe('acme-co--my-repo');
+  });
+
+  it('never emits a leading separator', () => {
+    expect(deriveArtifactsRepoName('-acme', 'api')).toMatch(/^[A-Za-z0-9]/);
+  });
+
+  it('caps length at 64 including collision suffixes', () => {
+    const long = 'a'.repeat(80);
+    expect(deriveArtifactsRepoName(long, long).length).toBeLessThanOrEqual(64);
+    const suffixed = deriveArtifactsRepoName(long, long, 3);
+    expect(suffixed.length).toBeLessThanOrEqual(64);
+    expect(suffixed.endsWith('-4')).toBe(true);
+  });
+
+  it('adds a numeric suffix per collision attempt', () => {
+    expect(deriveArtifactsRepoName('acme', 'api', 1)).toBe('acme--api-2');
+  });
+});
+
+describe('factoryUnsupportedReason', () => {
+  it('passes GitHub repos through', () => {
+    expect(factoryUnsupportedReason({ provider: 'github', owner: 'a', name: 'b' })).toBeNull();
+  });
+
+  it('names the repo when rejecting an Artifacts repo', () => {
+    const reason = factoryUnsupportedReason({ provider: 'artifacts', owner: 'acme', name: 'api' });
+    expect(reason).toContain('acme/api');
+    expect(reason).toContain('Phase 2');
+  });
+});

--- a/src/integrations/git/remotes.ts
+++ b/src/integrations/git/remotes.ts
@@ -1,0 +1,83 @@
+// Pure half of the git-provider seam (docs/artifacts-provider.md): remote
+// shapes and builders with no Workers runtime dependency. Credential minting
+// and provider dispatch live in ./provider.ts.
+
+export type GitProviderKind = 'github' | 'artifacts';
+
+// Must match the `artifacts` binding namespace in wrangler.jsonc (and its
+// triggers.events filters) — the binding does not expose its configured
+// namespace at runtime.
+export const ARTIFACTS_NAMESPACE = 'turbodiff-repos';
+
+export interface WorkspaceRemote {
+  provider: GitProviderKind;
+  // Shell-embeddable authenticated URL for clone/fetch/push commands. It
+  // only ever references env vars ($GIT_TOKEN / $GIT_REMOTE), so no secret
+  // enters a command string.
+  authUrl: string;
+  // Credential-free URL — the only form allowed in .git/config origins.
+  cleanUrl: string;
+  // Per-command `git -c ...` flags, placed before the subcommand.
+  configFlags: string;
+  // env entries every command using authUrl/configFlags must receive.
+  env: Record<string, string>;
+  // The minted credential, for redaction lists.
+  token: string;
+}
+
+// GitHub keeps its exact historical command shape: token inside the URL as
+// x-access-token basic auth, no config flags.
+export function githubWorkspaceRemote(repository: string, token: string): WorkspaceRemote {
+  return {
+    provider: 'github',
+    authUrl: `https://x-access-token:$GIT_TOKEN@github.com/${repository}.git`,
+    cleanUrl: `https://github.com/${repository}.git`,
+    configFlags: '',
+    env: { GIT_TOKEN: token },
+    token,
+  };
+}
+
+// Artifacts authenticates via an Authorization header because its tokens can
+// carry URL-hostile characters (`?expires=` suffix).
+export function artifactsWorkspaceRemote(remoteUrl: string, token: string): WorkspaceRemote {
+  return {
+    provider: 'artifacts',
+    authUrl: '$GIT_REMOTE',
+    cleanUrl: remoteUrl,
+    configFlags: '-c http.extraHeader="Authorization: Bearer $GIT_TOKEN"',
+    env: { GIT_TOKEN: token, GIT_REMOTE: remoteUrl },
+    token,
+  };
+}
+
+// Factory flows that end in a GitHub pull request (generation, plans,
+// automations, PR fix/verify loops) still assume GitHub. Native change
+// requests for Artifacts repos land in Phase 2; until then intake rejects
+// up front instead of stranding a run at the PR step.
+export function factoryUnsupportedReason(repo: {
+  provider: string;
+  owner: string;
+  name: string;
+}): string | null {
+  if (repo.provider === 'github') return null;
+  return (
+    `${repo.owner}/${repo.name} is hosted on Cloudflare Artifacts; factory runs need the ` +
+    'native change-request layer (Phase 2) and are not yet available for Artifacts repos'
+  );
+}
+
+// Artifacts repo names allow [A-Za-z0-9._-] after an alphanumeric, max 64
+// chars. Project identity is `<owner>--<name>`, sanitized; the caller
+// appends a numeric suffix on collision (attempt 1 → "-2", etc.).
+export function deriveArtifactsRepoName(owner: string, name: string, attempt = 0): string {
+  const sanitize = (part: string) =>
+    part
+      .replaceAll(/[^A-Za-z0-9._-]+/g, '-')
+      .replaceAll(/^[._-]+/g, '')
+      .replaceAll(/-{3,}/g, '--');
+  const suffix = attempt > 0 ? `-${attempt + 1}` : '';
+  const base = `${sanitize(owner)}--${sanitize(name)}`.slice(0, 64 - suffix.length);
+  const trimmed = base.replaceAll(/[._-]+$/g, '');
+  return `${trimmed}${suffix}`;
+}

--- a/src/integrations/github/app.ts
+++ b/src/integrations/github/app.ts
@@ -135,6 +135,11 @@ async function mintToken(
   installationId: number,
   scope?: { repositories: string[]; permissions: Record<string, string> },
 ): Promise<{ token: string; expires_at: string }> {
+  // Negative ids are synthetic Artifacts installations (git/provider.ts) —
+  // a caller reaching GitHub with one is a provider-dispatch bug upstream.
+  if (installationId < 0) {
+    throw new Error(`installation ${installationId} is Artifacts-hosted, not a GitHub App install`);
+  }
   return githubJson<{ token: string; expires_at: string }>(
     await appJwt(),
     `/app/installations/${installationId}/access_tokens`,

--- a/src/services/artifacts.ts
+++ b/src/services/artifacts.ts
@@ -1,0 +1,172 @@
+import { env } from 'cloudflare:workers';
+import { redactSecrets } from '../ai/runtime/redaction.ts';
+import { runnerSandbox } from '../ai/runtime/sandbox.ts';
+import {
+  createArtifactsInstallation,
+  createArtifactsRepository,
+  getArtifactsInstallationByLogin,
+  getRepoByArtifactsName,
+  recordArtifactsPush,
+  removeRepositories,
+  type RepositoryRow,
+} from '../data/db.ts';
+import { artifactsWorkspaceRemote, deriveArtifactsRepoName } from '../integrations/git/provider.ts';
+import {
+  isArtifactsPushedEvent,
+  ARTIFACTS_REPO_DELETED,
+  type ArtifactsEvent,
+} from '../shared/artifacts-events.ts';
+
+// Artifacts-hosted project lifecycle (docs/artifacts-provider.md):
+// provisioning (repo + synthetic tenancy + initial commit), user clone
+// tokens, and event application for the ArtifactsEventsWorkflow.
+
+// Same identifier grammar the GitHub routes accept for owner/name segments.
+export const PROJECT_SEGMENT = /^[\w.-]{1,80}$/;
+
+export interface CreatedProject {
+  repo: RepositoryRow;
+  remote: string;
+}
+
+function isArtifactsErrorWithCode<T>(err: T, code: string): boolean {
+  return err instanceof Error && 'code' in err && err.code === code;
+}
+
+// Creates the Artifacts repo (retrying the derived name on collision), seeds
+// an initial commit so every consumer has a base branch to clone, and only
+// then records the D1 rows — a failed provisioning never leaves a repo row
+// pointing at a broken remote. The Artifacts repo itself is compensated away
+// on later failures.
+export async function createArtifactsProject(input: {
+  owner: string;
+  name: string;
+  description?: string;
+}): Promise<CreatedProject> {
+  if (!PROJECT_SEGMENT.test(input.owner) || !PROJECT_SEGMENT.test(input.name)) {
+    throw new Error(`owner and name must match ${PROJECT_SEGMENT}`);
+  }
+
+  let created: Awaited<ReturnType<typeof env.GIT_ARTIFACTS.create>> | null = null;
+  for (let attempt = 0; attempt < 3 && !created; attempt++) {
+    const candidate = deriveArtifactsRepoName(input.owner, input.name, attempt);
+    try {
+      created = await env.GIT_ARTIFACTS.create(candidate, {
+        description: input.description?.trim() || `turbodiff project ${input.owner}/${input.name}`,
+      });
+    } catch (err) {
+      if (!isArtifactsErrorWithCode(err, 'ALREADY_EXISTS')) throw err;
+    }
+  }
+  if (!created) {
+    throw new Error(`an Artifacts repo already exists for every candidate name of ${input.name}`);
+  }
+
+  try {
+    await seedInitialCommit(created.name, created.remote, created.token, input);
+    const installation =
+      (await getArtifactsInstallationByLogin(input.owner)) ??
+      (await createArtifactsInstallation(input.owner));
+    const repo = await createArtifactsRepository({
+      installationId: installation.id,
+      owner: input.owner,
+      name: input.name,
+      artifactsRepo: created.name,
+      defaultBranch: created.defaultBranch,
+    });
+    return { repo, remote: created.remote };
+  } catch (err) {
+    // Compensate so a retry doesn't trip over a half-provisioned repo.
+    await env.GIT_ARTIFACTS.delete(created.name).catch((cleanupErr) => {
+      console.error(
+        `turbodiff: failed to clean up artifacts repo ${created?.name} after provisioning error:`,
+        cleanupErr,
+      );
+    });
+    throw err;
+  }
+}
+
+async function seedInitialCommit(
+  artifactsRepo: string,
+  remoteUrl: string,
+  token: string,
+  input: { owner: string; name: string; description?: string },
+): Promise<void> {
+  const remote = artifactsWorkspaceRemote(remoteUrl, token);
+  const sandbox = runnerSandbox(`provision--${artifactsRepo}`.toLowerCase(), {
+    sleepAfter: '5m',
+  });
+  const dir = `/workspace/provision-${artifactsRepo}`;
+  const readme =
+    `# ${input.name}\n\n` +
+    `${input.description?.trim() || 'A turbodiff project.'}\n\n` +
+    `Created by [turbodiff](https://turbodiff.dev); hosted on Cloudflare Artifacts.\n`;
+
+  // First exec on a cold container pays the boot, hence the generous timeout.
+  const init = await sandbox.exec(
+    `rm -rf ${dir} && mkdir -p ${dir} && cd ${dir} && git init -q -b main && ` +
+      `git config user.name "turbodiff[bot]" && ` +
+      `git config user.email "turbodiff[bot]@users.noreply.github.com"`,
+    { timeout: 5 * 60_000 },
+  );
+  if (!init.success) {
+    throw new Error(`provisioning workspace init failed: ${init.stderr.slice(0, 500)}`);
+  }
+  await sandbox.writeFile(`${dir}/README.md`, readme);
+  const push = await sandbox.exec(
+    `cd ${dir} && git add -A && git commit -q -m "Initialize ${input.name}" && ` +
+      `git ${remote.configFlags} push -q "${remote.authUrl}" main`,
+    { env: remote.env, timeout: 2 * 60_000 },
+  );
+  if (!push.success) {
+    throw new Error(
+      `initial commit push failed: ${redactSecrets(push.stderr, [token]).slice(0, 500)}`,
+    );
+  }
+  await sandbox.exec(`rm -rf ${dir}`).catch(() => {});
+}
+
+export interface CloneCredential {
+  remote: string;
+  token: string;
+  scope: 'read' | 'write';
+  expiresAt: string;
+}
+
+// A user-facing clone credential: the "deploy key" replacement that lets
+// anyone with access clone their turbodiff-hosted repo with plain git.
+export async function mintArtifactsCloneToken(
+  repo: RepositoryRow,
+  scope: 'read' | 'write',
+  ttlSeconds: number,
+): Promise<CloneCredential> {
+  if (repo.provider !== 'artifacts' || !repo.artifacts_repo) {
+    throw new Error(`${repo.owner}/${repo.name} is not an Artifacts-hosted repo`);
+  }
+  const handle = await env.GIT_ARTIFACTS.get(repo.artifacts_repo);
+  const token = await handle.createToken(scope, ttlSeconds);
+  return { remote: handle.remote, token: token.plaintext, scope, expiresAt: token.expiresAt };
+}
+
+// Applies one Artifacts event to D1. Runs inside the ArtifactsEventsWorkflow;
+// must stay idempotent (workflow steps can be retried).
+export async function applyArtifactsEvent(event: ArtifactsEvent): Promise<string> {
+  if (isArtifactsPushedEvent(event)) {
+    const row = await recordArtifactsPush(
+      event.repoName,
+      event.eventTimestamp ?? new Date().toISOString(),
+    );
+    if (!row) return `push to untracked repo ${event.repoName} ignored`;
+    return `recorded push to ${row.owner}/${row.name} (${event.ref})`;
+  }
+  if (event.type === ARTIFACTS_REPO_DELETED) {
+    const row = await getRepoByArtifactsName(event.repoName);
+    if (!row || row.provider !== 'artifacts') return `delete of untracked repo ${event.repoName}`;
+    // The hosted repo is gone (operator delete); drop the stale row so the
+    // dashboard and factory stop offering it.
+    await removeRepositories([row.id]);
+    return `removed repository row for deleted repo ${row.owner}/${row.name}`;
+  }
+  return `no handler for ${event.type}`;
+}

--- a/src/services/artifacts.worker.test.ts
+++ b/src/services/artifacts.worker.test.ts
@@ -1,0 +1,141 @@
+/* oxlint-disable typescript/triple-slash-reference -- generated Worker bindings */
+/// <reference path="../../worker-configuration.d.ts" />
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+
+import { env } from 'cloudflare:workers';
+import { applyD1Migrations } from 'cloudflare:test';
+import { beforeAll, describe, expect, it } from 'vite-plus/test';
+import type { D1Migration } from '@cloudflare/vitest-pool-workers';
+import {
+  createArtifactsInstallation,
+  createArtifactsRepository,
+  getArtifactsInstallationByLogin,
+  getRepoByArtifactsName,
+  getRepoByFullName,
+} from '../data/db.ts';
+import { applyArtifactsEvent } from './artifacts.ts';
+
+type TestEnv = Cloudflare.Env & { TEST_MIGRATIONS: D1Migration[] };
+// SAFETY: vitest.worker.config.ts defines the test-only TEST_MIGRATIONS
+// miniflare binding, which the generated production Cloudflare.Env cannot
+// know about.
+const testEnv = env as TestEnv;
+
+beforeAll(async () => {
+  await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+  // A GitHub tenant, to prove the two id spaces coexist.
+  await testEnv.DB.batch([
+    testEnv.DB.prepare(
+      `INSERT INTO installations (id, account_login, account_id, account_type)
+			 VALUES (1001, 'acme', 2001, 'Organization')`,
+    ),
+    testEnv.DB.prepare(
+      `INSERT INTO repositories (id, installation_id, owner, name)
+			 VALUES (101, 1001, 'acme', 'api')`,
+    ),
+  ]);
+});
+
+describe('synthetic Artifacts tenancy', () => {
+  it('allocates installations downward in the negative id space', async () => {
+    const first = await createArtifactsInstallation('hosted-org');
+    const second = await createArtifactsInstallation('other-org');
+    expect(first.id).toBe(-1);
+    expect(second.id).toBe(-2);
+    expect(first.provider).toBe('artifacts');
+    expect(first.account_type).toBe('Organization');
+    // GitHub rows are untouched by the allocation scan.
+    expect((await getArtifactsInstallationByLogin('hosted-org'))?.id).toBe(-1);
+  });
+
+  it('records artifacts repositories with negative ids alongside GitHub rows', async () => {
+    const installation = await getArtifactsInstallationByLogin('hosted-org');
+    const repo = await createArtifactsRepository({
+      installationId: installation!.id,
+      owner: 'hosted-org',
+      name: 'shop',
+      artifactsRepo: 'hosted-org--shop',
+      defaultBranch: 'main',
+    });
+    expect(repo.id).toBeLessThan(0);
+    expect(repo.provider).toBe('artifacts');
+    expect(repo.artifacts_repo).toBe('hosted-org--shop');
+    expect(repo.default_branch).toBe('main');
+    // Lookup paths used by routes and event ingestion.
+    expect((await getRepoByArtifactsName('hosted-org--shop'))?.id).toBe(repo.id);
+    expect((await getRepoByFullName('hosted-org', 'shop'))?.provider).toBe('artifacts');
+    // The GitHub repo is still a GitHub repo.
+    expect((await getRepoByFullName('acme', 'api'))?.provider).toBe('github');
+  });
+
+  it('rejects duplicate artifacts repo names via the unique index', async () => {
+    const installation = await getArtifactsInstallationByLogin('hosted-org');
+    await expect(
+      createArtifactsRepository({
+        installationId: installation!.id,
+        owner: 'hosted-org',
+        name: 'shop-copy',
+        artifactsRepo: 'hosted-org--shop',
+        defaultBranch: 'main',
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('applyArtifactsEvent', () => {
+  it('records pushes on tracked repos and ignores untracked ones', async () => {
+    const outcome = await applyArtifactsEvent({
+      type: 'cf.artifacts.repo.pushed',
+      namespace: 'turbodiff-repos',
+      repoName: 'hosted-org--shop',
+      ref: 'refs/heads/main',
+      before: 'a'.repeat(40),
+      after: 'b'.repeat(40),
+      eventTimestamp: '2026-08-21T10:00:00.000Z',
+    });
+    expect(outcome).toContain('hosted-org/shop');
+    expect((await getRepoByArtifactsName('hosted-org--shop'))?.last_push_at).toBe(
+      '2026-08-21T10:00:00.000Z',
+    );
+
+    const ignored = await applyArtifactsEvent({
+      type: 'cf.artifacts.repo.pushed',
+      namespace: 'turbodiff-repos',
+      repoName: 'not-ours',
+      ref: 'refs/heads/main',
+      before: 'a'.repeat(40),
+      after: 'b'.repeat(40),
+      eventTimestamp: null,
+    });
+    expect(ignored).toContain('ignored');
+  });
+
+  it('drops the repository row when the hosted repo is deleted', async () => {
+    const installation = await getArtifactsInstallationByLogin('hosted-org');
+    await createArtifactsRepository({
+      installationId: installation!.id,
+      owner: 'hosted-org',
+      name: 'ephemeral',
+      artifactsRepo: 'hosted-org--ephemeral',
+      defaultBranch: 'main',
+    });
+    await applyArtifactsEvent({
+      type: 'cf.artifacts.repo.deleted',
+      namespace: 'turbodiff-repos',
+      repoName: 'hosted-org--ephemeral',
+      eventTimestamp: null,
+    });
+    expect(await getRepoByArtifactsName('hosted-org--ephemeral')).toBeNull();
+  });
+
+  it('never deletes a GitHub row, even on a name collision', async () => {
+    // A malicious or buggy event naming a GitHub repo's slug must not touch it.
+    await applyArtifactsEvent({
+      type: 'cf.artifacts.repo.deleted',
+      namespace: 'turbodiff-repos',
+      repoName: 'acme--api',
+      eventTimestamp: null,
+    });
+    expect(await getRepoByFullName('acme', 'api')).not.toBeNull();
+  });
+});

--- a/src/services/repository-sync.ts
+++ b/src/services/repository-sync.ts
@@ -17,6 +17,10 @@ const SYNC_INTERVAL_MS = 60_000;
 const lastSyncAt = new Map<number, number>();
 
 export async function syncInstallationRepos(installationId: number): Promise<void> {
+  // Synthetic Artifacts installations (negative ids, docs/artifacts-provider.md)
+  // have no GitHub side to reconcile against — asking GitHub about them would
+  // 404 and, worse, delete every repo row as "stale".
+  if (installationId < 0) return;
   const last = lastSyncAt.get(installationId) ?? 0;
   if (Date.now() - last < SYNC_INTERVAL_MS) return;
   lastSyncAt.set(installationId, Date.now());

--- a/src/shared/artifacts-events.test.ts
+++ b/src/shared/artifacts-events.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { isArtifactsPushedEvent, parseArtifactsEvent } from './artifacts-events.ts';
+
+// Envelope shapes from the documented schema:
+// developers.cloudflare.com/queues/event-subscriptions/events-schemas/
+const PUSHED = {
+  type: 'cf.artifacts.repo.pushed',
+  source: { type: 'artifacts.repo', namespace: 'turbodiff-repos', repoName: 'acme--api' },
+  payload: {
+    ref: 'refs/heads/main',
+    before: 'abc123def456abc123def456abc123def456abc1',
+    after: 'def789ghi012def789ghi012def789ghi012def7',
+    commits: [],
+    totalCommitsCount: 1,
+    commitsTruncated: false,
+  },
+  metadata: {
+    accountId: 'f9f79265f388666de8122cfb508d7776',
+    eventSubscriptionId: '1830c4bb612e43c3af7f4cada31fbf3f',
+    eventSchemaVersion: 1,
+    eventTimestamp: '2026-08-21T02:48:57.132Z',
+  },
+};
+
+describe('parseArtifactsEvent', () => {
+  it('parses a documented pushed event', () => {
+    const event = parseArtifactsEvent(PUSHED);
+    expect(event).not.toBeNull();
+    if (!event || !isArtifactsPushedEvent(event)) throw new Error('expected pushed event');
+    expect(event.namespace).toBe('turbodiff-repos');
+    expect(event.repoName).toBe('acme--api');
+    expect(event.ref).toBe('refs/heads/main');
+    expect(event.after).toBe('def789ghi012def789ghi012def789ghi012def7');
+    expect(event.eventTimestamp).toBe('2026-08-21T02:48:57.132Z');
+  });
+
+  it('parses a lifecycle event without a pushed payload', () => {
+    const event = parseArtifactsEvent({
+      type: 'cf.artifacts.repo.deleted',
+      source: { type: 'artifacts', namespace: 'turbodiff-repos', repoName: 'acme--api' },
+      payload: { repoId: '0tvugavnogssnwzk' },
+      metadata: { eventTimestamp: '2026-08-21T00:00:00.000Z' },
+    });
+    expect(event).toEqual({
+      type: 'cf.artifacts.repo.deleted',
+      namespace: 'turbodiff-repos',
+      repoName: 'acme--api',
+      eventTimestamp: '2026-08-21T00:00:00.000Z',
+    });
+  });
+
+  it('rejects a pushed event with a malformed payload rather than crashing', () => {
+    expect(parseArtifactsEvent({ ...PUSHED, payload: { ref: 42 } })).toBeNull();
+  });
+
+  it('rejects non-artifacts and shapeless input', () => {
+    expect(parseArtifactsEvent(null)).toBeNull();
+    expect(parseArtifactsEvent('cf.artifacts.repo.pushed')).toBeNull();
+    expect(
+      parseArtifactsEvent({ type: 'cf.r2.bucket.created', source: { type: 'r2' } }),
+    ).toBeNull();
+    expect(parseArtifactsEvent({ type: 'cf.artifacts.repo.pushed', source: {} })).toBeNull();
+  });
+});

--- a/src/shared/artifacts-events.ts
+++ b/src/shared/artifacts-events.ts
@@ -1,0 +1,78 @@
+import { isJsonObject, isString } from './json.ts';
+
+// Cloudflare Artifacts event envelopes, delivered as Workflow params by the
+// `triggers.events` entries in wrangler.jsonc (docs/artifacts-provider.md).
+// Typed to the documented schema
+// (developers.cloudflare.com/queues/event-subscriptions/events-schemas/) and
+// parsed defensively at the boundary: the platform versions the schema
+// (metadata.eventSchemaVersion), so an unrecognized shape degrades to null
+// instead of a workflow crash-loop.
+
+export const ARTIFACTS_PUSHED = 'cf.artifacts.repo.pushed';
+export const ARTIFACTS_REPO_DELETED = 'cf.artifacts.repo.deleted';
+
+export interface ArtifactsPushedEvent {
+  type: typeof ARTIFACTS_PUSHED;
+  namespace: string;
+  repoName: string;
+  // e.g. "refs/heads/main"
+  ref: string;
+  before: string;
+  after: string;
+  eventTimestamp: string | null;
+}
+
+export interface ArtifactsRepoLifecycleEvent {
+  // repo.created / repo.deleted / repo.forked / repo.imported and any future
+  // non-push repo event.
+  type: string;
+  namespace: string;
+  repoName: string;
+  eventTimestamp: string | null;
+}
+
+export type ArtifactsEvent = ArtifactsPushedEvent | ArtifactsRepoLifecycleEvent;
+
+export function isArtifactsPushedEvent(event: ArtifactsEvent): event is ArtifactsPushedEvent {
+  return event.type === ARTIFACTS_PUSHED;
+}
+
+// Generic like the json.ts guards so callers keep their type evidence; the
+// workflow hands its untyped params straight in and gets a domain event out.
+export function parseArtifactsEvent<T>(raw: T): ArtifactsEvent | null {
+  if (!isJsonObject(raw) || !isString(raw.type) || !raw.type.startsWith('cf.artifacts.')) {
+    return null;
+  }
+  const source = isJsonObject(raw.source) ? raw.source : null;
+  if (!source || !isString(source.namespace) || !isString(source.repoName)) return null;
+  const metadata = isJsonObject(raw.metadata) ? raw.metadata : null;
+  const eventTimestamp =
+    metadata && isString(metadata.eventTimestamp) ? metadata.eventTimestamp : null;
+
+  if (raw.type === ARTIFACTS_PUSHED) {
+    const payload = isJsonObject(raw.payload) ? raw.payload : null;
+    if (
+      !payload ||
+      !isString(payload.ref) ||
+      !isString(payload.before) ||
+      !isString(payload.after)
+    ) {
+      return null;
+    }
+    return {
+      type: ARTIFACTS_PUSHED,
+      namespace: source.namespace,
+      repoName: source.repoName,
+      ref: payload.ref,
+      before: payload.before,
+      after: payload.after,
+      eventTimestamp,
+    };
+  }
+  return {
+    type: raw.type,
+    namespace: source.namespace,
+    repoName: source.repoName,
+    eventTimestamp,
+  };
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -32,6 +32,12 @@
   // here and are served publicly via GET /artifacts/*. Create once per account:
   //   npx wrangler r2 bucket create turbodiff-artifacts
   "r2_buckets": [{ "binding": "ARTIFACTS", "bucket_name": "turbodiff-artifacts" }],
+  // Git hosting for turbodiff-owned projects (docs/artifacts-provider.md).
+  // Named GIT_ARTIFACTS because ARTIFACTS is the R2 evidence bucket. The
+  // namespace must match ARTIFACTS_NAMESPACE in src/integrations/git/provider.ts
+  // and the triggers.events filters below. Requires the Artifacts closed beta
+  // on this account.
+  "artifacts": [{ "binding": "GIT_ARTIFACTS", "namespace": "turbodiff-repos" }],
   "vars": {
     // The name of your existing Cloudflare AI Gateway.
     "AI_GATEWAY_ID": "default",
@@ -105,6 +111,11 @@
       "name": "turbodiff-resolve-conflict",
       "class_name": "ConflictResolveWorkflow",
     },
+    {
+      "binding": "ARTIFACTS_EVENTS_WORKFLOW",
+      "name": "turbodiff-artifacts-events",
+      "class_name": "ArtifactsEventsWorkflow",
+    },
   ],
   // Decouples factory runs (minutes) from the requests that trigger them
   // (seconds). One queue for both fix and generation messages, discriminated
@@ -129,7 +140,25 @@
   // aren't expressible as static Cron Triggers, so this fires often and the
   // handler itself finds and claims whatever's due — schedule precision is
   // bounded by this interval.
-  "triggers": { "crons": ["*/15 * * * *"] },
+  "triggers": {
+    "crons": ["*/15 * * * *"],
+    // Artifacts event ingestion (docs/artifacts-provider.md): the platform
+    // starts one ArtifactsEventsWorkflow instance per matching event. No
+    // repo_name filter — one entry covers every repo in the namespace,
+    // including repos created after this deploy.
+    "events": [
+      {
+        "type": "cf.artifacts.repo.pushed",
+        "filter": { "namespace": "turbodiff-repos" },
+        "targets": [{ "type": "workflow", "workflow_name": "turbodiff-artifacts-events" }],
+      },
+      {
+        "type": "cf.artifacts.repo.deleted",
+        "filter": { "namespace": "turbodiff-repos" },
+        "targets": [{ "type": "workflow", "workflow_name": "turbodiff-artifacts-events" }],
+      },
+    ],
+  },
   // Every agent generates a Durable Object class named after its identity
   // (PrReviewer -> FluePrReviewerAgent), and Cloudflare requires a migration
   // entry for each one. Append a new tag when you add an agent:


### PR DESCRIPTION
Production-ready first slice of Artifacts as an alternative to GitHub. Built fresh from main; the Phase 0/0.5 spikes (PR #91) stay unmerged as reference. Architecture and ops runbook: `docs/artifacts-provider.md`; end-state narrative: `docs/artifacts-vision.md`.

## What this delivers

**The provider seam.** New `src/integrations/git/` module: every sandbox git operation (workspace prep, clones, fetches, all pushes) resolves a `WorkspaceRemote` from the repo row instead of hardcoding `github.com`. GitHub's command shapes are byte-identical to before — this is a pure seam extraction for existing flows. Artifacts remotes authenticate via `http.extraHeader` because Artifacts tokens are URL-hostile.

**Synthetic tenancy (migration `0035`).** `provider` columns on installations/repositories plus `artifacts_repo`, `default_branch`, `last_push_at`. Artifacts rows allocate ids in the **negative range** — GitHub ids are positive, so the spaces can't collide — which lets Artifacts projects reuse the entire installation-scoped access model (scoping, budgets, org mapping) with zero query changes. `mintToken` and `syncInstallationRepos` hard-guard against a synthetic id ever reaching GitHub.

**Provisioning + clone access.**
- `POST /internal/projects {owner, name, description?}` — creates the repo in the `turbodiff-repos` namespace (collision-suffixed naming), seeds an initial commit from the sandbox, records D1 rows; compensating deletes mean no row ever points at a broken remote.
- `POST /internal/repos/clone-token {repo, scope?, ttl_seconds?}` — repo-scoped credential so users clone/push with plain git. The deploy-key replacement.

**Event ingestion, declaratively.** `triggers.events` in `wrangler.jsonc` starts one `ArtifactsEventsWorkflow` instance per `repo.pushed`/`repo.deleted` event in the namespace — no per-repo subscription provisioning, no API tokens, and repos created after deploy are covered automatically. Pushes stamp `last_push_at`; deletes drop the stale row. Typed, defensive envelope parsing per the documented schema.

**Capability gates.** Every factory intake that ends in a GitHub PR (features, plans, automations, fix runs) rejects Artifacts repos with an explicit "needs the native change-request layer (Phase 2)" error. GitHub repos are completely untouched.

## Verification

- `check:types` (all 3 tsconfig programs), lint (0 errors), build, and `wrangler deploy --dry-run` all pass.
- 43 unit tests + 79 worker/D1 integration tests pass, including new coverage for the remote builders (credentials never in command strings), event parsing, negative-id allocation against real migrations, and event application (incl. "a delete event can never touch a GitHub row").
- Not yet exercised against the live closed beta: binding provisioning under the new namespace and end-to-end event delivery — the smoke test in `docs/artifacts-provider.md` is the exact post-deploy sequence.

## What Phase 2 builds on this

Native change requests (D1 CR tables, the Phase-0.5 diff engine, cockpit CR view via `@pierre/diffs`), at which point the gates lift flow by flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)