### PR TITLE
Fix wide layout for Artifacts repos in the code browser

### DIFF
--- a/src/client/components/app-shell.tsx
+++ b/src/client/components/app-shell.tsx
@@ -14,6 +14,7 @@ import {
 import { useState, type ReactNode } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import type { ApiMe } from '../../shared/api-types.ts';
+import { codeRoute } from '../lib/layout.ts';
 import { navShortcuts, noOverlayOpen } from '../lib/shortcuts.ts';
 import { useIsDesktop } from '../lib/use-is-desktop.ts';
 import { useLiveRefresh } from '../lib/use-live-refresh.ts';
@@ -186,9 +187,11 @@ export function AppShell({ me, children }: { me: ApiMe; children: ReactNode }) {
     [],
   );
   // The cockpit's diff pane needs room; the code browser gets the whole
-  // viewport — a full-width, full-height workspace on desktop.
+  // viewport — a full-width, full-height workspace on desktop. codeRoute
+  // lives in lib/layout.ts: Artifacts repos have negative ids, which a
+  // bare \d+ here silently dropped into the reading-width container.
   const wide = pathname.startsWith('/factory/features/');
-  const code = /^\/repos\/\d+\/code/.test(pathname);
+  const code = codeRoute(pathname);
   // The board's three lanes need more room than the reading-width default.
   const board = pathname === '/';
   return (

--- a/src/client/lib/layout.test.ts
+++ b/src/client/lib/layout.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { codeRoute } from './layout.ts';
+
+describe('codeRoute', () => {
+  it('matches the code browser for GitHub repo ids', () => {
+    expect(codeRoute('/repos/1257539637/code/')).toBe(true);
+    expect(codeRoute('/repos/1/code/src/http/api.ts')).toBe(true);
+  });
+
+  it('matches Artifacts repos, whose synthetic ids are negative', () => {
+    expect(codeRoute('/repos/-1/code')).toBe(true);
+    expect(codeRoute('/repos/-42/code/src/main.tsx')).toBe(true);
+  });
+
+  it('matches nothing else', () => {
+    expect(codeRoute('/')).toBe(false);
+    expect(codeRoute('/factory/features/56')).toBe(false);
+    expect(codeRoute('/repos/abc/code')).toBe(false);
+    expect(codeRoute('/repos/1/settings')).toBe(false);
+  });
+});

--- a/src/client/lib/layout.ts
+++ b/src/client/lib/layout.ts
@@ -1,0 +1,8 @@
+// Route predicate for the code browser's full-width, full-height workspace
+// treatment (app-shell.tsx). Kept as a pure function because the repo-id
+// match has a trap: Artifacts-hosted repos ride synthetic NEGATIVE ids
+// (/repos/-1/code), and a bare \d+ silently dropped them into the
+// reading-width container.
+export function codeRoute(pathname: string): boolean {
+  return /^\/repos\/-?\d+\/code/.test(pathname);
+}


### PR DESCRIPTION
The code browser's full-viewport treatment matched `/repos/\d+/code` — but Artifacts-hosted repos ride synthetic **negative** ids (`/repos/-1/code`), so their code browser fell into the narrow reading-width container: tree squeezed into the middle of the page, half the screen dead, unlike the identical page on a GitHub repo.

Extracted the predicate into `lib/layout.ts` (`codeRoute`, matching `-?\d+`) with tests covering both id signs, so the trap is named and pinned.

Verified against the built SPA + stub API serving `/repos/-1/code`: the Artifacts-id page now renders the same full-width workspace as a GitHub-id page, tree left-aligned, viewer filling the rest.

(Original fix rode the tail of #106 after it merged; this is the same change rebased onto main, resolved against #107's full-viewport layout — whose new `code` predicate had inherited the same \d+ bug.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)