### PR TITLE
Record the App installer and bootstrap them as owner on late sign-in

### DIFF
--- a/migrations/0043_installer_github_id.sql
+++ b/migrations/0043_installer_github_id.sql
@@ -1,0 +1,11 @@
+-- The GitHub user who installed the App — the `sender` on the `installation
+-- created` webhook. Recorded so the first-owner bootstrap survives the
+-- installer signing in *after* installing: the webhook-time ensureOwnerMember
+-- is a no-op without a user row, and the request-time GitHub-admin bootstrap
+-- depends on an org-membership API call that fails when the App lacks the
+-- Organization Members (read) permission — leaving the organization with
+-- zero member rows and nobody able to grant the settings/member capability.
+-- ensureInstallerOwner (src/services/access-control.ts) closes that gap from
+-- this column. NULL for installations that predate this migration, for
+-- deliveries without a sender, and for synthetic Artifacts rows.
+ALTER TABLE installations ADD COLUMN installer_github_id INTEGER;

--- a/src/data/repositories.ts
+++ b/src/data/repositories.ts
@@ -10,6 +10,7 @@ export interface InstallationRow {
   account_type: string;
   suspended: number;
   provider: string; // 'github' | 'artifacts' (synthetic tenancy rows)
+  installer_github_id: number | null; // App installer (webhook sender); feeds the deferred owner bootstrap
 }
 
 export interface RepositoryRow {
@@ -48,13 +49,21 @@ interface WebhookRepo {
   full_name: string;
 }
 
-export async function upsertInstallation(id: number, account: WebhookAccount): Promise<void> {
+export async function upsertInstallation(
+  id: number,
+  account: WebhookAccount,
+  installerGithubId?: number,
+): Promise<void> {
+  // COALESCE keeps a recorded installer through deliveries that carry no
+  // sender (installation_repositories) — only the `installation created`
+  // delivery may set it.
   await env.DB.prepare(
-    `INSERT INTO installations (id, account_login, account_id, account_type, suspended)
-		 VALUES (?1, ?2, ?3, ?4, 0)
-		 ON CONFLICT(id) DO UPDATE SET account_login = ?2, account_id = ?3, account_type = ?4, suspended = 0`,
+    `INSERT INTO installations (id, account_login, account_id, account_type, suspended, installer_github_id)
+		 VALUES (?1, ?2, ?3, ?4, 0, ?5)
+		 ON CONFLICT(id) DO UPDATE SET account_login = ?2, account_id = ?3, account_type = ?4, suspended = 0,
+		   installer_github_id = COALESCE(?5, installer_github_id)`,
   )
-    .bind(id, account.login, account.id, account.type)
+    .bind(id, account.login, account.id, account.type, installerGithubId ?? null)
     .run();
 }
 

--- a/src/http/api.worker.test.ts
+++ b/src/http/api.worker.test.ts
@@ -480,6 +480,76 @@ describe('organization member management', () => {
     expect(member?.role).toBe('owner');
   });
 
+  it('promotes the recorded installer of a memberless organization without touching GitHub', async () => {
+    // The exact production dead end: the installer signed in only after
+    // installing (webhook-time ensureOwnerMember was a no-op), and the
+    // GitHub admin check fails closed — orgAdmin false stands in for the
+    // App lacking the Organization Members permission.
+    await seedOrg(null);
+    await testEnv.DB.prepare(
+      'UPDATE installations SET installer_github_id = 3001 WHERE id = 1001',
+    ).run();
+    const response = await authenticatedApi(undefined, async () => false).request(
+      'https://turbodiff.test/api/organizations/1001/members',
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ my_role: 'owner' });
+    const member = await testEnv.DB.prepare(
+      `SELECT role FROM "member" WHERE "organizationId" = 'org1' AND "userId" = 'u1'`,
+    ).first<{ role: string }>();
+    expect(member?.role).toBe('owner');
+  });
+
+  it('never promotes the installer once the organization has any member row', async () => {
+    // An explicit row means the org has working governance — a demoted or
+    // removed installer must not climb back in through the bootstrap.
+    await seedOrg(null);
+    await seedCoOwner();
+    await testEnv.DB.prepare(
+      'UPDATE installations SET installer_github_id = 3001 WHERE id = 1001',
+    ).run();
+    const response = await authenticatedApi(undefined, async () => false).request(
+      'https://turbodiff.test/api/organizations/1001/members',
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ my_role: 'member' });
+  });
+
+  it('never promotes a caller who is not the recorded installer of a memberless organization', async () => {
+    await seedOrg(null);
+    await testEnv.DB.prepare(
+      'UPDATE installations SET installer_github_id = 9999 WHERE id = 1001',
+    ).run();
+    const response = await authenticatedApi(undefined, async () => false).request(
+      'https://turbodiff.test/api/organizations/1001/members',
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ my_role: 'member' });
+    const count = await testEnv.DB.prepare(
+      `SELECT COUNT(*) AS n FROM "member" WHERE "organizationId" = 'org1'`,
+    ).first<{ n: number }>();
+    expect(count?.n).toBe(0);
+  });
+
+  it('opens the settings capability gate for the recorded installer', async () => {
+    // Same shape as the promotion test above, but through a capability-gated
+    // mutation — proving the heal runs on the capabilityDenied choke point
+    // (the route the production lockout actually 403'd on).
+    await seedOrg(null);
+    await testEnv.DB.prepare(
+      'UPDATE installations SET installer_github_id = 3001 WHERE id = 1001',
+    ).run();
+    const response = await authenticatedApi(
+      async () => true,
+      async () => false,
+    ).request('https://turbodiff.test/api/repos/101', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(response.status).toBe(200);
+  });
+
   it('never re-elevates a caller who already has an explicit member row', async () => {
     await seedOrg('member');
     await seedCoOwner();

--- a/src/http/webhooks.worker.test.ts
+++ b/src/http/webhooks.worker.test.ts
@@ -242,6 +242,39 @@ describe('GitHub webhook authentication and mirroring', () => {
       .bind(org?.id)
       .first<{ n: number }>();
     expect(memberCount?.n).toBe(0);
+
+    // …but the installer's identity is recorded, so the deferred owner
+    // bootstrap (ensureInstallerOwner) can promote them once they sign in.
+    const installation = await testEnv.DB.prepare(
+      'SELECT installer_github_id FROM installations WHERE id = 1001',
+    ).first<{ installer_github_id: number | null }>();
+    expect(installation?.installer_github_id).toBe(9999);
+  });
+
+  it('keeps the recorded installer through deliveries that carry no sender', async () => {
+    const created = {
+      action: 'created',
+      installation: {
+        id: 1001,
+        account: { login: 'acme', id: 2001, type: 'Organization' },
+      },
+      sender: { id: 9999, login: 'never-signed-in' },
+      repositories: [],
+    };
+    expect((await postWebhook(webhookApp(), 'installation', created)).status).toBe(200);
+    const reposChanged = {
+      action: 'added',
+      installation: created.installation,
+      repositories_added: [{ id: 101, name: 'api', full_name: 'acme/api' }],
+    };
+    expect(
+      (await postWebhook(webhookApp(), 'installation_repositories', reposChanged)).status,
+    ).toBe(200);
+
+    const installation = await testEnv.DB.prepare(
+      'SELECT installer_github_id FROM installations WHERE id = 1001',
+    ).first<{ installer_github_id: number | null }>();
+    expect(installation?.installer_github_id).toBe(9999);
   });
 });
 

--- a/src/services/access-control.ts
+++ b/src/services/access-control.ts
@@ -58,15 +58,17 @@ export async function ensureOrganizationForInstallation(
 }
 
 // Records a GitHub user as the organization's owner — called for the App
-// installer from the `installation created` webhook, and from the
-// GitHub-admin bootstrap below (ensureGithubAdminOwner) for orgs provisioned
-// without an installer identity. Only possible if the user already has a
-// better-auth `user` row (i.e. they signed in to Turbodiff before or after
-// installing the app). If they haven't yet, this is a no-op: the
-// auto-provisioning fallback in memberRole treats them as an implicit
-// 'member' (never locked out) until their first sign-in, at which point an
-// existing owner/admin can promote them via
-// PATCH /organizations/:installationId/members/:memberId — or, if they end
+// installer from the `installation created` webhook, and from the installer
+// and GitHub-admin bootstraps below (ensureInstallerOwner,
+// ensureGithubAdminOwner) for orgs the webhook couldn't finish provisioning.
+// Only possible if the user already has a better-auth `user` row (i.e. they
+// signed in to Turbodiff before or after installing the app). If they
+// haven't yet, this is a no-op: the auto-provisioning fallback in memberRole
+// treats them as an implicit 'member' (never locked out) until their first
+// sign-in, at which point the installer bootstrap picks them up from the
+// installer_github_id recorded on the installations row — or an existing
+// owner/admin promotes them via
+// PATCH /organizations/:installationId/members/:memberId, or, if they end
 // up the org's only member, the sole-member heal in
 // orgForInstallationWithHeal promotes them itself.
 // Synthetic Artifacts installations a user can reach via an explicit member
@@ -133,6 +135,33 @@ async function hasMemberRow(organizationId: string, githubId: number): Promise<b
   return row !== null;
 }
 
