### PR TITLE
Fix Artifacts code browse: ls-tree records lost their NUL separators

### DIFF
--- a/src/services/ls-tree.test.ts
+++ b/src/services/ls-tree.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { parseLsTreeZ } from './ls-tree.ts';
+
+// Real `git ls-tree -l -z` shape: `mode SP type SP sha SP+ size TAB name`,
+// records NUL-terminated. Sizes are right-aligned by git, hence the runs of
+// spaces before them. NUL rides as a named constant — a NUL escape inside a
+// template literal is a syntax error when a digit follows it.
+const NUL = String.fromCharCode(0);
+const SHA_A = 'a0373c127e472633630c8da9f9440ae5bb4c9127';
+const SHA_B = '5322d7feeaeae76b7cb1abac69cfbb2992b11e76';
+const SHA_TREE = 'ca7fbed7d08676e31c1e0999ce324bd40f04b981';
+
+const ROOT_LISTING =
+  `100644 blob ${SHA_A}     144\t.cta.json${NUL}` +
+  `100644 blob ${SHA_B}      42\t.gitignore${NUL}` +
+  `040000 tree ${SHA_TREE}       -\tsrc${NUL}`;
+
+describe('parseLsTreeZ', () => {
+  it('parses NUL-separated records into entries', () => {
+    const entries = parseLsTreeZ(ROOT_LISTING, '');
+    expect(entries).toEqual([
+      { name: '.cta.json', path: '.cta.json', type: 'file', size: 144, sha: SHA_A },
+      { name: '.gitignore', path: '.gitignore', type: 'file', size: 42, sha: SHA_B },
+      { name: 'src', path: 'src', type: 'dir', size: null, sha: SHA_TREE },
+    ]);
+  });
+
+  it('prefixes the parent path onto entry paths', () => {
+    const entries = parseLsTreeZ(`100644 blob ${SHA_A}      10\tindex.ts${NUL}`, 'src/http');
+    expect(entries[0]?.path).toBe('src/http/index.ts');
+  });
+
+  it('keeps spaces in filenames intact (the point of -z)', () => {
+    const entries = parseLsTreeZ(`100644 blob ${SHA_A}       9\tmy notes.md${NUL}`, '');
+    expect(entries[0]?.name).toBe('my notes.md');
+  });
+
+  it('classifies symlinks and submodules', () => {
+    const entries = parseLsTreeZ(
+      `120000 blob ${SHA_A}      11\tlink${NUL}160000 commit ${SHA_B}       -\tvendored${NUL}`,
+      '',
+    );
+    expect(entries.map((entry) => entry.type)).toEqual(['symlink', 'submodule']);
+  });
+
+  it('returns nothing for an empty tree and ignores a trailing empty record', () => {
+    expect(parseLsTreeZ('', '')).toEqual([]);
+  });
+
+  it('regression: a listing with its NULs stripped must not parse as one giant entry', () => {
+    // The bug this file exists for: sandbox exec stdout drops NUL bytes, so
+    // the un-encoded listing collapsed into a single record whose "name" was
+    // the rest of the whole listing. The caller now base64-ships the bytes so
+    // parseLsTreeZ never sees stripped input — but if it ever does, the
+    // damage shows up as one entry, which this test documents.
+    const stripped = ROOT_LISTING.replaceAll(NUL, '');
+    const entries = parseLsTreeZ(stripped, '');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.name.startsWith('.cta.json100644 blob')).toBe(true);
+    // And the intact input parses to the real three entries (asserted above).
+    expect(parseLsTreeZ(ROOT_LISTING, '')).toHaveLength(3);
+  });
+});

--- a/src/services/ls-tree.ts
+++ b/src/services/ls-tree.ts
@@ -1,0 +1,32 @@
+import type { ApiTreeEntry } from '../shared/api-types.ts';
+
+// Parser for `git ls-tree -l -z` output: NUL-separated records, each
+// `mode SP type SP sha SP+ size TAB name`, names unquoted (that's the point
+// of -z — spaces and quotes in filenames arrive verbatim). Kept pure and
+// dependency-free so the parsing has unit coverage; the sandbox round trip
+// it sits behind is only exercised in deployment smoke.
+export function parseLsTreeZ(out: string, path: string): ApiTreeEntry[] {
+  const entries: ApiTreeEntry[] = [];
+  for (const record of out.split('\0')) {
+    const tab = record.indexOf('\t');
+    if (tab < 0) continue;
+    const name = record.slice(tab + 1);
+    const [mode = '', objectType = '', sha = '', size = ''] = record.slice(0, tab).split(/\s+/);
+    const type: ApiTreeEntry['type'] =
+      objectType === 'tree'
+        ? 'dir'
+        : objectType === 'commit'
+          ? 'submodule'
+          : mode === '120000'
+            ? 'symlink'
+            : 'file';
+    entries.push({
+      name,
+      path: path ? `${path}/${name}` : name,
+      type,
+      size: size === '-' ? null : Number(size),
+      sha,
+    });
+  }
+  return entries;
+}

