### PR TITLE
Fix planner and conflict sweep hitting GitHub for Artifacts repos

### DIFF
--- a/src/ai/runners/planner.ts
+++ b/src/ai/runners/planner.ts
@@ -53,20 +53,31 @@ async function clonePlanRepos(
 
   const dirs: { repo: RepositoryRow; dir: string; cleanUrl: string }[] = [];
   for (const repo of repos) {
-    const token = await installationToken(repo.installation_id);
     // Planner sandboxes never push: contents READ-ONLY token.
     const remote = await resolveWorkspaceRemote(repo, 'read');
-    tokens.push(token, remote.token);
+    tokens.push(remote.token);
     const full = `${repo.owner}/${repo.name}`;
-    // SAFETY: GitHub's GET /repos/:owner/:repo REST schema always includes
-    // default_branch.
-    const info = (await (await gh(token, `/repos/${full}`)).json()) as { default_branch: string };
+    let base: string;
+    if (repo.provider === 'artifacts') {
+      // Artifacts repos carry their default branch in D1 — no forge API to
+      // ask, and installationToken rejects synthetic installation ids.
+      base = repo.default_branch ?? 'main';
+    } else {
+      const token = await installationToken(repo.installation_id);
+      tokens.push(token);
+      // SAFETY: GitHub's GET /repos/:owner/:repo REST schema always includes
+      // default_branch.
+      const info = (await (await gh(token, `/repos/${full}`)).json()) as {
+        default_branch: string;
+      };
+      base = info.default_branch;
+    }
     const dir = repos.length === 1 ? CLONE_DIR : `${CLONE_DIR}/${repo.owner}--${repo.name}`;
     if (repos.length > 1) await sandbox.exec(`mkdir -p ${dir}`);
     const clone = await sandbox.exec(
       `git ${remote.configFlags} clone --depth 50 --single-branch --branch "$GEN_BASE" ` +
         `"${remote.authUrl}" ${dir}`,
-      { env: { ...remote.env, GEN_BASE: info.default_branch }, timeout: 3 * 60_000 },
+      { env: { ...remote.env, GEN_BASE: base }, timeout: 3 * 60_000 },
     );
     if (!clone.success) {
       throw new Error(`git clone failed for ${full}: ${scrub(clone.stderr).slice(0, 500)}`);

--- a/src/data/factory.ts
+++ b/src/data/factory.ts
@@ -370,7 +370,8 @@ export async function listOpenFactoryPrConflictCandidates(): Promise<
 		 FROM features f
 		 JOIN repositories r ON r.id = f.repository_id
 		 WHERE f.pr_number IS NOT NULL AND f.status = 'pr_opened'
-		   AND r.enabled = 1 AND r.auto_resolve_conflicts = 1`,
+		   AND r.enabled = 1 AND r.auto_resolve_conflicts = 1
+		   AND r.provider = 'github'`,
   ).all<RepositoryRow & { factory_pr_number: number }>();
   return res.results.map(({ factory_pr_number, ...repo }) => ({
     repo,

--- a/src/services/merge-conflicts.ts
+++ b/src/services/merge-conflicts.ts
@@ -93,6 +93,9 @@ export async function maybeResolveConflict(
   opts?: { retryOnUnknown?: boolean },
 ): Promise<void> {
   if (repo.enabled !== 1) return;
+  // Conflict state for Artifacts CRs is native (engine dry-runs + the
+  // post-merge ripple) — this GitHub mergeable_state path never applies.
+  if (repo.provider !== 'github') return;
   const label = `${repo.owner}/${repo.name}#${prNumber}`;
   try {
     const feature = await getFeatureByRepoPr(repo.id, prNumber);


### PR DESCRIPTION
Live-test fix for the first real Artifacts project (3 files, +22/−7 — branched fresh from main; supersedes #94/#95, which accidentally resurrected the squash-merged #93 branch and re-showed its whole diff).

Planning on an Artifacts repo failed with `installation -1 is Artifacts-hosted, not a GitHub App install`. The planner's clone has gone through the provider seam since #92, but its `installationToken` mint and GitHub default-branch lookup stayed unconditional — lifting the plan gate in #93 exposed them. Artifacts repos now read `default_branch` from D1 and mint no GitHub token.

Also hardened the same latent coupling in the conflict machinery: the cron sweep's candidate query is now `provider = 'github'` and `maybeResolveConflict` early-returns for non-GitHub repos (native CRs own their conflict state via engine dry-runs and the post-merge ripple).

Audited every remaining `installationToken` call site — all others are behind provider branches or artifacts-gated intakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)