+// Deferred installer bootstrap: the `installation created` webhook records
+// the installer's GitHub id but can only write their owner row if they had
+// already signed in (ensureOwnerMember above is a no-op without a user row).
+// When the installer signs in later, this closes the gap on their first
+// request: an organization that still has zero member rows makes the
+// recorded installer its owner. Zero rows is precisely the dead-end state —
+// explicit rows only ever appear through an owner/admin or these bootstraps,
+// so any existing row means the org has working governance and in-app
+// decisions must stand. Needs nothing from GitHub, unlike the admin
+// bootstrap below, whose org-membership call fails closed when the App
+// lacks the Organization Members (read) permission.
+async function ensureInstallerOwner(
+  user: AuthedUser,
+  organizationId: string,
+  installerGithubId: number | null,
+): Promise<void> {
+  if (user.devFake || installerGithubId === null) return;
+  if (user.session.userId !== installerGithubId) return;
+  const count = await env.DB.prepare(
+    'SELECT COUNT(*) AS n FROM "member" WHERE "organizationId" = ?1',
+  )
+    .bind(organizationId)
+    .first<{ n: number }>();
+  if (!count || count.n > 0) return;
+  await ensureOwnerMember(organizationId, user.session.userId);
+}
+
 // First-owner bootstrap for orgs provisioned without an `installation
 // created` webhook (no installer identity): a caller with no member row who
 // is an admin (owner) of the org on GitHub becomes this org's owner. Runs