--- a/src/services/repo-browser-artifacts.ts
+++ b/src/services/repo-browser-artifacts.ts
@@ -5,7 +5,8 @@ import { generationSandbox } from '../ai/runtime/sandbox.ts';
 import type { RepositoryRow } from '../data/db.ts';
 import { resolveWorkspaceRemote } from '../integrations/git/provider.ts';
 import type { WorkspaceRemote } from '../integrations/git/remotes.ts';
-import type { ApiFileSave, ApiRepoFile, ApiRepoTree, ApiTreeEntry } from '../shared/api-types.ts';
+import type { ApiFileSave, ApiRepoFile, ApiRepoTree } from '../shared/api-types.ts';
+import { parseLsTreeZ } from './ls-tree.ts';
 import {
   decodeBase64Text,
   isValidRepoPath,
@@ -102,10 +103,16 @@ export async function readTreeArtifacts(
   let out: string;
   try {
     // Empty path ⇒ `rev:` ⇒ the root tree. -z gives NUL-separated records
-    // with unquoted names, so filenames with spaces/quotes parse safely.
+    // with unquoted names, so filenames with spaces/quotes parse safely —
+    // but exec stdout is not binary-safe (NUL bytes are stripped, which
+    // used to collapse the whole listing into one garbage entry), so the
+    // records ship out as base64, same as cat-file below. The temp file
+    // keeps ls-tree's exit code and stderr as the command's own (a plain
+    // pipe would report base64's), and $$ keeps concurrent reads apart.
     out = await git(
       ctx,
-      `git -C ${BROWSE_DIR} ls-tree -l -z "refs/remotes/origin/$BROWSE_REF:$BROWSE_PATH"`,
+      `git -C ${BROWSE_DIR} ls-tree -l -z "refs/remotes/origin/$BROWSE_REF:$BROWSE_PATH" > "/tmp/browse-tree.$$" && ` +
+        `base64 < "/tmp/browse-tree.$$" | tr -d '\\n' && rm -f "/tmp/browse-tree.$$"`,
       { BROWSE_REF: ref, BROWSE_PATH: path },
     );
   } catch (err) {
@@ -122,29 +129,13 @@ export async function readTreeArtifacts(
     }
     throw err;
   }
-  const entries: ApiTreeEntry[] = [];
-  // Each record: `mode SP type SP sha SP+ size TAB name`.
-  for (const record of out.split('\0')) {
-    const tab = record.indexOf('\t');
-    if (tab < 0) continue;
-    const name = record.slice(tab + 1);
-    const [mode = '', objectType = '', sha = '', size = ''] = record.slice(0, tab).split(/\s+/);
-    const type: ApiTreeEntry['type'] =
-      objectType === 'tree'
-        ? 'dir'
-        : objectType === 'commit'
-          ? 'submodule'
-          : mode === '120000'
-            ? 'symlink'
-            : 'file';
-    entries.push({
-      name,
-      path: path ? `${path}/${name}` : name,
-      type,
-      size: size === '-' ? null : Number(size),
-      sha,
-    });
+  const raw = decodeBase64Text(out.trim());
+  if (raw === null) {
+    // A filename that isn't valid UTF-8 can't round-trip through the JSON
+    // API contract at all.
+    throw new RepoBrowserError('directory listing is not valid UTF-8', 400);
   }
+  const entries = parseLsTreeZ(raw, path);
   sortTreeEntries(entries);
   return { path, entries };
 }


### PR DESCRIPTION
## What broke

Viewing and editing code for Artifacts-hosted repos was completely broken in production (screenshot: `ngineer101/Test-repo`): the file tree rendered a single giant entry containing the raw `ls-tree` output, every click produced a garbage path, and the file pane answered `file not found on this ref`.

## Root cause

`sandbox.exec` stdout is not binary-safe — it strips NUL bytes. `readTreeArtifacts` relied on `git ls-tree -l -z`'s NUL-separated records surviving that transport; with the NULs gone, `out.split('\\0')` yielded one record whose "name" was the rest of the entire listing. (The same file already base64-ships `cat-file blob` output for exactly this reason.)

## Fix

- Ship the listing out as base64 and decode/NUL-split in the worker. The temp-file form (`git … > /tmp/browse-tree.$$ && base64 < … `) keeps ls-tree's exit code and stderr as the command's own, so the existing unknown-ref / not-a-tree error mapping is unchanged.
- Extract parsing into pure `parseLsTreeZ` (`src/services/ls-tree.ts`) with unit tests, including a regression test documenting the NUL-stripped failure mode.

## Verification

- 6 new unit tests; full suite 68 + 121 worker tests pass.
- Ran the exact new shell pipeline against a real local git repo and fed the output through the shipped decode + parse path: 23 correct entries (names/sizes/shas). Bad ref exits 128 with git's own stderr through the `&&` chain.
- The real sandbox round trip is not exercisable locally — needs the post-deploy smoke test against an Artifacts repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)