### PR TITLE
Discover OAuth metadata at RFC 8414/9728 path-inserted well-known URLs

### DIFF
--- a/src/integrations/mcp/oauth.test.ts
+++ b/src/integrations/mcp/oauth.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vite-plus/test';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import type { JsonObject } from '../../shared/json.ts';
 // Co-located with the OAuth protocol adapter.
-import { generatePkce, packState, unpackState } from './oauth.ts';
+import { discoverOAuthEndpoints, generatePkce, packState, unpackState } from './oauth.ts';
 
 const SECRET = 'test-session-secret';
 
@@ -8,6 +9,111 @@ function b64urlToBytes(s: string): Uint8Array {
   const bin = atob(s.replace(/-/g, '+').replace(/_/g, '/'));
   return Uint8Array.from(bin, (c) => c.charCodeAt(0));
 }
+
+// Serves the given URL→body map; every other URL 404s. Discovery treats a
+// non-2xx as "document not published here" and moves on, so unmapped URLs
+// behave like a real server without that well-known path.
+function stubFetch(routes: Record<string, JsonObject>): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      return url in routes
+        ? new Response(JSON.stringify(routes[url]), {
+            headers: { 'content-type': 'application/json' },
+          })
+        : new Response('not found', { status: 404 });
+    }),
+  );
+}
+
+describe('discoverOAuthEndpoints', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const metadata = {
+    authorization_endpoint: 'https://auth.example.com/oauth2/authorize',
+    token_endpoint: 'https://auth.example.com/oauth2/token',
+    registration_endpoint: 'https://auth.example.com/oauth2/register',
+    scopes_supported: ['mcp'],
+  };
+
+  it('discovers a path-less authorization server (appended and inserted forms coincide)', async () => {
+    stubFetch({
+      'https://mcp.example.com/.well-known/oauth-protected-resource': {
+        authorization_servers: ['https://auth.example.com'],
+      },
+      'https://auth.example.com/.well-known/oauth-authorization-server': metadata,
+    });
+    const endpoints = await discoverOAuthEndpoints('https://mcp.example.com');
+    expect(endpoints).toMatchObject({
+      authorizationEndpoint: metadata.authorization_endpoint,
+      tokenEndpoint: metadata.token_endpoint,
+      registrationEndpoint: metadata.registration_endpoint,
+      scopesSupported: ['mcp'],
+    });
+  });
+
+  it('discovers a path-bearing authorization server via the RFC 8414 inserted form', async () => {
+    // The Stripe shape: the resource names https://access.example.com/mcp,
+    // whose metadata lives at /.well-known/oauth-authorization-server/mcp —
+    // the appended form 404s.
+    stubFetch({
+      'https://mcp.example.com/.well-known/oauth-protected-resource': {
+        authorization_servers: ['https://access.example.com/mcp'],
+      },
+      'https://access.example.com/.well-known/oauth-authorization-server/mcp': metadata,
+    });
+    const endpoints = await discoverOAuthEndpoints('https://mcp.example.com');
+    expect(endpoints.authorizationEndpoint).toBe(metadata.authorization_endpoint);
+    expect(endpoints.tokenEndpoint).toBe(metadata.token_endpoint);
+  });
+
+  it('falls back to appended OpenID Connect discovery for a path-bearing issuer', async () => {
+    stubFetch({
+      'https://mcp.example.com/.well-known/oauth-protected-resource': {
+        authorization_servers: ['https://auth.example.com/tenant1'],
+      },
+      'https://auth.example.com/tenant1/.well-known/openid-configuration': metadata,
+    });
+    const endpoints = await discoverOAuthEndpoints('https://mcp.example.com');
+    expect(endpoints.tokenEndpoint).toBe(metadata.token_endpoint);
+  });
+
+  it('finds protected-resource metadata at the path-inserted form for a path-mounted MCP server', async () => {
+    stubFetch({
+      'https://mcp.example.com/.well-known/oauth-protected-resource/mcp': {
+        authorization_servers: ['https://auth.example.com'],
+      },
+      'https://auth.example.com/.well-known/oauth-authorization-server': metadata,
+    });
+    const endpoints = await discoverOAuthEndpoints('https://mcp.example.com/mcp');
+    expect(endpoints.tokenEndpoint).toBe(metadata.token_endpoint);
+  });
+
+  it('throws when no metadata document is published at any candidate URL', async () => {
+    stubFetch({
+      'https://mcp.example.com/.well-known/oauth-protected-resource': {
+        authorization_servers: ['https://auth.example.com/mcp'],
+      },
+    });
+    await expect(discoverOAuthEndpoints('https://mcp.example.com')).rejects.toThrow(
+      /could not discover OAuth endpoints/,
+    );
+  });
+
+  it('rejects a discovered authorization server that is not https', async () => {
+    stubFetch({
+      'https://mcp.example.com/.well-known/oauth-protected-resource': {
+        authorization_servers: ['http://evil.example.com'],
+      },
+    });
+    await expect(discoverOAuthEndpoints('https://mcp.example.com')).rejects.toThrow(
+      /must be an https:\/\/ URL/,
+    );
+  });
+});
 
 describe('generatePkce', () => {
   it('derives the challenge as base64url(SHA-256(verifier))', async () => {

--- a/src/integrations/mcp/oauth.ts
+++ b/src/integrations/mcp/oauth.ts
@@ -76,23 +76,55 @@ function assertSecureUrl(raw: string, label: string): void {
   }
 }
 
+// RFC 8414 §3 and RFC 9728 §3 build well-known URLs by *inserting* the
+// well-known segment between host and path — an issuer/resource of
+// https://host/path publishes at https://host/.well-known/<doc>/path (this
+// is how Stripe's https://access.stripe.com/mcp serves its metadata).
+// OpenID Connect Discovery predates that rule and *appends* instead
+// (https://host/path/.well-known/openid-configuration); live servers exist
+// on both conventions. For a URL with no path the two forms coincide.
+function wellKnown(base: URL, doc: string, form: 'insert' | 'append'): string {
+  const path = base.pathname.replace(/\/+$/, '');
+  return form === 'insert'
+    ? `${base.origin}/.well-known/${doc}${path}`
+    : `${base.origin}${path}/.well-known/${doc}`;
+}
+
+async function fetchFirstJson(urls: string[]): Promise<JsonObject | null> {
+  for (const url of new Set(urls)) {
+    const data = await fetchJson(url);
+    if (data) return data;
+  }
+  return null;
+}
+
 export async function discoverOAuthEndpoints(mcpServerUrl: string): Promise<OAuthEndpoints> {
-  const origin = new URL(mcpServerUrl).origin;
+  const server = new URL(mcpServerUrl);
 
   // RFC 9728: the MCP server names which authorization server(s) protect it.
+  // A server mounted on a path publishes at the path-inserted form; the
+  // origin root stays as a fallback for servers that predate that rule.
   // Fall back to the MCP server's own origin as the authorization server —
   // the MCP spec's baseline for servers that are their own authorization
   // server.
-  const resource = await fetchJson(`${origin}/.well-known/oauth-protected-resource`);
+  const resource = await fetchFirstJson([
+    wellKnown(server, 'oauth-protected-resource', 'insert'),
+    `${server.origin}/.well-known/oauth-protected-resource`,
+  ]);
   const servers = resource?.authorization_servers;
-  const authServer = isJsonArray(servers) && isString(servers[0]) ? servers[0] : origin;
+  const authServer = isJsonArray(servers) && isString(servers[0]) ? servers[0] : server.origin;
   assertSecureUrl(authServer, 'authorization server');
 
   // RFC 8414, falling back to OpenID Connect discovery for authorization
-  // servers that only publish that document.
-  const metadata =
-    (await fetchJson(`${authServer}/.well-known/oauth-authorization-server`)) ??
-    (await fetchJson(`${authServer}/.well-known/openid-configuration`));
+  // servers that only publish that document. Spec-correct inserted form
+  // first, appended form second for each document.
+  const issuer = new URL(authServer);
+  const metadata = await fetchFirstJson([
+    wellKnown(issuer, 'oauth-authorization-server', 'insert'),
+    wellKnown(issuer, 'oauth-authorization-server', 'append'),
+    wellKnown(issuer, 'openid-configuration', 'insert'),
+    wellKnown(issuer, 'openid-configuration', 'append'),
+  ]);
   const authorizationEndpoint = metadata?.authorization_endpoint;
   const tokenEndpoint = metadata?.token_endpoint;
   if (!isString(authorizationEndpoint) || !isString(tokenEndpoint)) {


### PR DESCRIPTION
## Problem

Connecting the Stripe MCP server (`https://mcp.stripe.com`) failed with `OAuth connect failed: discovery_failed`. Its authorization server is `https://access.stripe.com/mcp` — and RFC 8414 puts a **path-bearing** issuer's metadata at the well-known segment *inserted between host and path*:

- `https://access.stripe.com/.well-known/oauth-authorization-server/mcp` → 200, full metadata
- `https://access.stripe.com/mcp/.well-known/oauth-authorization-server` (what discovery fetched) → 404

Sentry and Cloudflare kept working because their authorization servers sit at the origin root, where the two forms are the same URL.

## Fix

`discoverOAuthEndpoints` now tries a candidate list per document — spec-correct inserted form first, appended form as fallback (OpenID Connect Discovery appends by design; live servers exist on both conventions) — for both `oauth-authorization-server` and `openid-configuration`. The RFC 9728 protected-resource lookup gets the same treatment for MCP servers mounted on a path, keeping the origin root as fallback. For path-less servers the forms coincide and are deduped, so behavior there is byte-identical.

## Verification

- Ran the new `discoverOAuthEndpoints` against the live servers: `mcp.stripe.com` resolves all endpoints (authorize/token/register under `access.stripe.com/mcp/oauth2/`), `mcp.sentry.dev` and `mcp.cloudflare.com` still resolve — no regression on existing connections.
- Six new unit tests with a stubbed fetch, one mirroring the exact Stripe shape. `pnpm test` 81 passed, `pnpm test:worker` 121 passed.

## Heads-up

Stripe advertises `token_endpoint_auth_methods_supported: ["none"]` (public client, PKCE-only) while turbodiff registers with `client_secret_post`. If the connect flow now fails at `registration_failed` instead, that mismatch is the follow-up — discovery itself is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)