@@ -197,6 +226,10 @@ export async function orgForInstallationWithHeal(
     };
   }
   if (installation) {
+    // Installer first: it is a pure D1 check, and when it promotes the
+    // caller the admin bootstrap's no-member-row guard makes the GitHub
+    // call below unnecessary.
+    await ensureInstallerOwner(user, org.id, installation.installer_github_id);
     // The GitHub call inside runs only for callers with no member row —
     // exactly the callers who would otherwise be denied — and is cached 5
     // minutes in userIsGithubOrgAdmin, so owners/admins with rows never

--- a/src/services/github-webhooks.ts
+++ b/src/services/github-webhooks.ts
@@ -189,7 +189,7 @@ async function handleEvent(
 async function handleInstallation(p: InstallationEvent): Promise<WebhookHandlerResult> {
   switch (p.action) {
     case 'created':
-      await upsertInstallation(p.installation.id, p.installation.account);
+      await upsertInstallation(p.installation.id, p.installation.account, p.sender?.id);
       await addRepositories(p.installation.id, p.repositories ?? []);
       await ensureBuiltinAgents(p.installation.id);
       // Teams & orgs (migrations/0031_organizations.sql): Organization-type
@@ -223,9 +223,9 @@ async function handleInstallationRepositories(p: InstallationEvent): Promise<Web
   await upsertInstallation(p.installation.id, p.installation.account);
   // Same self-heal for the organization row: if the `installation created`
   // delivery was missed, this is the next chance to provision it (no sender
-  // on this event, so no owner to assign — that gap is closed lazily: a
-  // GitHub org admin is bootstrapped as owner on their first authenticated
-  // org request, see orgForInstallationWithHeal in
+  // on this event, so no owner to assign — that gap is closed lazily: the
+  // recorded installer or a GitHub org admin is bootstrapped as owner on
+  // their first authenticated org request, see orgForInstallationWithHeal in
   // src/services/access-control.ts, and an existing owner/admin can always
   // add one by hand).
   if (p.installation.account.type === 'Organization') {


### PR DESCRIPTION
## Problem

An Organization-type installation whose installer had no better-auth user row at webhook time produces an organization with **zero member rows** — a permanent lockout. Hit in prod by `supermeme-ai` (installed 2026-08-02, owner first signed in 2026-08-19):

- The `installation created` webhook calls `ensureOwnerMember`, which is a documented no-op when the installer has no `user` row yet.
- The request-time GitHub-admin bootstrap (`ensureGithubAdminOwner`) depends on `GET /user/memberships/orgs/{org}`, which fails closed when the App lacks the **Organization → Members (read)** permission (`userIsGithubOrgAdmin` swallows the error as `admin = false`; look for `org membership check failed` warns in worker logs).
- The sole-member promotion deliberately requires an existing row, so a zero-row org never qualifies.

Result: every caller resolves to implicit `member`, nobody ever gains the `settings`/`member` capability, and adding integrations or inviting members 403s forever. (The prod org was unblocked by inserting the owner row by hand; this PR closes the hole for future installations.)

## Fix

Record the installer's identity at webhook time, and finish the bootstrap when they eventually sign in:

- Migration `0043`: `installations.installer_github_id` — the `sender` on the `installation created` delivery. `COALESCE` in `upsertInstallation` keeps it through later sender-less deliveries (`installation_repositories`).
- `ensureInstallerOwner` in `orgForInstallationWithHeal`: an organization that still has **zero** member rows makes the recorded installer its owner on their first request. Zero rows is precisely the dead-end state — explicit rows only ever appear through an owner/admin or these bootstraps, so any existing row means the org has working governance and in-app decisions (including a demoted installer) are never overridden. Pure D1 check, runs before the GitHub-dependent admin bootstrap, works regardless of App permissions.

## Tests

Six new tests: webhook records the installer (and keeps it through sender-less deliveries); the request-path heal promotes the recorded installer of a memberless org, opens the settings capability gate, and never fires once any member row exists or for a non-installer caller. `pnpm test` 75 passed, `pnpm test:worker` 126 passed.

## Not in this PR

- No backfill for existing installations — GitHub doesn't expose the installer retroactively; the GitHub-admin bootstrap remains their only self-heal.
- Granting the App **Organization → Members (read)** (dashboard change) so the admin bootstrap actually works for non-installer admins — worth doing alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)