### PR TITLE
perf: make app interactions feel local-first

### DIFF
--- a/migrations/0044_performance_state.sql
+++ b/migrations/0044_performance_state.sql
@@ -1,0 +1,58 @@
+-- Durable read-side state used to keep interactive requests off GitHub and
+-- Artifacts git mirrors. Membership snapshots are refreshed from GitHub with
+-- bounded staleness; ref heads are advanced by durable Artifacts push events.
+
+CREATE TABLE user_installation_access (
+	user_id TEXT PRIMARY KEY,
+	installation_ids TEXT NOT NULL,
+	verified_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE repository_refs (
+	repository_id INTEGER NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+	ref TEXT NOT NULL,
+	head_sha TEXT NOT NULL,
+	pushed_at TEXT NOT NULL,
+	PRIMARY KEY (repository_id, ref)
+);
+
+CREATE INDEX idx_repository_refs_head
+	ON repository_refs (repository_id, head_sha);
+
+CREATE TABLE installation_repo_sync (
+	installation_id INTEGER PRIMARY KEY REFERENCES installations(id) ON DELETE CASCADE,
+	last_synced_at TEXT,
+	syncing_until TEXT
+);
+
+-- The board's backlog query scopes on installation and excludes planned
+-- todos. Without this partial index it becomes a full scan as history grows.
+CREATE INDEX idx_todos_installation_unplanned
+	ON todos (installation_id, id DESC)
+	WHERE plan_id IS NULL;
+
+-- Feature lookups by PR number are a frequent webhook/request path.
+CREATE INDEX idx_features_repository_pr
+	ON features (repository_id, pr_number, id DESC)
+	WHERE pr_number IS NOT NULL;
+
+-- 0042's live counter predates server-side board snapshots. These relation
+-- tables also shape /api/board, so every mutation must advance the snapshot
+-- key; otherwise a repo toggle or link edit can keep returning a cached old
+-- board even after the client correctly invalidates its query.
+CREATE TRIGGER bump_installations_perf_i AFTER INSERT ON installations BEGIN UPDATE factory_version SET version = version + 1 WHERE id = 1; END;
+CREATE TRIGGER bump_installations_perf_u AFTER UPDATE ON installations BEGIN UPDATE factory_version SET version = version + 1 WHERE id = 1; END;
+CREATE TRIGGER bump_installations_perf_d AFTER DELETE ON installations BEGIN UPDATE factory_version SET version = version + 1 WHERE id = 1; END;
+CREATE TRIGGER bump_repositories_perf_i AFTER INSERT ON repositories BEGIN UPDATE factory_version SET version = version + 1 WHERE id = 1; END;
+CREATE TRIGGER bump_repositories_perf_u AFTER UPDATE ON repositories BEGIN UPDATE factory_version SET version = version + 1 WHERE id = 1; END;
+CREATE TRIGGER bump_repositories_perf_d AFTER DELETE ON repositories BEGIN UPDATE factory_version SET version = version + 1 WHERE id = 1; END;
+CREATE TRIGGER bump_todo_repositories_perf_i AFTER INSERT ON todo_repositories BEGIN UPDATE factory_version SET version = version + 1 WHERE id = 1; END;
+CREATE TRIGGER bump_todo_repositories_perf_u AFTER UPDATE ON todo_repositories BEGIN UPDATE factory_version SET version = version + 1 WHERE id = 1; END;
+CREATE TRIGGER bump_todo_repositories_perf_d AFTER DELETE ON todo_repositories BEGIN UPDATE factory_version SET version = version + 1 WHERE id = 1; END;
+CREATE TRIGGER bump_plan_repositories_perf_i AFTER INSERT ON plan_repositories BEGIN UPDATE factory_version SET version = version + 1 WHERE id = 1; END;
+CREATE TRIGGER bump_plan_repositories_perf_u AFTER UPDATE ON plan_repositories BEGIN UPDATE factory_version SET version = version + 1 WHERE id = 1; END;
+CREATE TRIGGER bump_plan_repositories_perf_d AFTER DELETE ON plan_repositories BEGIN UPDATE factory_version SET version = version + 1 WHERE id = 1; END;
+
+-- 0042 covered the common insert/update paths, but hard deletion must also
+-- wake clients and invalidate board snapshots.
+CREATE TRIGGER bump_features_perf_d AFTER DELETE ON features BEGIN UPDATE factory_version SET version = version + 1 WHERE id = 1; END;

--- a/public/_headers
+++ b/public/_headers
@@ -1,12 +1,12 @@
 # Cache policy for Workers Static Assets (consumed by the platform, not
-# served). Content-hashed chunks and fonts are immutable; app.js/app.css
-# keep fixed names (the Worker shell references them statically) so they
-# stay on the platform default ETag revalidation — a chunk importing
-# "../app.js" would otherwise pin a stale entry forever.
+# served). Vite content-hashes every JS/CSS asset; the Worker resolves the
+# current names from /app/manifest.json when it renders the shell.
 /app/chunks/*
   Cache-Control: public, max-age=31536000, immutable
 /app/assets/*
   Cache-Control: public, max-age=31536000, immutable
+/app/manifest.json
+  Cache-Control: no-store
 /fonts/*
   Cache-Control: public, max-age=31536000, immutable
 /logo.png

--- a/src/ai/workflows/automation.ts
+++ b/src/ai/workflows/automation.ts
@@ -35,6 +35,7 @@ import {
   installationToken,
 } from '../../integrations/github/app.ts';
 import { UNTRUSTED_CONTENT_RULES } from '../../domain/prompt-security.ts';
+import { notifyAutomationLive } from '../../services/live-updates.ts';
 
 // A recurring, clock-driven counterpart to the generation workflow: a
 // user-authored prompt runs on a schedule (src/services/automation-poll.ts) against
@@ -249,6 +250,7 @@ export class AutomationWorkflow extends WorkflowEntrypoint<unknown, AutomationPa
             undefined,
             agentRan.usage ?? undefined,
           );
+          await notifyAutomationLive(automationId);
         });
         return 'no_changes';
       }
@@ -289,6 +291,7 @@ export class AutomationWorkflow extends WorkflowEntrypoint<unknown, AutomationPa
               checks.output,
               agentRan.usage ?? undefined,
             );
+            await notifyAutomationLive(automationId);
           });
           return 'checks_failed';
         }
@@ -349,6 +352,7 @@ export class AutomationWorkflow extends WorkflowEntrypoint<unknown, AutomationPa
           undefined,
           agentRan.usage ?? undefined,
         );
+        await notifyAutomationLive(automationId);
       });
 
       await step.do(
@@ -381,6 +385,7 @@ export class AutomationWorkflow extends WorkflowEntrypoint<unknown, AutomationPa
           },
           async () => {
             await finishAutomationRun(failedRunId, 'failed', undefined, undefined, message);
+            await notifyAutomationLive(automationId);
           },
         );
       }

--- a/src/ai/workflows/chat.ts
+++ b/src/ai/workflows/chat.ts
@@ -1,6 +1,7 @@
 import { env, WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from 'cloudflare:workers';
 import { processChatMessage } from '../runners/chat.ts';
 import type { ChatQueueMessage } from '../../shared/factory-messages.ts';
+import { notifyFeatureLive } from '../../services/live-updates.ts';
 
 // Chat turns run as a durable Workflow, mirroring FixWorkflow: the sandbox
 // work (clone/refresh + agent + tests + repair rounds) routinely exceeds the
@@ -22,6 +23,7 @@ export class ChatWorkflow extends WorkflowEntrypoint<unknown, ChatParams> {
       { retries: { limit: 1, delay: '5 minutes' }, timeout: '85 minutes' },
       async () => {
         await processChatMessage(event.payload.message);
+        await notifyFeatureLive(event.payload.message.featureId);
       },
     );
     return 'done';

--- a/src/ai/workflows/conflict-resolution.ts
+++ b/src/ai/workflows/conflict-resolution.ts
@@ -1,6 +1,7 @@
 import { env, WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from 'cloudflare:workers';
 import { processResolveConflictMessage } from '../runners/conflict-resolver.ts';
 import type { ConflictResolveQueueMessage } from '../../shared/factory-messages.ts';
+import { notifyRepositoryLive } from '../../services/live-updates.ts';
 
 // Conflict resolution runs as a durable Workflow, same as fix — an
 // agent-driven merge conflict resolution can exceed a queue consumer's wall
@@ -20,6 +21,7 @@ export class ConflictResolveWorkflow extends WorkflowEntrypoint<unknown, Conflic
       { retries: { limit: 1, delay: '5 minutes' }, timeout: '40 minutes' },
       async () => {
         await processResolveConflictMessage(event.payload.message);
+        await notifyRepositoryLive(event.payload.message.repoId);
       },
     );
     return 'done';

--- a/src/ai/workflows/fix.ts
+++ b/src/ai/workflows/fix.ts
@@ -1,6 +1,7 @@
 import { env, WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from 'cloudflare:workers';
 import { processFixMessage } from '../runners/fixer.ts';
 import type { FixQueueMessage } from '../../shared/factory-messages.ts';
+import { notifyRepositoryLive } from '../../services/live-updates.ts';
 
 // Fix runs as a durable Workflow — the last of the three long agent runs
 // (generation, verification, fix) to leave the queue consumer's 15-minute
@@ -21,6 +22,7 @@ export class FixWorkflow extends WorkflowEntrypoint<unknown, FixParams> {
       { retries: { limit: 1, delay: '5 minutes' }, timeout: '85 minutes' },
       async () => {
         await processFixMessage(event.payload.message);
+        await notifyRepositoryLive(event.payload.message.repoId);
       },
     );
     return 'done';

--- a/src/ai/workflows/generation.ts
+++ b/src/ai/workflows/generation.ts
@@ -43,6 +43,7 @@ import { UNTRUSTED_CONTENT_RULES } from '../../domain/prompt-security.ts';
 import { installDependencies, NPM_CACHE_ENV } from '../runtime/sandbox-deps.ts';
 import { mintUserToken } from '../../services/user-tokens.ts';
 import { openNativeChangeRequest } from '../../services/change-requests.ts';
+import { notifyFeatureLive } from '../../services/live-updates.ts';
 import { enqueueFactoryMessage } from '../../services/factory-queue.ts';
 
 // Phase 2 of the software factory, re-architected as a Cloudflare Workflow.
@@ -223,6 +224,7 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
               status: 'failed',
               error: 'repository missing or disabled',
             });
+            await notifyFeatureLive(featureId);
             return null;
           }
           let base: string;
@@ -366,6 +368,7 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
             error: 'agent produced no file changes',
             usage: agentRan.usage ?? undefined,
           });
+          await notifyFeatureLive(featureId);
         });
         return 'no_changes';
       }
@@ -513,6 +516,7 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
               error: checks.output.slice(-500),
               usage: totalUsage ?? undefined,
             });
+            await notifyFeatureLive(featureId);
           });
           return 'checks_failed';
         }
@@ -573,6 +577,7 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
             changeRequestId: cr.id,
             usage: totalUsage ?? undefined,
           });
+          await notifyFeatureLive(featureId);
           if (ctx.acceptance) await enqueueFactoryMessage({ kind: 'verify', featureId });
           return cr.number;
         }
@@ -621,6 +626,7 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
           prNumber: pr.number,
           usage: totalUsage ?? undefined,
         });
+        await notifyFeatureLive(featureId);
         // Phase 4: acceptance criteria get an empirical verification run.
         if (ctx.acceptance) await enqueueFactoryMessage({ kind: 'verify', featureId });
         return pr.number;
@@ -656,6 +662,7 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
         },
         async () => {
           await updateFeature(featureId, { status: 'failed', error: message });
+          await notifyFeatureLive(featureId);
         },
       );
       console.error(`turbodiff: generation workflow failed for feature ${featureId}:`, err);

--- a/src/ai/workflows/verification.ts
+++ b/src/ai/workflows/verification.ts
@@ -2,6 +2,7 @@ import { env, WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from '
 import { getFeature, latestVerificationForFeature } from '../../data/db.ts';
 import { runVerification } from '../runners/verifier.ts';
 import { parseUtc } from '../../shared/time.ts';
+import { notifyFeatureLive } from '../../services/live-updates.ts';
 
 // Verification as a durable Workflow, for the same reason generation is one:
 // the queue consumer's 15-minute wall clock silently killed long verify runs
@@ -23,6 +24,7 @@ export class VerificationWorkflow extends WorkflowEntrypoint<unknown, Verificati
       { retries: { limit: 1, delay: '5 minutes' }, timeout: '40 minutes' },
       async () => {
         await runVerification(featureId);
+        await notifyFeatureLive(featureId);
       },
     );
     return 'done';

--- a/src/app.ts
+++ b/src/app.ts
@@ -43,15 +43,26 @@ const app = new Hono();
 // executable.
 app.use('*', async (c, next) => {
   await next();
-  c.res.headers.set('x-content-type-options', 'nosniff');
-  if (c.res.headers.get('content-type')?.includes('text/html')) {
-    c.res.headers.set(
+  // Responses returned by the static-assets binding have immutable Headers.
+  // Re-wrap the response once so security headers work for both Worker-owned
+  // responses and hashed assets. A WebSocket upgrade must retain its native
+  // response object and does not need document security headers.
+  if (c.res.status === 101) return;
+  const headers = new Headers(c.res.headers);
+  headers.set('x-content-type-options', 'nosniff');
+  if (headers.get('content-type')?.includes('text/html')) {
+    headers.set(
       'content-security-policy',
       "frame-ancestors 'none'; base-uri 'self'; object-src 'none'",
     );
-    c.res.headers.set('x-frame-options', 'DENY');
-    c.res.headers.set('referrer-policy', 'same-origin');
+    headers.set('x-frame-options', 'DENY');
+    headers.set('referrer-policy', 'same-origin');
   }
+  c.res = new Response(c.res.body, {
+    status: c.res.status,
+    statusText: c.res.statusText,
+    headers,
+  });
 });
 
 app.get('/healthz', async (c) => {

--- a/src/client/components/app-shell.tsx
+++ b/src/client/components/app-shell.tsx
@@ -11,7 +11,7 @@ import {
   Settings,
   Sparkles,
 } from 'lucide-react';
-import { useState, type ReactNode } from 'react';
+import { lazy, Suspense, useState, type ReactNode } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import type { ApiMe } from '../../shared/api-types.ts';
 import { codeRoute } from '../lib/layout.ts';
@@ -19,10 +19,15 @@ import { navShortcuts, noOverlayOpen } from '../lib/shortcuts.ts';
 import { useIsDesktop } from '../lib/use-is-desktop.ts';
 import { useLiveRefresh } from '../lib/use-live-refresh.ts';
 import { cn } from '../lib/utils.ts';
-import { CommandPalette } from './command-palette.tsx';
 import { Lamp } from './identity.tsx';
-import { ShortcutHelp } from './shortcut-help.tsx';
 import { Kbd } from './ui/kbd.tsx';
+
+const CommandPalette = lazy(() =>
+  import('./command-palette.tsx').then((module) => ({ default: module.CommandPalette })),
+);
+const ShortcutHelp = lazy(() =>
+  import('./shortcut-help.tsx').then((module) => ({ default: module.ShortcutHelp })),
+);
 
 // Control-room nav: every destination is a station with a distinct icon,
 // lit where you are, dark elsewhere. Settings is the single admin
@@ -166,7 +171,7 @@ export function AppShell({ me, children }: { me: ApiMe; children: ReactNode }) {
   const isDesktop = useIsDesktop();
   // App-wide live updates: one tiny version poll instead of per-page
   // full-payload polling (see use-live-refresh.ts).
-  useLiveRefresh();
+  useLiveRefresh(me.installation_ids);
   useHotkeys(
     NAV_SHORTCUTS.map((s) => s.key).join(','),
     (_e, hk) => {
@@ -266,13 +271,21 @@ export function AppShell({ me, children }: { me: ApiMe; children: ReactNode }) {
       </main>
 
       <BottomTabs />
-      <ShortcutHelp
-        nav={SIDEBAR_NAV}
-        open={helpOpen}
-        onOpenChange={setHelpOpen}
-        onToggle={() => setHelpOpen((prev) => !prev)}
-      />
-      <CommandPalette nav={SIDEBAR_NAV} open={paletteOpen} onOpenChange={setPaletteOpen} />
+      {helpOpen ? (
+        <Suspense fallback={null}>
+          <ShortcutHelp
+            nav={SIDEBAR_NAV}
+            open={helpOpen}
+            onOpenChange={setHelpOpen}
+            onToggle={() => setHelpOpen((prev) => !prev)}
+          />
+        </Suspense>
+      ) : null}
+      {paletteOpen ? (
+        <Suspense fallback={null}>
+          <CommandPalette nav={SIDEBAR_NAV} open={paletteOpen} onOpenChange={setPaletteOpen} />
+        </Suspense>
+      ) : null}
     </div>
   );
 }

--- a/src/client/components/cockpit-patch-diff.tsx
+++ b/src/client/components/cockpit-patch-diff.tsx
@@ -1,0 +1,67 @@
+import {
+  PatchDiff,
+  WorkerPoolContextProvider,
+  type DiffLineAnnotation,
+  type SelectedLineRange,
+  type WorkerPoolOptions,
+} from '@pierre/diffs/react';
+import DiffWorker from '@pierre/diffs/worker/worker.js?worker';
+import type { ReactNode } from 'react';
+import type { ApiCockpitComment } from '../../shared/api-types.ts';
+import { ensureDiffStyles } from './diff-styles.ts';
+
+export interface CockpitCommentMeta {
+  comment?: ApiCockpitComment;
+  composer?: boolean;
+}
+
+const DIFF_POOL_OPTIONS = {
+  workerFactory: () => new DiffWorker(),
+  poolSize: Math.min(4, Math.max(1, (navigator.hardwareConcurrency || 2) - 1)),
+} satisfies WorkerPoolOptions;
+const DIFF_HIGHLIGHTER_OPTIONS = { theme: 'pierre-dark' as const };
+
+export function CockpitDiffWorkspace({ children }: { children: ReactNode }) {
+  ensureDiffStyles();
+  return (
+    <WorkerPoolContextProvider
+      poolOptions={DIFF_POOL_OPTIONS}
+      highlighterOptions={DIFF_HIGHLIGHTER_OPTIONS}
+    >
+      {children}
+    </WorkerPoolContextProvider>
+  );
+}
+
+export function CockpitPatchDiff({
+  patch,
+  annotations,
+  renderAnnotation,
+  diffStyle,
+  prOpen,
+  onSelectionEnd,
+}: {
+  patch: string;
+  annotations: DiffLineAnnotation<CockpitCommentMeta>[];
+  renderAnnotation: (annotation: DiffLineAnnotation<CockpitCommentMeta>) => ReactNode;
+  diffStyle: 'split' | 'unified';
+  prOpen: boolean;
+  onSelectionEnd: (range: SelectedLineRange | null) => void;
+}) {
+  return (
+    <div className="diffs-scope rounded-none border-0">
+      <PatchDiff
+        patch={patch}
+        lineAnnotations={annotations}
+        renderAnnotation={renderAnnotation}
+        options={{
+          theme: 'pierre-dark',
+          diffStyle,
+          disableFileHeader: true,
+          enableLineSelection: prOpen,
+          onLineSelectionEnd: onSelectionEnd,
+        }}
+      />
+    </div>
+  );
+}

--- a/src/client/lib/performance.ts
+++ b/src/client/lib/performance.ts
@@ -1,0 +1,50 @@
+interface LayoutShiftEntry extends PerformanceEntry {
+  value: number;
+  hadRecentInput: boolean;
+}
+
+const metrics = new Map<string, number>();
+
+function observe(type: string, record: (entry: PerformanceEntry) => void): void {
+  try {
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) record(entry);
+    });
+    observer.observe({ type, buffered: true });
+  } catch {
+    // Older browsers simply omit unsupported metrics.
+  }
+}
+
+// A 10% real-user sample is enough to catch regressions without turning a
+// performance feature into a meaningful source of network or log volume.
+export function startPerformanceMonitoring(): void {
+  if (Math.random() >= 0.1) return;
+  const navigation = performance.getEntriesByType('navigation')[0];
+  if (navigation instanceof PerformanceNavigationTiming) {
+    metrics.set('ttfb', navigation.responseStart);
+    metrics.set('dom_interactive', navigation.domInteractive);
+  }
+  observe('largest-contentful-paint', (entry) => metrics.set('lcp', entry.startTime));
+  observe('event', (entry) =>
+    metrics.set('inp', Math.max(metrics.get('inp') ?? 0, entry.duration)),
+  );
+  observe('layout-shift', (entry) => {
+    // SAFETY: entries delivered by the layout-shift observer implement the
+    // LayoutShift Performance API extension.
+    const shift = entry as LayoutShiftEntry;
+    if (!shift.hadRecentInput) metrics.set('cls', (metrics.get('cls') ?? 0) + shift.value);
+  });
+
+  const report = () => {
+    if (metrics.size === 0) return;
+    const body = JSON.stringify({ path: location.pathname, metrics: Object.fromEntries(metrics) });
+    void fetch('/api/performance', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+      keepalive: true,
+    });
+  };
+  addEventListener('pagehide', report, { once: true });
+}

--- a/src/client/lib/queries.ts
+++ b/src/client/lib/queries.ts
@@ -10,6 +10,7 @@ import type {
   ApiBoard,
   ApiChatList,
   ApiFeatureDetail,
+  ApiFeatureDiff,
   ApiIntegrations,
   ApiMe,
   ApiOrgMembers,
@@ -108,6 +109,19 @@ export const featureQuery = (id: number) =>
       if (fixInFlight) return LIVE_POLL_MS;
       return false;
     },
+  });
+
+export const featureDiffQuery = (id: number, version: string | null) =>
+  queryOptions({
+    queryKey: ['feature-diff', id, version],
+    queryFn: () =>
+      api.get<ApiFeatureDiff>(
+        `/api/factory/features/${id}/diff${version ? `?v=${encodeURIComponent(version)}` : ''}`,
+      ),
+    // A PR/CR diff is a snapshot. Mutations that push a new commit explicitly
+    // invalidate this key; status/comment refreshes leave it untouched.
+    staleTime: Infinity,
+    gcTime: 30 * 60_000,
   });
 
 // A user chat message in one of these states has a turn in flight — the

--- a/src/client/lib/use-live-refresh.ts
+++ b/src/client/lib/use-live-refresh.ts
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { isJsonObject } from '../../shared/json.ts';
 import { api } from './api.ts';
 
 // Cheap live updates: poll the one-row change counter (GET
@@ -8,17 +9,88 @@ import { api } from './api.ts';
 // refetches queries with active observers, so the cost of a bump is exactly
 // the page being looked at. The per-query 30s intervals in queries.ts remain
 // as a slow fallback; this hook is what makes changes land in seconds.
-const VERSION_POLL_MS = 4_000;
+const FALLBACK_POLL_MS = 30_000;
 
 // Query keys that mirror live factory state.
 const LIVE_KEYS = ['board', 'task', 'feature', 'chat', 'automation-runs', 'automation-run'];
 
-export function useLiveRefresh(): void {
+export function useLiveRefresh(installationIds: number[]): void {
   const queryClient = useQueryClient();
+  const idsKey = [...new Set(installationIds)].sort((a, b) => a - b).join(',');
+  const [fullyConnected, setFullyConnected] = useState(false);
+  const invalidate = useCallback(() => {
+    for (const key of LIVE_KEYS) {
+      void queryClient.invalidateQueries({ queryKey: [key] });
+    }
+  }, [queryClient]);
+
+  useEffect(() => {
+    const ids = idsKey.split(',').filter(Boolean).map(Number);
+    if (ids.length === 0) return;
+    let stopped = false;
+    let connected = 0;
+    const sockets = new Set<WebSocket>();
+    const reconnectTimers = new Set<number>();
+    const heartbeatTimers = new Map<WebSocket, number>();
+    const updateConnectionState = () => setFullyConnected(connected === ids.length);
+
+    const connect = (installationId: number, attempt: number) => {
+      if (stopped) return;
+      const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const socket = new WebSocket(`${protocol}//${location.host}/api/live/${installationId}`);
+      sockets.add(socket);
+      let opened = false;
+      socket.addEventListener('open', () => {
+        opened = true;
+        connected += 1;
+        updateConnectionState();
+        const timer = window.setInterval(() => {
+          if (socket.readyState === WebSocket.OPEN) socket.send('{"type":"ping"}');
+        }, 25_000);
+        heartbeatTimers.set(socket, timer);
+      });
+      socket.addEventListener('message', (event) => {
+        try {
+          const message: unknown = JSON.parse(String(event.data));
+          if (isJsonObject(message) && message.type === 'invalidate') invalidate();
+        } catch {
+          // Unknown hub messages do not invalidate data or break the socket.
+        }
+      });
+      socket.addEventListener('close', () => {
+        sockets.delete(socket);
+        const heartbeat = heartbeatTimers.get(socket);
+        if (heartbeat !== undefined) window.clearInterval(heartbeat);
+        heartbeatTimers.delete(socket);
+        if (opened) connected = Math.max(0, connected - 1);
+        updateConnectionState();
+        if (stopped) return;
+        const delay = Math.min(30_000, 1_000 * 2 ** Math.min(attempt, 5));
+        const timer = window.setTimeout(() => {
+          reconnectTimers.delete(timer);
+          connect(installationId, opened ? 0 : attempt + 1);
+        }, delay);
+        reconnectTimers.add(timer);
+      });
+    };
+
+    for (const installationId of ids) connect(installationId, 0);
+    return () => {
+      stopped = true;
+      setFullyConnected(false);
+      for (const timer of reconnectTimers) window.clearTimeout(timer);
+      for (const timer of heartbeatTimers.values()) window.clearInterval(timer);
+      for (const socket of sockets) socket.close(1000, 'route closed');
+    };
+  }, [idsKey, invalidate]);
+
+  // A deliberately slow global counter remains as a safety net during
+  // deploys, offline transitions, or browsers where WebSockets are blocked.
   const { data } = useQuery({
     queryKey: ['factory-version'],
     queryFn: () => api.get<{ v: number }>('/api/factory/version'),
-    refetchInterval: VERSION_POLL_MS,
+    enabled: !fullyConnected,
+    refetchInterval: fullyConnected ? false : FALLBACK_POLL_MS,
     // Version numbers are meaningless across reloads — never persist, and
     // don't let a cached value suppress the first real read.
     gcTime: 0,
@@ -29,10 +101,8 @@ export function useLiveRefresh(): void {
     const v = data?.v;
     if (v === undefined) return;
     if (prev.current !== null && v !== prev.current) {
-      for (const key of LIVE_KEYS) {
-        void queryClient.invalidateQueries({ queryKey: [key] });
-      }
+      invalidate();
     }
     prev.current = v;
-  }, [data?.v, queryClient]);
+  }, [data?.v, invalidate]);
 }

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -44,8 +44,6 @@ import {
   taskQuery,
   usageQuery,
 } from './lib/queries.ts';
-import { BoardPage } from './pages/board.tsx';
-import { TaskPage } from './pages/task.tsx';
 import './styles.css';
 
 function ShellLayout() {
@@ -139,14 +137,14 @@ const boardRoute = createRoute({
   getParentRoute: () => shellRoute,
   path: '/',
   loader: () => queryClient.ensureQueryData(boardQuery),
-  component: BoardPage,
+  component: lazyRouteComponent(() => import('./pages/board.tsx'), 'BoardPage'),
 });
 
 const taskRoute = createRoute({
   getParentRoute: () => shellRoute,
   path: '/tasks/$taskId',
   loader: ({ params }) => queryClient.ensureQueryData(taskQuery(Number(params.taskId))),
-  component: TaskPage,
+  component: lazyRouteComponent(() => import('./pages/task.tsx'), 'TaskPage'),
 });
 
 const usageRoute = createRoute({
@@ -334,6 +332,17 @@ declare module '@tanstack/react-router' {
 }
 
 void registerServiceWorker();
+// Monitoring is a post-boot concern: keep it out of the interaction-critical
+// graph and initialize it only when the browser has idle time.
+const startMonitoring = () =>
+  void import('./lib/performance.ts').then(({ startPerformanceMonitoring }) =>
+    startPerformanceMonitoring(),
+  );
+if ('requestIdleCallback' in window) {
+  window.requestIdleCallback(startMonitoring, { timeout: 5_000 });
+} else {
+  setTimeout(startMonitoring, 2_000);
+}
 
 // Warm-boot persistence: the last-known payloads of the cheap, list-shaped
 // queries hydrate from localStorage before first render, so a reload paints
@@ -350,7 +359,7 @@ const PERSISTED_KEYS = new Set([
   'usage',
 ]);
 // Bump to drop persisted caches whose shape no longer matches the client.
-const PERSIST_BUSTER = 'v1';
+const PERSIST_BUSTER = 'v2';
 const persistOptions: PersistQueryClientOptions = {
   queryClient,
   persister: createSyncStoragePersister({

--- a/src/client/pages/code.tsx
+++ b/src/client/pages/code.tsx
@@ -10,7 +10,7 @@ import {
   Pencil,
   WrapText,
 } from 'lucide-react';
-import { useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useMemo, useRef, useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { toast } from 'sonner';
 import type { ApiFileSave, ApiRepoCode } from '../../shared/api-types.ts';
@@ -24,7 +24,6 @@ import {
 } from '../lib/line-diff.ts';
 import { repoCodeQuery, repoFileQuery } from '../lib/queries.ts';
 import { cn } from '../lib/utils.ts';
-import { CodeEditor } from '../components/code-editor.tsx';
 import { RepoTree } from '../components/repo-tree.tsx';
 import { EmptyState, Muted, PageTitle } from '../components/section.tsx';
 import { Button, buttonVariants } from '../components/ui/button.tsx';
@@ -34,6 +33,10 @@ import { Field, Input } from '../components/ui/input.tsx';
 import { Kbd } from '../components/ui/kbd.tsx';
 import { OptionCard } from '../components/ui/option-card.tsx';
 import { Popover, PopoverContent, PopoverTrigger } from '../components/ui/popover.tsx';
+
+const CodeEditor = lazy(() =>
+  import('../components/code-editor.tsx').then((module) => ({ default: module.CodeEditor })),
+);
 
 // The code browser: the whole repository readable (and editable) in the
 // browser, straight off the GitHub REST API — no clone. The branch rides in
@@ -592,16 +595,20 @@ function FilePane({
         </span>
       </div>
       <div className="h-[calc(100dvh-16rem)] min-h-96 overflow-hidden rounded-lg border border-line bg-surface lg:h-auto lg:min-h-0 lg:flex-1">
-        <CodeEditor
-          value={editing ? buffer : loadedText}
-          onChange={setBuffer}
-          path={path}
-          readOnly={!editing}
-          wrap={wrap}
-          onSave={() => {
-            if (editing && dirty) openSave();
-          }}
-        />
+        <Suspense
+          fallback={<div className="h-full animate-pulse bg-surface" aria-label="Loading editor" />}
+        >
+          <CodeEditor
+            value={editing ? buffer : loadedText}
+            onChange={setBuffer}
+            path={path}
+            readOnly={!editing}
+            wrap={wrap}
+            onSave={() => {
+              if (editing && dirty) openSave();
+            }}
+          />
+        </Suspense>
       </div>
 
       <Dialog open={saveOpen} onOpenChange={setSaveOpen}>

--- a/src/client/pages/feature.tsx
+++ b/src/client/pages/feature.tsx
@@ -1,6 +1,6 @@
-import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
-import { PatchDiff, type DiffLineAnnotation, type SelectedLineRange } from '@pierre/diffs/react';
+import type { DiffLineAnnotation, SelectedLineRange } from '@pierre/diffs/react';
 import {
   ChevronDown,
   ChevronRight,
@@ -8,19 +8,24 @@ import {
   PanelLeftClose,
   PanelLeftOpen,
 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import type { ApiCockpitComment, ApiFeatureDetail, ApiMe } from '../../shared/api-types.ts';
 import { api, ApiError } from '../lib/api.ts';
 import { useDictation } from '../lib/dictation.ts';
 import { sentence } from '../lib/format.ts';
 import { applyOptimistic, optimisticId, optimisticNow } from '../lib/optimistic.ts';
-import { featureQuery, FIX_TERMINAL, GENERATION_STOPPED } from '../lib/queries.ts';
+import {
+  featureDiffQuery,
+  featureQuery,
+  FIX_TERMINAL,
+  GENERATION_STOPPED,
+} from '../lib/queries.ts';
 import { cn } from '../lib/utils.ts';
 import { AgentRunLog } from '../components/agent-run-log.tsx';
 import { ChatPanel } from '../components/chat-panel.tsx';
 import { ConfirmButton } from '../components/confirm-button.tsx';
-import { ensureDiffStyles } from '../components/diff-styles.ts';
+import type { CockpitCommentMeta } from '../components/cockpit-patch-diff.tsx';
 import { CertStrip, Lamp, Serial, Stamp, type LampTone } from '../components/identity.tsx';
 import { FILE_STATUS_DOT, FileTree } from '../components/file-tree.tsx';
 import { Markdown } from '../components/markdown.tsx';
@@ -47,17 +52,23 @@ import { Textarea } from '../components/ui/input.tsx';
 
 type CockpitFile = ApiFeatureDetail['files'][number];
 
+const CockpitPatchDiff = lazy(() =>
+  import('../components/cockpit-patch-diff.tsx').then((module) => ({
+    default: module.CockpitPatchDiff,
+  })),
+);
+const CockpitDiffWorkspace = lazy(() =>
+  import('../components/cockpit-patch-diff.tsx').then((module) => ({
+    default: module.CockpitDiffWorkspace,
+  })),
+);
+
 type Selection = {
   file: string;
   startLine: number;
   endLine: number;
   side: 'additions' | 'deletions';
 };
-
-interface CommentMeta {
-  comment?: ApiCockpitComment;
-  composer?: boolean;
-}
 
 function onApiError<T>(err: T) {
   toast.error(err instanceof ApiError ? err.message : 'Request failed');
@@ -350,25 +361,26 @@ function Composer({
 }
 
 function FileDiff({
-  data,
+  featureId,
+  comments,
+  prOpen,
   file,
   diffStyle,
 }: {
-  data: ApiFeatureDetail;
+  featureId: number;
+  comments: ApiCockpitComment[];
+  prOpen: boolean;
   file: CockpitFile;
   diffStyle: 'split' | 'unified';
 }) {
   const [selection, setSelection] = useState<Selection | null>(null);
-  const prOpen = data.pr?.state === 'open';
 
   const annotations = useMemo(() => {
-    const list: DiffLineAnnotation<CommentMeta>[] = data.comments
-      .filter((c) => c.path === file.filename)
-      .map((c) => ({
-        side: c.side === 'deletions' ? 'deletions' : 'additions',
-        lineNumber: c.line,
-        metadata: { comment: c },
-      }));
+    const list: DiffLineAnnotation<CockpitCommentMeta>[] = comments.map((c) => ({
+      side: c.side === 'deletions' ? 'deletions' : 'additions',
+      lineNumber: c.line,
+      metadata: { comment: c },
+    }));
     if (selection) {
       list.push({
         side: selection.side,
@@ -377,7 +389,7 @@ function FileDiff({
       });
     }
     return list;
-  }, [data.comments, file.filename, selection]);
+  }, [comments, selection]);
 
   const onSelectionEnd = useCallback(
     (range: SelectedLineRange | null) => {
@@ -400,15 +412,15 @@ function FileDiff({
     );
   }
   return (
-    <div className="diffs-scope rounded-none border-0">
-      <PatchDiff
+    <Suspense fallback={<div className="h-64 animate-pulse bg-surface" />}>
+      <CockpitPatchDiff
         patch={file.patch}
-        lineAnnotations={annotations}
-        renderAnnotation={(a: DiffLineAnnotation<CommentMeta>) =>
+        annotations={annotations}
+        renderAnnotation={(a: DiffLineAnnotation<CockpitCommentMeta>) =>
           a.metadata?.composer && selection ? (
             <Composer
               selection={selection}
-              featureId={data.feature.id}
+              featureId={featureId}
               onDone={() => setSelection(null)}
               onCancel={() => setSelection(null)}
             />
@@ -416,23 +428,20 @@ function FileDiff({
             <CommentCard comment={a.metadata.comment} />
           ) : null
         }
-        options={{
-          theme: 'pierre-dark',
-          diffStyle,
-          // The card header (FileSection) owns the filename/stats row.
-          disableFileHeader: true,
-          enableLineSelection: prOpen,
-          onLineSelectionEnd: onSelectionEnd,
-        }}
+        diffStyle={diffStyle}
+        prOpen={prOpen}
+        onSelectionEnd={onSelectionEnd}
       />
-    </div>
+    </Suspense>
   );
 }
 
 // One collapsible file card: sticky header (path, status, ±counts, comment
 // count) over the diff surface.
-function FileSection({
-  data,
+const FileSection = memo(function FileSection({
+  featureId,
+  comments,
+  prOpen,
   file,
   collapsed,
   commentCount,
@@ -440,7 +449,9 @@ function FileSection({
   onToggle,
   sectionRef,
 }: {
-  data: ApiFeatureDetail;
+  featureId: number;
+  comments: ApiCockpitComment[];
+  prOpen: boolean;
   file: CockpitFile;
   collapsed: boolean;
   commentCount: number;
@@ -456,7 +467,7 @@ function FileSection({
     <section
       ref={sectionRef}
       data-file={file.filename}
-      className="mt-3 scroll-mt-3 overflow-clip rounded-lg border border-line bg-surface"
+      className="mt-3 scroll-mt-3 overflow-clip rounded-lg border border-line bg-surface [contain-intrinsic-size:auto_600px] [content-visibility:auto]"
     >
       <button
         type="button"
@@ -497,17 +508,36 @@ function FileSection({
           {file.deletions > 0 ? <span className="text-danger">−{file.deletions}</span> : null}
         </span>
       </button>
-      {collapsed ? null : <FileDiff data={data} file={file} diffStyle={diffStyle} />}
+      {collapsed ? null : (
+        <FileDiff
+          featureId={featureId}
+          comments={comments}
+          prOpen={prOpen}
+          file={file}
+          diffStyle={diffStyle}
+        />
+      )}
     </section>
   );
-}
+});
 
 export default function FeaturePage() {
-  ensureDiffStyles();
   const { featureId } = useParams({ from: '/shell/factory/features/$featureId' });
   const id = Number(featureId);
   const queryClient = useQueryClient();
-  const { data } = useSuspenseQuery(featureQuery(id));
+  const { data: summary } = useSuspenseQuery(featureQuery(id));
+  const diffQuery = useQuery({
+    ...featureDiffQuery(id, summary.diff_version),
+    enabled: summary.pr !== null,
+  });
+  const data = useMemo<ApiFeatureDetail>(
+    () => ({
+      ...summary,
+      files: diffQuery.data?.files ?? [],
+      more_files: diffQuery.data?.more_files ?? 0,
+    }),
+    [summary, diffQuery.data],
+  );
   const refresh = () => {
     void queryClient.invalidateQueries({ queryKey: ['feature', id] });
   };
@@ -548,11 +578,19 @@ export default function FeaturePage() {
   };
   const sectionEls = useRef(new Map<string, HTMLElement>());
 
-  const commentCounts = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const c of data.comments) counts.set(c.path, (counts.get(c.path) ?? 0) + 1);
-    return counts;
+  const commentsByFile = useMemo(() => {
+    const comments = new Map<string, ApiCockpitComment[]>();
+    for (const comment of data.comments) {
+      const existing = comments.get(comment.path) ?? [];
+      existing.push(comment);
+      comments.set(comment.path, existing);
+    }
+    return comments;
   }, [data.comments]);
+  const commentCounts = useMemo(
+    () => new Map([...commentsByFile].map(([path, comments]) => [path, comments.length])),
+    [commentsByFile],
+  );
 
   const toggleFile = (filename: string) =>
     setCollapsed((prev) => {
@@ -1065,21 +1103,49 @@ export default function FeaturePage() {
             </AccordionItem>
           </Accordion>
 
-          {data.files.map((f) => (
-            <FileSection
-              key={f.filename}
-              data={data}
-              file={f}
-              diffStyle={diffStyle}
-              collapsed={collapsed.has(f.filename)}
-              commentCount={commentCounts.get(f.filename) ?? 0}
-              onToggle={() => toggleFile(f.filename)}
-              sectionRef={(el) => {
-                if (el) sectionEls.current.set(f.filename, el);
-                else sectionEls.current.delete(f.filename);
-              }}
+          {diffQuery.isPending ? (
+            <div
+              className="mt-3 h-80 animate-pulse rounded-lg border border-line bg-surface"
+              role="status"
+              aria-label="Loading diff"
             />
-          ))}
+          ) : null}
+          {diffQuery.isError ? (
+            <Card className="mt-3">
+              <p className="text-sm text-danger">The diff could not be loaded.</p>
+              <Button
+                variant="secondary"
+                size="sm"
+                className="mt-3"
+                onClick={() => void diffQuery.refetch()}
+              >
+                Retry
+              </Button>
+            </Card>
+          ) : null}
+          {data.files.length > 0 ? (
+            <Suspense fallback={<div className="mt-3 h-80 animate-pulse bg-surface" />}>
+              <CockpitDiffWorkspace>
+                {data.files.map((f) => (
+                  <FileSection
+                    key={f.filename}
+                    featureId={data.feature.id}
+                    comments={commentsByFile.get(f.filename) ?? []}
+                    prOpen={prState === 'open'}
+                    file={f}
+                    diffStyle={diffStyle}
+                    collapsed={collapsed.has(f.filename)}
+                    commentCount={commentsByFile.get(f.filename)?.length ?? 0}
+                    onToggle={() => toggleFile(f.filename)}
+                    sectionRef={(el) => {
+                      if (el) sectionEls.current.set(f.filename, el);
+                      else sectionEls.current.delete(f.filename);
+                    }}
+                  />
+                ))}
+              </CockpitDiffWorkspace>
+            </Suspense>
+          ) : null}
           {data.more_files > 0 ? (
             <Muted className="mt-3 block">
               …and {data.more_files} more files — see the PR on GitHub.

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -23,10 +23,12 @@ import { runPlanAnalyze, runPlanRefine } from './ai/runners/planner.ts';
 import { dispatchNativeCrReviews } from './ai/review/native-dispatch.ts';
 import { runQueuedCrMerge } from './services/change-requests.ts';
 import { startVerification, VerificationWorkflow } from './ai/workflows/verification.ts';
+import { notifyPlanLive } from './services/live-updates.ts';
 
 // The fixer sandbox container (docs/software-factory-design.md). Declared in
 // wrangler.jsonc under containers/durable_objects with migration tag v2.
 export { Sandbox } from '@cloudflare/sandbox';
+export { LiveUpdates } from './live-updates.ts';
 
 // Generation, verification, and automations run as durable Workflows
 // (bindings GEN_WORKFLOW / VERIFY_WORKFLOW / AUTOMATION_WORKFLOW in
@@ -57,9 +59,11 @@ export default {
           break;
         case 'plan_analyze':
           await runPlanAnalyze(body.planId);
+          await notifyPlanLive(body.planId);
           break;
         case 'plan_refine':
           await runPlanRefine(body.planId);
+          await notifyPlanLive(body.planId);
           break;
         case 'verify':
           // Just creates a durable workflow instance — verify runs exceed

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -11,3 +11,4 @@ export * from './usage.ts';
 export * from './credentials.ts';
 export * from './board.ts';
 export * from './automations.ts';
+export * from './performance.ts';

--- a/src/data/db.worker.test.ts
+++ b/src/data/db.worker.test.ts
@@ -17,18 +17,24 @@ import {
   createPlanForTodo,
   createTodo,
   createUserChatMessage,
+  deleteRepositoryRef,
+  claimInstallationRepoSync,
   deletePushSubscriptionByEndpoint,
   deletePushSubscriptionById,
   dispatchOpenCockpitComments,
   finishFixAttempt,
   getChatMessage,
   getFeature,
+  installationAccessSnapshot,
   hasPendingChatTurn,
   listChatMessages,
   listPushSubscriptionsForUser,
   listReposForPlan,
   pipelineCostByMonth,
   recentChatHistory,
+  recordRepositoryRef,
+  repositoryRef,
+  repositoryRefs,
   setChatMessageStatus,
   setChatSessionId,
   tryRecordAutomationRun,
@@ -36,6 +42,8 @@ import {
   tryRecordReview,
   updatePlan,
   upsertPushSubscription,
+  finishInstallationRepoSync,
+  storeInstallationAccessSnapshot,
 } from './db.ts';
 
 type TestEnv = Cloudflare.Env & { TEST_MIGRATIONS: D1Migration[] };
@@ -63,6 +71,9 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   const tables = [
+    'installation_repo_sync',
+    'repository_refs',
+    'user_installation_access',
     'push_subscriptions',
     'agent_runs',
     'chat_messages',
@@ -93,6 +104,45 @@ beforeEach(async () => {
   ];
   await testEnv.DB.batch(tables.map((table) => testEnv.DB.prepare(`DELETE FROM "${table}"`)));
   await seedTenant();
+});
+
+describe('performance state', () => {
+  it('round-trips durable membership snapshots and rejects corrupt data', async () => {
+    await storeInstallationAccessSnapshot('user-1', [1001, 2002]);
+    const snapshot = await installationAccessSnapshot('user-1');
+    expect(snapshot?.installationIds).toEqual([1001, 2002]);
+    expect(snapshot?.verifiedAt).toBeGreaterThan(0);
+
+    await testEnv.DB.prepare(
+      `UPDATE user_installation_access SET installation_ids = '[1001,"bad"]' WHERE user_id = 'user-1'`,
+    ).run();
+    expect(await installationAccessSnapshot('user-1')).toBeNull();
+  });
+
+  it('records ref heads and serializes repository refresh claims across callers', async () => {
+    await recordRepositoryRef(101, 'refs/heads/main', 'abc123', '2026-01-02T03:04:05Z');
+    await recordRepositoryRef(101, 'refs/heads/main', 'def456', '2026-01-03T03:04:05Z');
+    await recordRepositoryRef(101, 'refs/heads/topic', 'fedcba', '2026-01-03T03:04:06Z');
+    expect(await repositoryRef(101, 'refs/heads/main')).toMatchObject({ head_sha: 'def456' });
+    expect((await repositoryRefs(101)).map((ref) => ref.ref)).toEqual([
+      'refs/heads/main',
+      'refs/heads/topic',
+    ]);
+    await deleteRepositoryRef(101, 'refs/heads/topic');
+    expect((await repositoryRefs(101)).map((ref) => ref.ref)).toEqual(['refs/heads/main']);
+
+    const claims = await Promise.all(
+      Array.from({ length: 6 }, () => claimInstallationRepoSync(1001)),
+    );
+    expect(claims.filter(Boolean)).toHaveLength(1);
+    await finishInstallationRepoSync(1001, true);
+    expect(await claimInstallationRepoSync(1001)).toBe(false);
+    await testEnv.DB.prepare(
+      `UPDATE installation_repo_sync SET last_synced_at = datetime('now', '-6 minutes')
+		 WHERE installation_id = 1001`,
+    ).run();
+    expect(await claimInstallationRepoSync(1001)).toBe(true);
+  });
 });
 
 describe('fix attempt invariants', () => {

--- a/src/data/factory.ts
+++ b/src/data/factory.ts
@@ -162,6 +162,24 @@ export async function todoRepositoriesForTodos(todoIds: number[]): Promise<TodoR
   return res.results;
 }
 
+// Board rollup form: installation-scoped so it can run in parallel with the
+// todo list instead of waiting for its ids and starting a second D1 phase.
+export async function boardTodoRepositories(installationIds: number[]): Promise<TodoRepoRow[]> {
+  if (installationIds.length === 0) return [];
+  const placeholders = placeholderList(installationIds.length);
+  const res = await env.DB.prepare(
+    `SELECT tr.todo_id, tr.repository_id, r.owner, r.name
+		 FROM todo_repositories tr
+		 JOIN todos t ON t.id = tr.todo_id
+		 JOIN repositories r ON r.id = tr.repository_id
+		 WHERE t.installation_id IN (${placeholders}) AND t.plan_id IS NULL
+		 ORDER BY tr.todo_id, tr.position`,
+  )
+    .bind(...installationIds)
+    .all<TodoRepoRow>();
+  return res.results;
+}
+
 export async function listReposForPlan(planId: number): Promise<RepositoryRow[]> {
   const res = await env.DB.prepare(
     `SELECT r.* FROM plan_repositories pr
@@ -207,6 +225,31 @@ export async function getTaskRepoStatuses(planIds: number[]): Promise<TaskRepoSt
 		 ORDER BY pr.plan_id, pr.position`,
   )
     .bind(...planIds)
+    .all<TaskRepoStatusRow>();
+  return res.results;
+}
+
+// Board rollup form: installation-scoped so statuses load alongside plans in
+// the first D1 wave. The id-scoped variant remains for the task detail route.
+export async function boardTaskRepoStatuses(
+  installationIds: number[],
+): Promise<TaskRepoStatusRow[]> {
+  if (installationIds.length === 0) return [];
+  const placeholders = placeholderList(installationIds.length);
+  const res = await env.DB.prepare(
+    `SELECT pr.plan_id, pr.repository_id, r.owner, r.name, r.provider,
+		        f.id AS feature_id, f.status AS feature_status, f.error AS feature_error,
+		        f.pr_number AS pr_number,
+		        v.status AS verification_status, v.results AS verification_results
+		 FROM plan_repositories pr
+		 JOIN plans p ON p.id = pr.plan_id
+		 JOIN repositories r ON r.id = pr.repository_id
+		 LEFT JOIN features f ON f.plan_id = pr.plan_id AND f.repository_id = pr.repository_id
+		 LEFT JOIN verifications v ON v.id = (SELECT MAX(id) FROM verifications WHERE feature_id = f.id)
+		 WHERE r.installation_id IN (${placeholders}) AND p.archived = 0
+		 ORDER BY pr.plan_id, pr.position`,
+  )
+    .bind(...installationIds)
     .all<TaskRepoStatusRow>();
   return res.results;
 }

--- a/src/data/performance.ts
+++ b/src/data/performance.ts
@@ -1,0 +1,124 @@
+import { env } from 'cloudflare:workers';
+import { isJsonArray, isNumber, parseJson } from '../shared/json.ts';
+
+export interface InstallationAccessSnapshot {
+  installationIds: number[];
+  verifiedAt: number;
+}
+
+export async function installationAccessSnapshot(
+  userId: string,
+): Promise<InstallationAccessSnapshot | null> {
+  const row = await env.DB.prepare(
+    'SELECT installation_ids, verified_at FROM user_installation_access WHERE user_id = ?1',
+  )
+    .bind(userId)
+    .first<{ installation_ids: string; verified_at: string }>();
+  if (!row) return null;
+  let parsed;
+  try {
+    parsed = parseJson(row.installation_ids);
+  } catch {
+    return null;
+  }
+  if (!isJsonArray(parsed)) return null;
+  const installationIds = parsed.filter(isNumber);
+  if (installationIds.length !== parsed.length || !installationIds.every(Number.isInteger)) {
+    return null;
+  }
+  const verifiedAt = Date.parse(`${row.verified_at.replace(' ', 'T')}Z`);
+  if (!Number.isFinite(verifiedAt)) return null;
+  return { installationIds, verifiedAt };
+}
+
+export async function storeInstallationAccessSnapshot(
+  userId: string,
+  installationIds: number[],
+): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO user_installation_access (user_id, installation_ids, verified_at)
+		 VALUES (?1, ?2, CURRENT_TIMESTAMP)
+		 ON CONFLICT(user_id) DO UPDATE SET installation_ids = ?2, verified_at = CURRENT_TIMESTAMP`,
+  )
+    .bind(userId, JSON.stringify(installationIds))
+    .run();
+}
+
+export interface RepositoryRefRow {
+  repository_id: number;
+  ref: string;
+  head_sha: string;
+  pushed_at: string;
+}
+
+export async function recordRepositoryRef(
+  repositoryId: number,
+  ref: string,
+  headSha: string,
+  pushedAt: string,
+): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO repository_refs (repository_id, ref, head_sha, pushed_at)
+		 VALUES (?1, ?2, ?3, ?4)
+		 ON CONFLICT(repository_id, ref)
+		 DO UPDATE SET head_sha = ?3, pushed_at = ?4`,
+  )
+    .bind(repositoryId, ref, headSha, pushedAt)
+    .run();
+}
+
+export async function deleteRepositoryRef(repositoryId: number, ref: string): Promise<void> {
+  await env.DB.prepare('DELETE FROM repository_refs WHERE repository_id = ?1 AND ref = ?2')
+    .bind(repositoryId, ref)
+    .run();
+}
+
+export async function repositoryRef(
+  repositoryId: number,
+  ref: string,
+): Promise<RepositoryRefRow | null> {
+  return env.DB.prepare('SELECT * FROM repository_refs WHERE repository_id = ?1 AND ref = ?2')
+    .bind(repositoryId, ref)
+    .first<RepositoryRefRow>();
+}
+
+export async function repositoryRefs(repositoryId: number): Promise<RepositoryRefRow[]> {
+  const rows = await env.DB.prepare(
+    'SELECT * FROM repository_refs WHERE repository_id = ?1 ORDER BY ref',
+  )
+    .bind(repositoryId)
+    .all<RepositoryRefRow>();
+  return rows.results;
+}
+
+export async function claimInstallationRepoSync(
+  installationId: number,
+  intervalMinutes = 5,
+): Promise<boolean> {
+  const row = await env.DB.prepare(
+    `INSERT INTO installation_repo_sync (installation_id, syncing_until)
+		 VALUES (?1, datetime('now', '+5 minutes'))
+		 ON CONFLICT(installation_id) DO UPDATE SET syncing_until = datetime('now', '+5 minutes')
+		 WHERE (syncing_until IS NULL OR syncing_until < CURRENT_TIMESTAMP)
+		   AND (last_synced_at IS NULL OR last_synced_at < datetime('now', '-' || ?2 || ' minutes'))
+		 RETURNING installation_id`,
+  )
+    .bind(installationId, intervalMinutes)
+    .first<{ installation_id: number }>();
+  return row !== null;
+}
+
+export async function finishInstallationRepoSync(
+  installationId: number,
+  success: boolean,
+): Promise<void> {
+  await env.DB.prepare(
+    success
+      ? `UPDATE installation_repo_sync
+		   SET last_synced_at = CURRENT_TIMESTAMP, syncing_until = NULL
+		   WHERE installation_id = ?1`
+      : `UPDATE installation_repo_sync SET syncing_until = NULL WHERE installation_id = ?1`,
+  )
+    .bind(installationId)
+    .run();
+}

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -7,6 +7,8 @@ import { formatUnmetCriteriaFindings, type CriterionResult } from '../domain/ver
 import {
   agentUsageForMonth,
   automationUsageForMonth,
+  boardTaskRepoStatuses,
+  boardTodoRepositories,
   closeChangeRequest,
   countReviews,
   createAgent,
@@ -74,6 +76,7 @@ import {
   pipelineCostByMonth,
   pipelineCostForMonth,
   repoUsageForMonth,
+  repositoryRef,
   resolveAgentEnabled,
   resolveSkillEnabled,
   setRepoConnectionLink,
@@ -90,7 +93,6 @@ import {
   setRepoSkillEnabled,
   setTaskRunnerModel,
   setTodoRepositories,
-  todoRepositoriesForTodos,
   updateAgent,
   updateAutomation,
   updateFeature,
@@ -109,10 +111,16 @@ import {
   resolveConnectionAuth,
   startOAuthConnect,
 } from '../services/connections.ts';
+import { notifyInstallationsLive } from '../services/live-updates.ts';
 import { transcriptKey } from '../ai/runtime/agent-runs.ts';
 import { isRunnerModel } from '../shared/runner-models.ts';
 import { computeNextRunAt } from '../domain/automation-schedule.ts';
-import { requireUser, userCanPushToRepo, userIsGithubOrgAdmin } from '../services/auth.ts';
+import {
+  githubTokenForUser,
+  requireUser,
+  userCanPushToRepo,
+  userIsGithubOrgAdmin,
+} from '../services/auth.ts';
 import { APIError } from 'better-auth';
 import { auth } from '../integrations/auth/better-auth.ts';
 import { certificateUrl } from '../services/certificates.ts';
@@ -179,6 +187,7 @@ import type {
   ApiChatList,
   ApiConnectionTest,
   ApiFeatureDetail,
+  ApiFeatureDiff,
   ApiIntegrations,
   ApiInvitation,
   ApiMe,
@@ -196,6 +205,58 @@ import type {
   ApiFileSave,
   ApiRepoCode,
 } from '../shared/api-types.ts';
+
+interface DeferredExecution {
+  waitUntil(promise: Promise<void>): void;
+}
+
+const fallbackExecution: DeferredExecution = {
+  waitUntil(promise) {
+    // Hono's direct-request test harness has no Worker ExecutionContext.
+    // The operation has already started; consume a background rejection so
+    // response semantics remain the same as production waitUntil.
+    void promise.catch(() => {});
+  },
+};
+
+function deferredExecution(c: Context): DeferredExecution {
+  try {
+    return c.executionCtx;
+  } catch {
+    return fallbackExecution;
+  }
+}
+
+async function immutableRepoJson<T>(
+  executionCtx: DeferredExecution,
+  cacheKey: string | null,
+  load: () => Promise<T>,
+): Promise<T> {
+  if (!cacheKey) return load();
+  const request = new Request(`https://repo-read-cache.turbodiff.internal/${cacheKey}`);
+  try {
+    const cached = await caches.default.match(request);
+    if (cached) return cached.json<T>();
+  } catch {
+    // Cache API is best-effort (and absent in some unit harnesses).
+  }
+  const value = await load();
+  try {
+    executionCtx.waitUntil(
+      caches.default
+        .put(
+          request,
+          Response.json(value, {
+            headers: { 'cache-control': 'public, max-age=31536000, immutable' },
+          }),
+        )
+        .catch(() => {}),
+    );
+  } catch {
+    // The read result remains valid when the edge cache is unavailable.
+  }
+  return value;
+}
 
 // JSON API for the SPA (src/client). Session-cookie authed — the same
 // requireUser gate as the old server-rendered pages, but failures answer
@@ -247,6 +308,28 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
   const orgAdmin = dependencies.orgAdmin ?? userIsGithubOrgAdmin;
   const enqueueFactory = dependencies.enqueueFactory ?? enqueueFactoryMessage;
 
+  // Every API response exposes its Worker time to DevTools. Slow paths emit a
+  // structured event into Workers Observability with a stable 250ms budget.
+  app.use('*', async (c, next) => {
+    const started = performance.now();
+    await next();
+    const durationMs = performance.now() - started;
+    if (c.res.status !== 101) {
+      c.res.headers.append('server-timing', `worker;dur=${durationMs.toFixed(1)}`);
+    }
+    if (durationMs >= 250) {
+      console.warn(
+        JSON.stringify({
+          event: 'api_latency_budget_exceeded',
+          method: c.req.method,
+          path: c.req.path,
+          status: c.res.status,
+          duration_ms: Math.round(durationMs),
+        }),
+      );
+    }
+  });
+
   // CSRF gate for the cookie-authed data plane: browsers attach Origin to
   // every POST (same-origin and cross-site alike), so a mismatched Origin is
   // a forged cross-site request regardless of cookie SameSite behavior —
@@ -264,10 +347,26 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
     await next();
   });
 
+  // Successful writes publish a tiny invalidation to this user's
+  // installation hubs. The RPC is deferred so mutation latency never waits
+  // for connected browsers; background jobs can call the same service.
+  app.use('*', async (c, next) => {
+    await next();
+    if (SAFE_METHODS.has(c.req.method) || c.req.path === '/performance' || c.res.status >= 400) {
+      return;
+    }
+    deferredExecution(c).waitUntil(
+      notifyInstallationsLive(c.get('user').installationIds).catch((err) => {
+        console.warn('turbodiff: live write invalidation failed', err);
+      }),
+    );
+  });
+
   app.use('*', async (c, next) => {
     const user = await authenticate(c.req.raw);
     if (!user) return c.json({ error: 'unauthorized' }, 401);
     c.set('user', user);
+    if (user.membershipRefresh) deferredExecution(c).waitUntil(user.membershipRefresh());
     await next();
   });
 
@@ -300,7 +399,44 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
       github_connected: user.githubConnected,
       github_app_slug: env.GITHUB_APP_SLUG,
       vapid_public_key: env.VAPID_PUBLIC_KEY,
+      installation_ids: user.installationIds,
     });
+  });
+
+  app.get('/live/:installationId', async (c) => {
+    const installationId = Number(c.req.param('installationId'));
+    const origin = c.req.header('origin');
+    if (origin && origin !== new URL(c.req.url).origin) {
+      return c.json({ error: 'cross-origin websocket rejected' }, 403);
+    }
+    if (
+      !Number.isInteger(installationId) ||
+      !c.get('user').installationIds.includes(installationId)
+    ) {
+      return c.json({ error: 'unknown installation' }, 404);
+    }
+    return await env.LIVE_UPDATES.getByName(String(installationId)).fetch(c.req.raw);
+  });
+
+  app.post('/performance', async (c) => {
+    const body = await c.req.json<JsonObject>().catch(() => null);
+    if (!body || !isString(body.path) || !isJsonObject(body.metrics)) {
+      return c.json({ error: 'invalid performance sample' }, 400);
+    }
+    const allowed = new Set(['ttfb', 'dom_interactive', 'lcp', 'inp', 'cls']);
+    const metrics = Object.fromEntries(
+      Object.entries(body.metrics).filter(
+        ([name, value]) => allowed.has(name) && isNumber(value) && Number.isFinite(value),
+      ),
+    );
+    console.log(
+      JSON.stringify({
+        event: 'client_performance',
+        path: body.path.slice(0, 160),
+        metrics,
+      }),
+    );
+    return c.json({ ok: true });
   });
 
   // Web Push subscription (src/services/push-notifications.ts). Body shape matches
@@ -459,49 +595,75 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
 
   app.get('/board', async (c) => {
     const { installationIds } = c.get('user');
-    // The board deliberately shows /api/usage's pipeline figure, not the
-    // review-only one dashboardStats computes — same number, both surfaces.
-    const [groups, plans, todos, stats, pipelineCost] = await Promise.all([
-      listInstallationsWithRepos(installationIds),
-      listPlansForInstallations(installationIds),
-      listTodos(installationIds),
-      dashboardStats(installationIds),
-      pipelineCostForMonth(installationIds, currentMonth()),
-    ]);
-    // Batched per-task/per-todo repo reads — one query each, not per-row.
-    const [repoStatuses, todoRepos] = await Promise.all([
-      getTaskRepoStatuses(plans.map((p) => p.id)),
-      todoRepositoriesForTodos(todos.map((t) => t.id)),
-    ]);
-    return c.json<ApiBoard>({
-      stats: { month_pipeline_cost_usd: pipelineCost, running: stats.running },
-      todos: todos.map((t) => ({
-        id: t.id,
-        installation_id: t.installation_id,
-        title: t.title,
-        notes: t.notes,
-        created_at: t.created_at,
-        repos: todoRepos
-          .filter((r) => r.todo_id === t.id)
-          .map((r) => ({ id: r.repository_id, owner: r.owner, name: r.name })),
-      })),
-      tasks: plans
-        .filter((p) => p.archived !== 1)
-        .map((p) => serializeTask(p, repoStatuses, { includePlan: false })),
-      installations: groups.map(({ installation }) => ({
-        id: installation.id,
-        account_login: installation.account_login,
-      })),
-      repos: groups
-        .flatMap((g) => g.repos)
-        .filter((r) => r.enabled === 1)
-        .map((r) => ({
-          id: r.id,
-          owner: r.owner,
-          name: r.name,
-          installation_id: r.installation_id,
-        })),
-    });
+    const version = await factoryVersion();
+    const tenantKey = installationIds
+      .slice()
+      .sort((a, b) => a - b)
+      .join(',');
+    const board = await immutableRepoJson(
+      deferredExecution(c),
+      `board/${encodeURIComponent(tenantKey)}/${version}`,
+      async (): Promise<ApiBoard> => {
+        // All D1 rollups start in one wave. The repo-link queries are scoped
+        // directly by installation rather than waiting for plan/todo ids.
+        const [groups, plans, todos, stats, pipelineCost, repoStatuses, todoRepos] =
+          await Promise.all([
+            listInstallationsWithRepos(installationIds),
+            listPlansForInstallations(installationIds),
+            listTodos(installationIds),
+            dashboardStats(installationIds),
+            pipelineCostForMonth(installationIds, currentMonth()),
+            boardTaskRepoStatuses(installationIds),
+            boardTodoRepositories(installationIds),
+          ]);
+        const statusesByPlan = new Map<number, typeof repoStatuses>();
+        for (const status of repoStatuses) {
+          const rows = statusesByPlan.get(status.plan_id) ?? [];
+          rows.push(status);
+          statusesByPlan.set(status.plan_id, rows);
+        }
+        const reposByTodo = new Map<number, typeof todoRepos>();
+        for (const repo of todoRepos) {
+          const rows = reposByTodo.get(repo.todo_id) ?? [];
+          rows.push(repo);
+          reposByTodo.set(repo.todo_id, rows);
+        }
+        return {
+          stats: { month_pipeline_cost_usd: pipelineCost, running: stats.running },
+          todos: todos.map((todo) => ({
+            id: todo.id,
+            installation_id: todo.installation_id,
+            title: todo.title,
+            notes: todo.notes,
+            created_at: todo.created_at,
+            repos: (reposByTodo.get(todo.id) ?? []).map((repo) => ({
+              id: repo.repository_id,
+              owner: repo.owner,
+              name: repo.name,
+            })),
+          })),
+          tasks: plans
+            .filter((plan) => plan.archived !== 1)
+            .map((plan) =>
+              serializeTask(plan, statusesByPlan.get(plan.id) ?? [], { includePlan: false }),
+            ),
+          installations: groups.map(({ installation }) => ({
+            id: installation.id,
+            account_login: installation.account_login,
+          })),
+          repos: groups
+            .flatMap((group) => group.repos)
+            .filter((repo) => repo.enabled === 1)
+            .map((repo) => ({
+              id: repo.id,
+              owner: repo.owner,
+              name: repo.name,
+              installation_id: repo.installation_id,
+            })),
+        };
+      },
+    );
+    return c.json(board);
   });
 
   // A backlog card targets 1-3 repos from the same installation (multi-repo
@@ -886,8 +1048,15 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         const token = await installationToken(repo.installation_id);
         return c.json(await readTree(token, repo, ref, path));
       }
-      // Artifacts mints its own credential inside (resolveWorkspaceRemote).
-      return c.json(await readTreeArtifacts(repo, ref, path));
+      const recorded = await repositoryRef(repo.id, ref);
+      const data = await immutableRepoJson(
+        deferredExecution(c),
+        recorded
+          ? `artifacts/tree/${repo.id}/${recorded.head_sha}/${encodeURIComponent(path)}`
+          : null,
+        () => readTreeArtifacts(repo, ref, path),
+      );
+      return c.json(data);
     } catch (err) {
       if (err instanceof RepoBrowserError) return c.json({ error: err.message }, err.status);
       console.error('turbodiff: tree read failed:', err);
@@ -907,7 +1076,15 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         const token = await installationToken(repo.installation_id);
         return c.json(await readFile(token, repo, ref, path));
       }
-      return c.json(await readFileArtifacts(repo, ref, path));
+      const recorded = await repositoryRef(repo.id, ref);
+      const data = await immutableRepoJson(
+        deferredExecution(c),
+        recorded
+          ? `artifacts/file/${repo.id}/${recorded.head_sha}/${encodeURIComponent(path)}`
+          : null,
+        () => readFileArtifacts(repo, ref, path),
+      );
+      return c.json(data);
     } catch (err) {
       if (err instanceof RepoBrowserError) return c.json({ error: err.message }, err.status);
       console.error('turbodiff: file read failed:', err);
@@ -1038,6 +1215,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
       },
       repo: `${repo.owner}/${repo.name}`,
       provider: repo.provider,
+      diff_version: null,
       cr_number: null,
       checks: [],
       plan: null,
@@ -1063,7 +1241,6 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
       latestVerificationForFeature(feature.id),
       listCockpitComments(feature.id),
     ]);
-    const MAX_FILES = 50;
     if (repo.provider === 'artifacts') {
       // Native change request: same response shape as the GitHub path,
       // sourced from the CR row and the R2 diff cache.
@@ -1071,22 +1248,9 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         ? await getChangeRequest(feature.change_request_id)
         : null;
       if (cr) {
+        base.diff_version = cr.source_head;
         base.cr_number = cr.number;
-        const patchByPath = new Map(
-          splitPatchByFile(await getCrDiffPatch(cr)).map((f) => [f.path, f.patch]),
-        );
         const crFiles = parseCrFiles(cr);
-        base.files = crFiles.slice(0, MAX_FILES).map((f) => {
-          const filePatch = patchByPath.get(f.path);
-          return {
-            filename: f.path,
-            status: f.status,
-            additions: f.additions ?? 0,
-            deletions: f.deletions ?? 0,
-            patch: filePatch && filePatch.length < 100_000 ? filePatch : null,
-          };
-        });
-        base.more_files = Math.max(0, crFiles.length - MAX_FILES);
         base.pr = {
           state: cr.status,
           html_url: null,
@@ -1137,7 +1301,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
       // Conditional requests (githubJsonCached): between polls these three
       // reads are usually unchanged — GitHub's 304s cost no rate-limit
       // credit and skip re-downloading up to 100 file patches.
-      const [prMeta, prFiles, prReviews] = await Promise.all([
+      const [prMeta, prReviews] = await Promise.all([
         githubJsonCached<{
           state: string;
           merged: boolean;
@@ -1146,35 +1310,14 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
           deletions: number;
           changed_files: number;
           mergeable_state: string | null;
+          head: { sha: string };
         }>(token, `${ghBase}/pulls/${feature.pr_number}`),
-        githubJsonCached<
-          {
-            filename: string;
-            status: string;
-            additions: number;
-            deletions: number;
-            patch?: string;
-          }[]
-        >(token, `${ghBase}/pulls/${feature.pr_number}/files?per_page=100`),
         githubJsonCached<{ state: string; body: string; user: { login: string } | null }[]>(
           token,
           `${ghBase}/pulls/${feature.pr_number}/reviews?per_page=100`,
         ),
       ]);
 
-      // GitHub's per-file patch lacks git headers, so wrap it into a minimal
-      // single-file patch for @pierre/diffs (rendered client-side).
-      base.files = prFiles.slice(0, MAX_FILES).map((f) => ({
-        filename: f.filename,
-        status: f.status,
-        additions: f.additions,
-        deletions: f.deletions,
-        patch:
-          f.patch && f.patch.length < 100_000
-            ? `diff --git a/${f.filename} b/${f.filename}\n--- a/${f.filename}\n+++ b/${f.filename}\n${f.patch}\n`
-            : null,
-      }));
-      base.more_files = Math.max(0, prFiles.length - MAX_FILES);
       base.pr = {
         state: prMeta.merged ? 'merged' : prMeta.state,
         html_url: prMeta.html_url,
@@ -1183,6 +1326,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         changed_files: prMeta.changed_files,
         mergeable_state: prMeta.mergeable_state,
       };
+      base.diff_version = prMeta.head.sha;
       base.reviews = prReviews.map((r) => ({
         state: r.state,
         body: r.body,
@@ -1227,6 +1371,88 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
       verification?.results ?? null,
     );
     return c.json(base);
+  });
+
+  // Diff snapshot: intentionally separate from the volatile cockpit summary.
+  // Comments, checks, and run statuses can refresh without re-fetching or
+  // re-parsing hundreds of kilobytes of patches. This endpoint is loaded only
+  // after the summary has painted.
+  app.get('/factory/features/:id/diff', async (c) => {
+    const id = Number(c.req.param('id'));
+    const feature = Number.isInteger(id) ? await getFeature(id) : null;
+    const repo = feature ? await getRepoById(feature.repository_id) : null;
+    if (!feature || !repo || !c.get('user').installationIds.includes(repo.installation_id)) {
+      return c.json({ error: 'unknown feature' }, 404);
+    }
+    const rawVersion = c.req.query('v');
+    // Versioned snapshots are immutable, but only accept commit-like client
+    // versions so an authenticated caller cannot create unbounded cache keys.
+    const requestedVersion =
+      rawVersion && /^[0-9a-f]{7,64}$/i.test(rawVersion) ? rawVersion.toLowerCase() : null;
+    const artifactsCr =
+      repo.provider === 'artifacts' && feature.change_request_id
+        ? await getChangeRequest(feature.change_request_id)
+        : null;
+    const diffVersion = artifactsCr?.source_head ?? requestedVersion;
+    const empty: ApiFeatureDiff = { version: diffVersion, files: [], more_files: 0 };
+    if (!feature.pr_number) return c.json(empty);
+
+    const MAX_FILES = 50;
+    const load = async (): Promise<ApiFeatureDiff> => {
+      if (repo.provider === 'artifacts') {
+        if (!artifactsCr) return empty;
+        const patchByPath = new Map(
+          splitPatchByFile(await getCrDiffPatch(artifactsCr)).map((file) => [
+            file.path,
+            file.patch,
+          ]),
+        );
+        const crFiles = parseCrFiles(artifactsCr);
+        return {
+          version: artifactsCr.source_head,
+          files: crFiles.slice(0, MAX_FILES).map((file) => {
+            const patch = patchByPath.get(file.path);
+            return {
+              filename: file.path,
+              status: file.status,
+              additions: file.additions ?? 0,
+              deletions: file.deletions ?? 0,
+              patch: patch && patch.length < 100_000 ? patch : null,
+            };
+          }),
+          more_files: Math.max(0, crFiles.length - MAX_FILES),
+        };
+      }
+
+      const token = await installationToken(repo.installation_id);
+      const files = await githubJsonCached<
+        {
+          filename: string;
+          status: string;
+          additions: number;
+          deletions: number;
+          patch?: string;
+        }[]
+      >(token, `/repos/${repo.owner}/${repo.name}/pulls/${feature.pr_number}/files?per_page=100`);
+      return {
+        version: requestedVersion,
+        files: files.slice(0, MAX_FILES).map((file) => ({
+          filename: file.filename,
+          status: file.status,
+          additions: file.additions,
+          deletions: file.deletions,
+          patch:
+            file.patch && file.patch.length < 100_000
+              ? `diff --git a/${file.filename} b/${file.filename}\n--- a/${file.filename}\n+++ b/${file.filename}\n${file.patch}\n`
+              : null,
+        })),
+        more_files: Math.max(0, files.length - MAX_FILES),
+      };
+    };
+    const cacheKey = diffVersion
+      ? `feature-diff/${feature.id}/${encodeURIComponent(diffVersion)}`
+      : null;
+    return c.json(await immutableRepoJson(deferredExecution(c), cacheKey, load));
   });
 
   // Line-anchored review comment from the cockpit diff. This only records
@@ -1670,7 +1896,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         409,
       );
     }
-    const userToken = c.get('user').session.ghToken;
+    const userToken = await githubTokenForUser(c.get('user'));
     try {
       await mergePullRequest(userToken || appToken, repo.owner, repo.name, feature.pr_number);
     } catch (err) {
@@ -1723,7 +1949,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
     const denied = await requireRepoPush(c, repo, canPushToRepo);
     if (denied) return denied;
     const appToken = await installationToken(repo.installation_id);
-    const userToken = c.get('user').session.ghToken;
+    const userToken = await githubTokenForUser(c.get('user'));
     const closePath = `/repos/${repo.owner}/${repo.name}/pulls/${feature.pr_number}`;
     const closeBody = { method: 'PATCH' as const, body: JSON.stringify({ state: 'closed' }) };
     try {
@@ -1781,8 +2007,19 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
   // installation can enable any agent.
   app.get('/agents', async (c) => {
     const { installationIds } = c.get('user');
-    await Promise.all(installationIds.map((id) => ensureBuiltinAgents(id)));
     const agents = await listAgents(installationIds);
+    // Installation webhooks own normal seeding. Keep this best-effort repair
+    // path off the response's critical path for legacy or partially mirrored
+    // installations.
+    deferredExecution(c).waitUntil(
+      Promise.all(
+        installationIds.map((id) =>
+          ensureBuiltinAgents(id).catch((err) =>
+            console.warn(`turbodiff: agent repair failed for installation ${id}:`, err),
+          ),
+        ),
+      ).then(() => undefined),
+    );
     const seen = new Set<string>();
     return c.json<ApiAgentsList>({
       github_app_slug: env.GITHUB_APP_SLUG,
@@ -2451,14 +2688,15 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
     // Self-heal the repo mirror against GitHub — a missed
     // installation_repositories webhook otherwise leaves stale repos here
     // (and on every other page reading the repositories table) forever.
-    await Promise.all(
-      installationIds.map((id) =>
-        syncInstallationRepos(id).catch((err) =>
-          console.warn(`turbodiff: repo sync failed for installation ${id}:`, err),
+    deferredExecution(c).waitUntil(
+      Promise.all(
+        installationIds.map((id) =>
+          syncInstallationRepos(id).catch((err) =>
+            console.warn(`turbodiff: repo sync failed for installation ${id}:`, err),
+          ),
         ),
-      ),
+      ).then(() => undefined),
     );
-    await Promise.all(installationIds.map((id) => ensureBuiltinAgents(id)));
     const [groups, agents, overrides, skills, skillOverrides] = await Promise.all([
       listInstallationsWithRepos(installationIds),
       listAgents(installationIds),
@@ -2466,6 +2704,15 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
       listSkills(installationIds),
       listRepoSkillOverrides(installationIds),
     ]);
+    deferredExecution(c).waitUntil(
+      Promise.all(
+        installationIds.map((id) =>
+          ensureBuiltinAgents(id).catch((err) =>
+            console.warn(`turbodiff: agent repair failed for installation ${id}:`, err),
+          ),
+        ),
+      ).then(() => undefined),
+    );
     const overrideMap = new Map(
       overrides.map((o) => [`${o.repository_id}:${o.agent_id}`, o.enabled]),
     );

--- a/src/http/api.worker.test.ts
+++ b/src/http/api.worker.test.ts
@@ -20,7 +20,7 @@ type Authenticate = NonNullable<ApiRouteDependencies['authenticate']>;
 const testEnv = env as TestEnv;
 
 const acmeUser: AuthedUser = {
-  session: { userId: 3001, login: 'octocat', ghToken: 'test-user-token' },
+  session: { authUserId: 'user-3001', userId: 3001, login: 'octocat' },
   installationIds: [1001],
   githubConnected: true,
   name: 'octocat',
@@ -86,6 +86,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   const tables = [
+    'repository_refs',
     'push_subscriptions',
     'chat_messages',
     'todo_repositories',
@@ -701,6 +702,19 @@ describe('cockpit chat', () => {
     const list = await app.request(`https://turbodiff.test/api/factory/features/${foreignId}/chat`);
     expect(list.status).toBe(404);
     expect((await postChat(app, foreignId, 'hello')).status).toBe(404);
+    expect(
+      (await app.request(`https://turbodiff.test/api/factory/features/${foreignId}/diff?v=abcdef1`))
+        .status,
+    ).toBe(404);
+  });
+
+  it('does not cache arbitrary client-provided diff versions', async () => {
+    const featureId = await seedFeature(101, 'generating', null);
+    const response = await chatApp().request(
+      `https://turbodiff.test/api/factory/features/${featureId}/diff?v=not-a-commit`,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ version: null, files: [], more_files: 0 });
   });
 
   it('rejects an empty message body', async () => {
@@ -785,6 +799,7 @@ describe('push subscriptions', () => {
     expect(response.status).toBe(200);
     const me = parseJson(await response.text());
     expect(isJsonObject(me) && isString(me.vapid_public_key)).toBe(true);
+    expect(isJsonObject(me) && me.installation_ids).toEqual([1001]);
   });
 
   it('upserts a subscription row for the signed-in user', async () => {

--- a/src/http/mcp.worker.test.ts
+++ b/src/http/mcp.worker.test.ts
@@ -23,7 +23,7 @@ type EnqueueFactory = NonNullable<McpRouteDependencies['enqueueFactory']>;
 const testEnv = env as TestEnv;
 
 const acmeUser: AuthedUser = {
-  session: { userId: 3001, login: 'octocat', ghToken: 'test-user-token' },
+  session: { authUserId: 'user-3001', userId: 3001, login: 'octocat' },
   installationIds: [1001],
   githubConnected: true,
   name: 'octocat',

--- a/src/http/ui.ts
+++ b/src/http/ui.ts
@@ -2,6 +2,7 @@ import { env } from 'cloudflare:workers';
 import { Hono, type Context } from 'hono';
 import { deleteCookie } from 'hono/cookie';
 import { auth } from '../integrations/auth/better-auth.ts';
+import { isJsonArray, isJsonObject, isString, parseJson } from '../shared/json.ts';
 import { renderAuthPage } from './auth-page.tsx';
 import { renderLanding } from './landing.tsx';
 
@@ -15,13 +16,97 @@ import { renderLanding } from './landing.tsx';
 // nothing stale lingers after the migration.
 const LEGACY_SESSION_COOKIE = 'turbodiff_session';
 
-// The shell references fixed asset names (no content hashes) so it can be a
-// static string here; see build.rollupOptions in vite.client.config.ts.
-// Boot-critical resources are declared up front: fonts are self-hosted
-// (public/fonts — no render-blocking cross-origin stylesheet), app.js is
-// modulepreloaded, and the route's API payload is preloaded so the data
-// round-trip overlaps the JS parse instead of following it.
-function shell(preload: string[]): string {
+interface ClientAsset {
+  file: string;
+  css: string[];
+  imports: string[];
+  isEntry: boolean;
+}
+
+type ClientManifest = Map<string, ClientAsset>;
+let manifestPromise: Promise<ClientManifest> | null = null;
+
+function clientManifest(value: ReturnType<typeof parseJson>): ClientManifest {
+  if (!isJsonObject(value)) throw new Error('client asset manifest is not an object');
+  const manifest = new Map<string, ClientAsset>();
+  for (const [key, raw] of Object.entries(value)) {
+    if (!isJsonObject(raw) || !isString(raw.file)) continue;
+    manifest.set(key, {
+      file: raw.file,
+      css: isJsonArray(raw.css) ? raw.css.filter(isString) : [],
+      imports: isJsonArray(raw.imports) ? raw.imports.filter(isString) : [],
+      isEntry: raw.isEntry === true,
+    });
+  }
+  return manifest;
+}
+
+async function loadClientManifest(c: Context): Promise<ClientManifest> {
+  // Static assets and Worker code deploy atomically, so one parsed manifest
+  // is valid for this isolate's lifetime. Share the in-flight read too: a
+  // burst of cold shell requests should parse the 200KB manifest once.
+  manifestPromise ??= (async () => {
+    const url = new URL('/app/manifest.json', c.req.url);
+    const response = await env.ASSETS.fetch(url);
+    if (!response.ok) throw new Error(`client asset manifest returned ${response.status}`);
+    return clientManifest(parseJson(await response.text()));
+  })();
+  try {
+    return await manifestPromise;
+  } catch (err) {
+    manifestPromise = null;
+    throw err;
+  }
+}
+
+function manifestAsset(manifest: ClientManifest, suffix: string): string | null {
+  const hit = [...manifest].find(([key]) => key.endsWith(suffix));
+  return hit?.[0] ?? null;
+}
+
+function routeAsset(path: string): string | null {
+  if (path === '/') return 'src/client/pages/board.tsx';
+  if (/^\/tasks\/\d+$/.test(path)) return 'src/client/pages/task.tsx';
+  if (/^\/factory\/features\/\d+$/.test(path)) return 'src/client/pages/feature.tsx';
+  if (/^\/repos\/-?\d+\/code(?:\/.*)?$/.test(path)) return 'src/client/pages/code.tsx';
+  if (path === '/usage') return 'src/client/pages/usage.tsx';
+  if (path === '/integrations') return 'src/client/pages/integrations.tsx';
+  if (path === '/agents') return 'src/client/pages/agents.tsx';
+  if (path === '/skills') return 'src/client/pages/skills.tsx';
+  if (path === '/automations') return 'src/client/pages/automations.tsx';
+  if (path === '/settings') return 'src/client/pages/settings.tsx';
+  if (path === '/onboarding') return 'src/client/pages/onboarding.tsx';
+  return null;
+}
+
+function clientAssets(manifest: ClientManifest, path: string) {
+  const entryKey = [...manifest].find(([, asset]) => asset.isEntry)?.[0];
+  if (!entryKey) throw new Error('client asset manifest has no entry');
+  const routeSuffix = routeAsset(path);
+  const routeKey = routeSuffix ? manifestAsset(manifest, routeSuffix) : null;
+  const pending = [entryKey, ...(routeKey ? [routeKey] : [])];
+  const visited = new Set<string>();
+  const scripts = new Set<string>();
+  const styles = new Set<string>();
+  while (pending.length > 0) {
+    const key = pending.pop();
+    if (!key || visited.has(key)) continue;
+    visited.add(key);
+    const asset = manifest.get(key);
+    if (!asset) continue;
+    scripts.add(`/app/${asset.file}`);
+    for (const css of asset.css) styles.add(`/app/${css}`);
+    pending.push(...asset.imports);
+  }
+  const entry = manifest.get(entryKey);
+  if (!entry) throw new Error('client asset manifest entry is missing');
+  return { entry: `/app/${entry.file}`, scripts: [...scripts], styles: [...styles] };
+}
+
+// Boot-critical resources are declared up front: fonts are self-hosted,
+// Vite's content-hashed entry and active route chunks are modulepreloaded,
+// and the route's API payload overlaps JS parse instead of following it.
+function shell(preload: string[], assets: ReturnType<typeof clientAssets>): string {
   return `<!doctype html>
 <html lang="en">
 	<head>
@@ -33,12 +118,12 @@ function shell(preload: string[]): string {
 		<link rel="manifest" href="/manifest.webmanifest" />
 		<link rel="apple-touch-icon" href="/logo.png" />
 		<meta name="theme-color" content="#3fb950" />
-		<link rel="modulepreload" href="/app/app.js" />
+${assets.scripts.map((path) => `\t\t<link rel="modulepreload" href="${path}" />`).join('\n')}
 		<link rel="preload" href="/fonts/ibm-plex-sans-normal-400-latin.woff2" as="font" type="font/woff2" crossorigin />
 		<link rel="preload" href="/fonts/ibm-plex-mono-normal-400-latin.woff2" as="font" type="font/woff2" crossorigin />
 ${preload.map((path) => `\t\t<link rel="preload" href="${path}" as="fetch" />`).join('\n')}
 		<link rel="stylesheet" href="/fonts/fonts.css" />
-		<link rel="stylesheet" href="/app/app.css" />
+${assets.styles.map((path) => `\t\t<link rel="stylesheet" href="${path}" />`).join('\n')}
 		<style>
 			html { background: #0f1318; }
 			/* Static splash inside #root, painted before app.js runs; React's
@@ -69,7 +154,7 @@ ${preload.map((path) => `\t\t<link rel="preload" href="${path}" as="fetch" />`).
 				<span>Loading<span class="cursor">_</span></span>
 			</div>
 		</div>
-		<script type="module" src="/app/app.js"></script>
+		<script type="module" src="${assets.entry}"></script>
 	</body>
 </html>`;
 }
@@ -77,7 +162,7 @@ ${preload.map((path) => `\t\t<link rel="preload" href="${path}" as="fetch" />`).
 // Which API payload each SPA route needs first — preloaded from the shell so
 // the browser has the response (or most of it) by the time app.js asks.
 // /api/me rides on every shell; per-route payloads keep the preload honest.
-function shellForPath(path: string): string {
+async function shellForPath(c: Context, path: string): Promise<string> {
   const preload = ['/api/me'];
   if (path === '/') preload.push('/api/board');
   else if (path === '/settings') preload.push('/api/settings');
@@ -87,7 +172,12 @@ function shellForPath(path: string): string {
   else if (path === '/skills') preload.push('/api/skills');
   else if (path === '/automations') preload.push('/api/automations');
   else if (/^\/tasks\/\d+$/.test(path)) preload.push(`/api${path}`);
-  return shell(preload);
+  else if (/^\/factory\/features\/\d+$/.test(path)) preload.push(`/api${path}`);
+  else {
+    const code = path.match(/^\/repos\/(-?\d+)\/code(?:\/.*)?$/);
+    if (code) preload.push(`/api/repos/${code[1]}/code`);
+  }
+  return shell(preload, clientAssets(await loadClientManifest(c), path));
 }
 
 // Cheap shell gate: a live better-auth session (cookie-cached — no D1 read
@@ -197,7 +287,7 @@ export function createUiRoutes() {
 
   app.get('/', async (c) => {
     if (!(await hasSession(c))) return c.html(renderLanding());
-    return c.html(shellForPath('/'));
+    return c.html(await shellForPath(c, '/'));
   });
 
   // Every SPA route the client router owns. Unauthenticated hits start OAuth,
@@ -224,7 +314,7 @@ export function createUiRoutes() {
   ]) {
     app.get(path, async (c) => {
       if (!(await hasSession(c))) return c.redirect('/auth/login');
-      return c.html(shellForPath(new URL(c.req.url).pathname));
+      return c.html(await shellForPath(c, new URL(c.req.url).pathname));
     });
   }
 

--- a/src/integrations/artifacts/content.ts
+++ b/src/integrations/artifacts/content.ts
@@ -1,0 +1,140 @@
+import { env } from 'cloudflare:workers';
+import type { RepositoryRow } from '../../data/db.ts';
+import type { ApiRepoTree, ApiTreeEntry } from '../../shared/api-types.ts';
+import { isJsonObject, isNumber, isString, type JsonValue } from '../../shared/json.ts';
+
+// Cloudflare's live Artifacts binding documentation includes these content
+// methods, but Wrangler 4.120's generated declarations lag that surface. Keep
+// the temporary augmentation narrow and validate every returned value at the
+// RPC boundary. Once Wrangler generates them, declaration merging becomes a
+// no-op and this block can be removed.
+declare global {
+  interface ArtifactsRepo {
+    log(options?: { ref?: string; limit?: number; offset?: number }): Promise<JsonValue>;
+    readCommit(hash: string): Promise<JsonValue>;
+    readTree(hash: string): Promise<JsonValue>;
+  }
+}
+
+interface ContentEntry {
+  name: string;
+  sha: string;
+  type: ApiTreeEntry['type'];
+  size: number | null;
+}
+
+function stringField(value: JsonValue | undefined, ...keys: string[]): string | null {
+  if (!isJsonObject(value)) return null;
+  for (const key of keys) {
+    if (isString(value[key]) && value[key]) return value[key];
+  }
+  return null;
+}
+
+function nestedHash(value: JsonValue, key: string): string | null {
+  if (!isJsonObject(value)) return null;
+  const nested = value[key];
+  return stringField(nested, 'hash', 'sha', 'id') ?? (isString(nested) ? nested : null);
+}
+
+function commitHash(log: JsonValue): string | null {
+  const rows = Array.isArray(log)
+    ? log
+    : isJsonObject(log) && Array.isArray(log.commits)
+      ? log.commits
+      : isJsonObject(log) && Array.isArray(log.entries)
+        ? log.entries
+        : [];
+  return stringField(rows[0], 'hash', 'sha', 'id', 'oid');
+}
+
+function commitTreeHash(commit: JsonValue): string | null {
+  return nestedHash(commit, 'tree') ?? stringField(commit, 'treeHash', 'tree_hash');
+}
+
+function contentEntries(tree: JsonValue): ContentEntry[] | null {
+  const rows = Array.isArray(tree)
+    ? tree
+    : isJsonObject(tree) && Array.isArray(tree.entries)
+      ? tree.entries
+      : isJsonObject(tree) && Array.isArray(tree.tree)
+        ? tree.tree
+        : null;
+  if (!rows) return null;
+  const entries: ContentEntry[] = [];
+  for (const row of rows) {
+    if (!isJsonObject(row)) return null;
+    const name = stringField(row, 'name', 'path');
+    const sha = stringField(row, 'hash', 'sha', 'id', 'oid');
+    const rawType = stringField(row, 'type', 'kind') ?? '';
+    if (!name || !sha) return null;
+    const type: ApiTreeEntry['type'] =
+      rawType === 'tree' || rawType === 'dir'
+        ? 'dir'
+        : rawType === 'commit' || rawType === 'submodule'
+          ? 'submodule'
+          : rawType === 'symlink'
+            ? 'symlink'
+            : 'file';
+    const rawSize = row.size;
+    entries.push({
+      name: name.split('/').at(-1) ?? name,
+      sha,
+      type,
+      size: type === 'dir' ? null : isNumber(rawSize) ? rawSize : null,
+    });
+  }
+  return entries;
+}
+
+/**
+ * Reads one directory through the Artifacts binding. Null means the deployed
+ * binding has not caught up to the documented content surface or returned an
+ * unrecognized beta shape; callers transparently use the git-mirror fallback.
+ */
+export async function readArtifactsTreeDirect(
+  repo: RepositoryRow,
+  ref: string,
+  path: string,
+  knownHeadSha?: string,
+): Promise<ApiRepoTree | null> {
+  if (!repo.artifacts_repo) return null;
+  try {
+    const handle = await env.GIT_ARTIFACTS.get(repo.artifacts_repo);
+    const head = knownHeadSha ?? commitHash(await handle.log({ ref, limit: 1, offset: 0 }));
+    if (!head) return null;
+    let treeHash = commitTreeHash(await handle.readCommit(head));
+    if (!treeHash) return null;
+
+    for (const segment of path.split('/').filter(Boolean)) {
+      const children = contentEntries(await handle.readTree(treeHash));
+      const child = children?.find((entry) => entry.name === segment && entry.type === 'dir');
+      if (!child) return null;
+      treeHash = child.sha;
+    }
+
+    const children = contentEntries(await handle.readTree(treeHash));
+    if (!children) return null;
+    const entries = children.map<ApiTreeEntry>((entry) => ({
+      name: entry.name,
+      path: path ? `${path}/${entry.name}` : entry.name,
+      type: entry.type,
+      size: entry.size,
+      sha: entry.sha,
+    }));
+    entries.sort(
+      (a, b) =>
+        (a.type === 'dir' ? 0 : 1) - (b.type === 'dir' ? 0 : 1) || a.name.localeCompare(b.name),
+    );
+    return { path, entries };
+  } catch (err) {
+    console.warn(
+      JSON.stringify({
+        message: 'artifacts binding content read fell back to sandbox mirror',
+        repo: repo.artifacts_repo,
+        detail: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return null;
+  }
+}

--- a/src/live-updates.ts
+++ b/src/live-updates.ts
@@ -1,0 +1,33 @@
+import { DurableObject } from 'cloudflare:workers';
+
+/** Hibernating, installation-scoped invalidation hub for the signed-in SPA. */
+export class LiveUpdates extends DurableObject<Env> {
+  async fetch(request: Request): Promise<Response> {
+    if (request.headers.get('upgrade')?.toLowerCase() !== 'websocket') {
+      return new Response('websocket upgrade required', { status: 426 });
+    }
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    this.ctx.acceptWebSocket(server);
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  broadcast(): void {
+    const message = JSON.stringify({ type: 'invalidate', at: Date.now() });
+    for (const socket of this.ctx.getWebSockets()) {
+      try {
+        socket.send(message);
+      } catch {
+        socket.close(1011, 'send failed');
+      }
+    }
+  }
+
+  webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): void {
+    // A tiny client heartbeat proves the connection is still usable after a
+    // network transition without creating an application-level subscription.
+    if (message === '{"type":"ping"}') {
+      socket.send('{"type":"pong"}');
+    }
+  }
+}

--- a/src/services/access-control.ts
+++ b/src/services/access-control.ts
@@ -172,7 +172,7 @@ async function ensureGithubAdminOwner(
   accountLogin: string,
   isOrgAdmin: typeof userIsGithubOrgAdmin,
 ): Promise<void> {
-  if (user.devFake || !user.session.ghToken) return;
+  if (user.devFake) return;
   if (await hasMemberRow(organizationId, user.session.userId)) return;
   if (!(await isOrgAdmin(user, accountLogin))) return;
   await ensureOwnerMember(organizationId, user.session.userId);

--- a/src/services/artifacts.ts
+++ b/src/services/artifacts.ts
@@ -21,6 +21,7 @@ import {
   ARTIFACTS_REPO_DELETED,
   type ArtifactsEvent,
 } from '../shared/artifacts-events.ts';
+import { deleteRepositoryRef, recordRepositoryRef } from '../data/performance.ts';
 import { listChangeRequestsForRepo } from '../data/db.ts';
 import { refreshChangeRequest } from './change-requests.ts';
 import { enqueueFactoryMessage } from './factory-queue.ts';
@@ -170,16 +171,16 @@ export async function mintArtifactsCloneToken(
 // must stay idempotent (workflow steps can be retried).
 export async function applyArtifactsEvent(event: ArtifactsEvent): Promise<string> {
   if (isArtifactsPushedEvent(event)) {
-    const row = await recordArtifactsPush(
-      event.repoName,
-      event.eventTimestamp ?? new Date().toISOString(),
-    );
+    const pushedAt = event.eventTimestamp ?? new Date().toISOString();
+    const row = await recordArtifactsPush(event.repoName, pushedAt);
     if (!row) return `push to untracked repo ${event.repoName} ignored`;
     // Native CR upkeep — the PR-synchronize webhook replacement: a moved
     // source branch refreshes its CR (and re-reviews when the repo opted
     // into review-on-push); a moved target branch (e.g. a merge landed)
     // refreshes every open CR against it.
     const branch = event.ref.replace(/^refs\/heads\//, '');
+    if (/^0+$/.test(event.after)) await deleteRepositoryRef(row.id, branch);
+    else await recordRepositoryRef(row.id, branch, event.after, pushedAt);
     let refreshed = 0;
     for (const cr of await listChangeRequestsForRepo(row.id, 'open')) {
       if (cr.source_branch !== branch && cr.target_branch !== branch) continue;

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,5 +1,9 @@
 import { env } from 'cloudflare:workers';
 import { auth, type AuthUser } from '../integrations/auth/better-auth.ts';
+import {
+  installationAccessSnapshot,
+  storeInstallationAccessSnapshot,
+} from '../data/performance.ts';
 import { syntheticInstallationIds } from './access-control.ts';
 import {
   fetchUserCanPush,
@@ -22,12 +26,16 @@ export type AuthedUser = {
   // repo-scoped query answers empty and every push check fails closed; the
   // attribution paths that read userId/login all sit behind an installation
   // check a GitHub-less user can't pass.
-  session: { userId: number; login: string; ghToken: string };
+  session: { authUserId: string; userId: number; login: string };
   installationIds: number[];
   githubConnected: boolean;
   // Display identity for the shell — the GitHub login when connected, the
   // sign-up name otherwise.
   name: string;
+  // A stale-but-authorized request may refresh its durable membership
+  // snapshot after responding. HTTP middleware attaches this to waitUntil;
+  // non-HTTP callers simply use the bounded stale snapshot.
+  membershipRefresh?: () => Promise<void>;
   // Local DEV_FAKE_INSTALLATIONS session — no GitHub token to verify repo
   // permissions with, so permission checks pass by construction.
   devFake?: boolean;
@@ -42,6 +50,7 @@ const INSTALLATIONS_TTL_MS = 5 * 60_000;
 const INSTALLATIONS_STALE_MAX_MS = 60 * 60_000;
 const tokenCache = new Map<string, { token: string; exp: number }>();
 const installationsCache = new Map<string, { ids: number[]; fetchedAt: number }>();
+const installationRefreshes = new Map<string, Promise<number[] | null>>();
 // Synthetic (Artifacts) installation ids were the one uncached D1 read on
 // every API request — same TTL discipline as the GitHub installation list,
 // with the same bounded staleness on membership revocation.
@@ -78,20 +87,70 @@ async function githubToken(userId: string): Promise<string> {
 // GitHub-verified installation ids, cached for 5 minutes and served stale
 // (up to an hour) when GitHub is unreachable. Null only when there is no
 // answer at all — fresh fetch failed and nothing usable is cached.
-async function installationIds(userId: string, ghToken: string): Promise<number[] | null> {
-  const cached = installationsCache.get(userId);
-  if (cached && Date.now() - cached.fetchedAt < INSTALLATIONS_TTL_MS) return cached.ids;
-  if (ghToken) {
+async function refreshInstallationIds(userId: string): Promise<number[] | null> {
+  const running = installationRefreshes.get(userId);
+  if (running) return running;
+  const refresh = (async () => {
+    const ghToken = await githubToken(userId);
+    if (!ghToken) return null;
     try {
       const ids = await fetchUserInstallationIds(ghToken);
+      await storeInstallationAccessSnapshot(userId, ids);
       installationsCache.set(userId, { ids, fetchedAt: Date.now() });
       return ids;
     } catch {
-      // fall through to the stale answer
+      return null;
+    }
+  })();
+  installationRefreshes.set(userId, refresh);
+  try {
+    return await refresh;
+  } finally {
+    if (installationRefreshes.get(userId) === refresh) installationRefreshes.delete(userId);
+  }
+}
+
+interface InstallationResolution {
+  ids: number[];
+  refresh?: () => Promise<void>;
+}
+
+async function installationIds(userId: string): Promise<InstallationResolution | null> {
+  const cached = installationsCache.get(userId);
+  if (cached && Date.now() - cached.fetchedAt < INSTALLATIONS_TTL_MS) {
+    return { ids: cached.ids };
+  }
+
+  const durable = await installationAccessSnapshot(userId);
+  const now = Date.now();
+  if (durable) {
+    installationsCache.set(userId, {
+      ids: durable.installationIds,
+      fetchedAt: durable.verifiedAt,
+    });
+    const age = now - durable.verifiedAt;
+    if (age < INSTALLATIONS_TTL_MS) return { ids: durable.installationIds };
+    if (age < INSTALLATIONS_STALE_MAX_MS) {
+      return {
+        ids: durable.installationIds,
+        refresh: async () => {
+          await refreshInstallationIds(userId);
+        },
+      };
     }
   }
-  if (cached && Date.now() - cached.fetchedAt < INSTALLATIONS_STALE_MAX_MS) return cached.ids;
+
+  const fresh = await refreshInstallationIds(userId);
+  if (fresh) return { ids: fresh };
+  if (cached && now - cached.fetchedAt < INSTALLATIONS_STALE_MAX_MS) {
+    return { ids: cached.ids };
+  }
   return null;
+}
+
+export async function githubTokenForUser(user: AuthedUser): Promise<string> {
+  if (user.devFake || !user.session.authUserId) return '';
+  return githubToken(user.session.authUserId);
 }
 
 // Whether GitHub says this user can push to the repo, checked with the
@@ -112,7 +171,8 @@ export async function userCanPushToRepo(
   name: string,
 ): Promise<boolean> {
   if (user.devFake) return true;
-  const { userId, ghToken } = user.session;
+  const { userId } = user.session;
+  const ghToken = await githubTokenForUser(user);
   if (!ghToken) return false;
   const key = `${userId}:${owner}/${name}`;
   const cached = repoPermCache.get(key);
@@ -134,7 +194,8 @@ const orgAdminCache = new Map<string, { admin: boolean; fetchedAt: number }>();
 // call (including a missing App org-members permission) answers false.
 export async function userIsGithubOrgAdmin(user: AuthedUser, orgLogin: string): Promise<boolean> {
   if (user.devFake) return true;
-  const { userId, ghToken } = user.session;
+  const { userId } = user.session;
+  const ghToken = await githubTokenForUser(user);
   if (!ghToken) return false;
   const key = `${userId}:${orgLogin}`;
   const cached = orgAdminCache.get(key);
@@ -160,7 +221,7 @@ export async function requireUser(request: Request): Promise<AuthedUser | null> 
   const host = new URL(request.url).hostname;
   if (fake && (host === 'localhost' || host === '127.0.0.1')) {
     return {
-      session: { userId: 0, login: 'dev', ghToken: '' },
+      session: { authUserId: '', userId: 0, login: 'dev' },
       installationIds: fake
         .split(',')
         .map(Number)
@@ -192,24 +253,26 @@ async function resolveAuthedUser(user: AuthUser): Promise<AuthedUser | null> {
   // repo-scoped answers empty, push checks fail closed.
   if (!login || githubId === null) {
     return {
-      session: { userId: 0, login: '', ghToken: '' },
+      session: { authUserId: user.id, userId: 0, login: '' },
       installationIds: [],
       githubConnected: false,
       name: user.name || user.email,
     };
   }
 
-  const ghToken = await githubToken(user.id);
-  const ids = await installationIds(user.id, ghToken);
-  if (ids === null) return null;
+  const [resolved, synthetic] = await Promise.all([
+    installationIds(user.id),
+    cachedSyntheticInstallationIds(githubId),
+  ]);
+  if (resolved === null) return null;
   // Artifacts-hosted projects ride on synthetic negative-id installations;
   // GitHub can't know about them, so membership-derived ids are unioned in.
-  const synthetic = await cachedSyntheticInstallationIds(githubId);
   return {
-    session: { userId: githubId, login, ghToken },
-    installationIds: [...new Set([...ids, ...synthetic])],
+    session: { authUserId: user.id, userId: githubId, login },
+    installationIds: [...new Set([...resolved.ids, ...synthetic])],
     githubConnected: true,
     name: login,
+    membershipRefresh: resolved.refresh,
   };
 }
 

--- a/src/services/live-updates.ts
+++ b/src/services/live-updates.ts
@@ -1,0 +1,68 @@
+import { env } from 'cloudflare:workers';
+import type { LiveUpdates } from '../live-updates.ts';
+
+// One hibernating Durable Object per GitHub installation. Invalidations carry
+// no application data; they only tell active clients to refresh the queries
+// they already have permission to read.
+export async function notifyInstallationsLive(installationIds: number[]): Promise<void> {
+  const uniqueIds = [...new Set(installationIds)];
+  if (uniqueIds.length === 0) return;
+  // SAFETY: wrangler.jsonc binds LIVE_UPDATES to the exported LiveUpdates
+  // class; Wrangler cannot currently infer RPC methods across Flue's
+  // generated Cloudflare entrypoint, so its generated namespace is untyped.
+  const namespace = env.LIVE_UPDATES as DurableObjectNamespace<LiveUpdates>;
+  await Promise.all(
+    uniqueIds.map((installationId) => namespace.getByName(String(installationId)).broadcast()),
+  );
+}
+
+async function notifyQueryLive(query: D1PreparedStatement): Promise<void> {
+  try {
+    const rows = await query.all<{ installation_id: number }>();
+    await notifyInstallationsLive(rows.results.map((row) => row.installation_id));
+  } catch (err) {
+    // UI invalidation is an acceleration layer. Durable work and mutations
+    // must remain successful when the hub is temporarily unavailable; the
+    // client's low-frequency poll is the recovery path.
+    console.warn('turbodiff: live invalidation failed', err);
+  }
+}
+
+export async function notifyFeatureLive(featureId: number): Promise<void> {
+  await notifyQueryLive(
+    env.DB.prepare(
+      `SELECT DISTINCT r.installation_id
+		 FROM features f JOIN repositories r ON r.id = f.repository_id
+		 WHERE f.id = ?1`,
+    ).bind(featureId),
+  );
+}
+
+export async function notifyPlanLive(planId: number): Promise<void> {
+  await notifyQueryLive(
+    env.DB.prepare(
+      `SELECT DISTINCT r.installation_id
+		 FROM repositories r
+		 WHERE r.id IN (
+		   SELECT repository_id FROM plan_repositories WHERE plan_id = ?1
+		   UNION SELECT repository_id FROM plans WHERE id = ?1
+		 )`,
+    ).bind(planId),
+  );
+}
+
+export async function notifyRepositoryLive(repositoryId: number): Promise<void> {
+  await notifyQueryLive(
+    env.DB.prepare('SELECT installation_id FROM repositories WHERE id = ?1').bind(repositoryId),
+  );
+}
+
+export async function notifyAutomationLive(automationId: number): Promise<void> {
+  await notifyQueryLive(
+    env.DB.prepare(
+      `SELECT r.installation_id
+		 FROM automations a JOIN repositories r ON r.id = a.repository_id
+		 WHERE a.id = ?1`,
+    ).bind(automationId),
+  );
+}

--- a/src/services/repo-browser-artifacts.ts
+++ b/src/services/repo-browser-artifacts.ts
@@ -3,6 +3,8 @@ import { redactSecrets } from '../ai/runtime/redaction.ts';
 import { prepareFullMirror } from '../ai/runtime/repository-workspace.ts';
 import { generationSandbox } from '../ai/runtime/sandbox.ts';
 import type { RepositoryRow } from '../data/db.ts';
+import { recordRepositoryRef, repositoryRef, repositoryRefs } from '../data/performance.ts';
+import { readArtifactsTreeDirect } from '../integrations/artifacts/content.ts';
 import { resolveWorkspaceRemote } from '../integrations/git/provider.ts';
 import type { WorkspaceRemote } from '../integrations/git/remotes.ts';
 import type { ApiFileSave, ApiRepoFile, ApiRepoTree } from '../shared/api-types.ts';
@@ -39,12 +41,8 @@ interface BrowseContext {
   remote: WorkspaceRemote | null;
 }
 
-// A read within this window of the last sync skips the remote fetch (and
-// the per-request token mint) entirely — clicking through a tree is many
-// reads against the same seconds-old mirror. Writes always resync.
-const MIRROR_FRESH_SECONDS = 30;
 // Inside .git so the worktree stays clean for the save path's `git add`.
-const SYNC_MARKER = `${BROWSE_DIR}/.git/turbodiff-synced-at`;
+const SYNC_MARKER = `${BROWSE_DIR}/.git/turbodiff-synced-version`;
 
 // Every public function starts here: clone on first touch, fetch --prune
 // after (the CR engine's sync pattern) — but at most once per freshness
@@ -54,10 +52,12 @@ async function browseContext(repo: RepositoryRow, scope: 'read' | 'write'): Prom
     throw new Error(`${repo.owner}/${repo.name} is not an Artifacts-hosted repo`);
   }
   const sandbox = generationSandbox(repo);
+  const version = repo.last_push_at ?? 'before-first-push-event';
   if (scope === 'read') {
     const probe = await sandbox.exec(
-      `now=$(date +%s); ts=$(cat ${SYNC_MARKER} 2>/dev/null || echo 0); ` +
-        `[ $((now - ts)) -lt ${MIRROR_FRESH_SECONDS} ] && echo fresh || echo stale`,
+      `stored=$(cat ${SYNC_MARKER} 2>/dev/null || true); ` +
+        `[ "$stored" = "$BROWSE_VERSION" ] && echo fresh || echo stale`,
+      { env: { BROWSE_VERSION: version } },
     );
     if (probe.success && probe.stdout.trim() === 'fresh') {
       return { sandbox, remote: null };
@@ -65,7 +65,7 @@ async function browseContext(repo: RepositoryRow, scope: 'read' | 'write'): Prom
   }
   const remote = await resolveWorkspaceRemote(repo, scope);
   await prepareFullMirror(sandbox, BROWSE_DIR, remote);
-  await sandbox.exec(`date +%s > ${SYNC_MARKER}`).catch(() => {});
+  await sandbox.writeFile(SYNC_MARKER, version).catch(() => {});
   return { sandbox, remote };
 }
 
@@ -100,17 +100,34 @@ function assertRefAndPath(ref: string, path: string): void {
 export async function listBranchesAndDefaultArtifacts(
   repo: RepositoryRow,
 ): Promise<{ default_branch: string | null; branches: string[] }> {
+  const recorded = await repositoryRefs(repo.id);
+  if (recorded.length > 0) {
+    return {
+      default_branch: repo.default_branch ?? recorded[0]?.ref ?? null,
+      branches: recorded.map((row) => row.ref),
+    };
+  }
   const ctx = await browseContext(repo, 'read');
   const out = await git(
     ctx,
-    `git -C ${BROWSE_DIR} for-each-ref --format='%(refname:strip=3)' refs/remotes/origin`,
+    `git -C ${BROWSE_DIR} for-each-ref --format='%(refname:strip=3)%09%(objectname)' refs/remotes/origin`,
   );
-  const branches = out
+  const discovered = out
     .split('\n')
     .map((line) => line.trim())
     // HEAD is the clone's origin/HEAD symref, not a branch.
-    .filter((name) => name && name !== 'HEAD')
-    .sort((a, b) => a.localeCompare(b));
+    .map((line) => {
+      const [name = '', sha = ''] = line.split('\t');
+      return { name, sha };
+    })
+    .filter(({ name, sha }) => name && name !== 'HEAD' && sha)
+    .sort((a, b) => a.name.localeCompare(b.name));
+  await Promise.all(
+    discovered.map(({ name, sha }) =>
+      recordRepositoryRef(repo.id, name, sha, repo.last_push_at ?? new Date().toISOString()),
+    ),
+  );
+  const branches = discovered.map(({ name }) => name);
   // default_branch is set at Artifacts project creation; fall back for rows
   // that somehow predate it.
   return { default_branch: repo.default_branch ?? branches[0] ?? null, branches };
@@ -122,6 +139,9 @@ export async function readTreeArtifacts(
   path: string,
 ): Promise<ApiRepoTree> {
   assertRefAndPath(ref, path);
+  const recorded = await repositoryRef(repo.id, ref);
+  const direct = await readArtifactsTreeDirect(repo, ref, path, recorded?.head_sha);
+  if (direct) return direct;
   const ctx = await browseContext(repo, 'read');
   let out: string;
   try {
@@ -173,22 +193,22 @@ export async function readFileArtifacts(
   const ctx = await browseContext(repo, 'read');
   const spec = `"refs/remotes/origin/$BROWSE_REF:$BROWSE_PATH"`;
   const refEnv = { BROWSE_REF: ref, BROWSE_PATH: path };
-  let stat: string;
+  let out: string;
   try {
-    stat = await git(
+    out = await git(
       ctx,
-      `git -C ${BROWSE_DIR} rev-parse ${spec} && ` +
-        `git -C ${BROWSE_DIR} cat-file -t ${spec} && ` +
-        `git -C ${BROWSE_DIR} cat-file -s ${spec}`,
+      `object=$(git -C ${BROWSE_DIR} rev-parse ${spec}) && ` +
+        `type=$(git -C ${BROWSE_DIR} cat-file -t "$object") && ` +
+        `size=$(git -C ${BROWSE_DIR} cat-file -s "$object") && ` +
+        `printf '%s\\n%s\\n%s\\n' "$object" "$type" "$size" && ` +
+        `if [ "$type" = blob ] && [ "$size" -le ${FILE_CAP} ]; then ` +
+        `git -C ${BROWSE_DIR} cat-file blob "$object" | base64 | tr -d '\\n'; fi`,
       refEnv,
     );
   } catch {
     throw new RepoBrowserError('file not found on this ref', 400);
   }
-  const [sha = '', type = '', sizeRaw = ''] = stat
-    .trim()
-    .split('\n')
-    .map((line) => line.trim());
+  const [sha = '', type = '', sizeRaw = '', ...encoded] = out.split('\n');
   if (type === 'tree') throw new RepoBrowserError('path is a directory, not a file', 400);
   if (type !== 'blob') {
     // Submodule (commit) entries have no text to show — render as binary.
@@ -198,14 +218,9 @@ export async function readFileArtifacts(
   if (size > FILE_CAP) {
     return { path, ref, sha, size, text: null, binary: false, too_large: true };
   }
-  // Exec stdout is not binary-safe, so ship the blob out as base64
-  // (`tr -d '\n'` rather than the GNU-only `base64 -w 0`).
-  const b64 = await git(
-    ctx,
-    `git -C ${BROWSE_DIR} cat-file blob ${spec} | base64 | tr -d '\\n'`,
-    refEnv,
-  );
-  const text = decodeBase64Text(b64.trim());
+  // The same exec emitted the bounded blob as base64 after the metadata,
+  // avoiding a third Sandbox round trip for every file click.
+  const text = decodeBase64Text(encoded.join('').trim());
   return { path, ref, sha, size, text, binary: text === null, too_large: false };
 }
 

--- a/src/services/repository-sync.ts
+++ b/src/services/repository-sync.ts
@@ -1,5 +1,7 @@
 import {
   addRepositories,
+  claimInstallationRepoSync,
+  finishInstallationRepoSync,
   listRepositoryIdsForInstallation,
   removeRepositories,
 } from '../data/db.ts';
@@ -12,39 +14,38 @@ import { githubPaginate } from '../integrations/github/client.ts';
 // GitHub's actual repo list — the same adds/removes the webhook would have
 // applied. Callers treat failures as non-fatal: the mirror stays as-is.
 
-// Per-isolate throttle so a burst of settings loads doesn't hammer GitHub.
-const SYNC_INTERVAL_MS = 60_000;
-const lastSyncAt = new Map<number, number>();
-
 export async function syncInstallationRepos(installationId: number): Promise<void> {
   // Synthetic Artifacts installations (negative ids, docs/artifacts-provider.md)
   // have no GitHub side to reconcile against — asking GitHub about them would
   // 404 and, worse, delete every repo row as "stale".
   if (installationId < 0) return;
-  const last = lastSyncAt.get(installationId) ?? 0;
-  if (Date.now() - last < SYNC_INTERVAL_MS) return;
-  lastSyncAt.set(installationId, Date.now());
+  if (!(await claimInstallationRepoSync(installationId))) return;
 
-  const token = await installationToken(installationId);
-  const live = await githubPaginate<
-    { repositories: { id: number; name: string; full_name: string }[] },
-    { id: number; name: string; full_name: string }
-  >(token, '/installation/repositories?per_page=100', (page) => page.repositories, {
-    // Reconciliation must see the complete repo list: a capped listing would
-    // permanently wedge large installations (the throw is caught upstream and
-    // the 60s throttle would retry-and-fail forever).
-    maxPages: Infinity,
-  });
+  try {
+    const token = await installationToken(installationId);
+    const live = await githubPaginate<
+      { repositories: { id: number; name: string; full_name: string }[] },
+      { id: number; name: string; full_name: string }
+    >(token, '/installation/repositories?per_page=100', (page) => page.repositories, {
+      // Reconciliation must see the complete repo list: a capped listing would
+      // permanently wedge large installations.
+      maxPages: Infinity,
+    });
 
-  await addRepositories(installationId, live);
-  const liveIds = new Set(live.map((r) => r.id));
-  const stale = (await listRepositoryIdsForInstallation(installationId)).filter(
-    (id) => !liveIds.has(id),
-  );
-  if (stale.length > 0) {
-    console.log(
-      `turbodiff: repo sync removed ${stale.length} stale repos for installation ${installationId}`,
+    await addRepositories(installationId, live);
+    const liveIds = new Set(live.map((r) => r.id));
+    const stale = (await listRepositoryIdsForInstallation(installationId)).filter(
+      (id) => !liveIds.has(id),
     );
-    await removeRepositories(stale);
+    if (stale.length > 0) {
+      console.log(
+        `turbodiff: repo sync removed ${stale.length} stale repos for installation ${installationId}`,
+      );
+      await removeRepositories(stale);
+    }
+    await finishInstallationRepoSync(installationId, true);
+  } catch (err) {
+    await finishInstallationRepoSync(installationId, false);
+    throw err;
   }
 }

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -234,6 +234,9 @@ export interface ApiFeatureDetail {
   };
   repo: string; // "owner/name"
   provider: string; // 'github' | 'artifacts'
+  // Source-branch head for the immutable diff snapshot. A new commit changes
+  // the query key; comments/status-only updates keep the existing patch data.
+  diff_version: string | null;
   // Native change-request number for Artifacts repos ("CR #3").
   cr_number: number | null;
   // Native check runs (Artifacts repos): repo check, review verdict, verify.
@@ -275,6 +278,15 @@ export interface ApiFeatureDetail {
   verification: ApiVerificationSummary | null;
   // Every generate/verify/fix run recorded for this feature, chronological.
   runs: ApiAgentRun[];
+}
+
+// The cockpit paints its controls, status, evidence, and conversations from
+// the summary response. Large patch strings arrive independently so they do
+// not block the first useful frame or get re-downloaded on every live update.
+export interface ApiFeatureDiff {
+  version: string | null;
+  files: ApiFeatureDetail['files'];
+  more_files: number;
 }
 
 export interface ApiAgentSummary {
@@ -355,6 +367,7 @@ export interface ApiMe {
   github_connected: boolean;
   github_app_slug: string;
   vapid_public_key: string;
+  installation_ids: number[];
 }
 
 // Native org roles (migrations/0031_organizations.sql), scoped per

--- a/vite.client.config.ts
+++ b/vite.client.config.ts
@@ -1,15 +1,66 @@
 import path from 'node:path';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite-plus';
+import { defineConfig, type Plugin } from 'vite-plus';
+
+const PERFORMANCE_BUDGETS = {
+  entry: 275_000,
+  css: 60_000,
+  featureRoute: 40_000,
+  cockpitDiff: 525_000,
+  codeRoute: 30_000,
+  codeEditor: 90_000,
+} as const;
+
+function performanceBudgets(): Plugin {
+  return {
+    name: 'turbodiff-performance-budgets',
+    apply: 'build',
+    generateBundle(_options, bundle) {
+      const assertBudget = (name: string, size: number, limit: number) => {
+        if (size <= limit) return;
+        this.error(`${name} is ${size} bytes; performance budget is ${limit} bytes`);
+      };
+      for (const output of Object.values(bundle)) {
+        if (output.type === 'asset') {
+          if (output.fileName.endsWith('.css')) {
+            assertBudget('client CSS', output.source.length, PERFORMANCE_BUDGETS.css);
+          }
+          continue;
+        }
+        if (output.isEntry) {
+          assertBudget('client entry', output.code.length, PERFORMANCE_BUDGETS.entry);
+        }
+        const module = output.facadeModuleId ?? '';
+        if (module.endsWith('/pages/feature.tsx')) {
+          assertBudget('feature route', output.code.length, PERFORMANCE_BUDGETS.featureRoute);
+        } else if (module.endsWith('/components/cockpit-patch-diff.tsx')) {
+          assertBudget(
+            'cockpit diff renderer',
+            output.code.length,
+            PERFORMANCE_BUDGETS.cockpitDiff,
+          );
+        } else if (module.endsWith('/pages/code.tsx')) {
+          assertBudget('code route', output.code.length, PERFORMANCE_BUDGETS.codeRoute);
+        } else if (module.endsWith('/components/code-editor.tsx')) {
+          assertBudget('code editor', output.code.length, PERFORMANCE_BUDGETS.codeEditor);
+        }
+      }
+    },
+  };
+}
 
 // Builds the signed-in SPA (src/client) into public/app, which the Worker
 // serves as static assets — the same pattern the old esbuild cockpit bundle
-// used. Entry + stylesheet get fixed names so the Worker's HTML shell
-// (src/routes/ui.ts) can reference them statically; code-split chunks
-// (@pierre/diffs syntax themes etc.) keep content hashes.
+// used. Every asset is content-hashed and the Worker reads Vite's manifest
+// through its static-assets binding when it renders the SPA shell. That lets
+// browsers cache the complete client forever without risking mixed deploys.
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), performanceBudgets()],
+  // The Worker serves every generated client file below /app/. Vite embeds
+  // this base into its dynamic-import preload helper; without it, route
+  // transitions probe /chunks/* and pay a failing request before import.
+  base: '/app/',
   // The outDir lives inside public/ (the Worker's static-asset dir), so
   // never mirror publicDir into it — Vite+ copies it by default.
   publicDir: false,
@@ -19,14 +70,13 @@ export default defineConfig({
   build: {
     outDir: 'public/app',
     emptyOutDir: true,
-    cssCodeSplit: false,
+    manifest: 'manifest.json',
     rollupOptions: {
       input: path.resolve(import.meta.dirname, 'src/client/main.tsx'),
       output: {
-        entryFileNames: 'app.js',
+        entryFileNames: 'assets/[name]-[hash].js',
         chunkFileNames: 'chunks/[name]-[hash].js',
-        assetFileNames: (info) =>
-          info.names.some((n) => n.endsWith('.css')) ? 'app.css' : 'assets/[name]-[hash][extname]',
+        assetFileNames: 'assets/[name]-[hash][extname]',
       },
     },
   },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,7 +1,10 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "turbodiff",
-  "compatibility_date": "2026-06-01",
+  "compatibility_date": "2026-08-08",
+  "assets": {
+    "binding": "ASSETS",
+  },
   "compatibility_flags": ["nodejs_compat"],
   // Version preview URLs (<version-prefix>-turbodiff.<subdomain>.workers.dev)
   // for the per-PR previews uploaded by .github/workflows/preview.yml. This
@@ -93,7 +96,10 @@
     },
   ],
   "durable_objects": {
-    "bindings": [{ "class_name": "Sandbox", "name": "Sandbox" }],
+    "bindings": [
+      { "class_name": "Sandbox", "name": "Sandbox" },
+      { "class_name": "LiveUpdates", "name": "LIVE_UPDATES" },
+    ],
   },
   // Generation runs as a durable Workflow (src/ai/workflows/generation.ts):
   // each stage is a memoized step with bounded retries, so a killed isolate
@@ -185,5 +191,6 @@
   "migrations": [
     { "tag": "v1", "new_sqlite_classes": ["FluePrReviewerAgent"] },
     { "tag": "v2", "new_sqlite_classes": ["Sandbox"] },
+    { "tag": "v3", "new_sqlite_classes": ["LiveUpdates"] },
   ],
 }


### PR DESCRIPTION
## Summary

Implements the ten highest-impact performance improvements from the audit, with extra focus on Cloudflare Artifacts code viewing:

1. Makes authentication local-first with durable installation-access snapshots, bounded stale fallback, and single-flight GitHub refreshes.
2. Makes Artifacts code browsing commit-addressed: push events persist branch heads, tree reads use the Artifacts binding directly when available, and immutable tree/file responses use the edge cache.
3. Cuts Artifacts sandbox overhead with version-based mirror freshness and a single metadata-plus-blob command per file read.
4. Splits volatile cockpit summaries from immutable diff snapshots so status refreshes no longer download or parse patches repeatedly.
5. Defers the cockpit diff engine, CodeMirror editor, board/task routes, and command overlays; shares one bounded diff worker pool and virtualizes offscreen file sections.
6. Content-hashes all client assets, serves them immutable, resolves them from the Vite manifest, and preloads the active route and API payload from the Worker shell.
7. Replaces eager full-payload polling with installation-scoped hibernating Durable Object WebSockets plus the existing low-frequency version fallback.
8. Parallelizes board D1 rollups, adds targeted indexes, and caches tenant-scoped board snapshots by the trigger-maintained factory version.
9. Moves repository reconciliation and built-in-agent repair off GET response paths and adds durable cross-isolate single-flight repo sync.
10. Adds real-user Web Vitals sampling, `Server-Timing`, slow-request logs, and enforced client bundle budgets.

The schema change is in `0044_performance_state.sql`; the live-update Durable Object is migration tag `v3`.

## Bundle impact

| Initial path | Before (raw / gzip) | After (raw / gzip) |
| --- | ---: | ---: |
| App entry | 297.29 / 93.19 KB | 258.67 / 83.42 KB |
| Feature cockpit | 504.77 / 141.85 KB | 30.53 / 9.37 KB |
| Code browser | 97.40 / 30.67 KB | 20.89 / 7.28 KB |

The 502.63 KB diff renderer loads only when diff content is requested. The 77.27 KB editor loads only after opening a file.

## Verification

- `vp test` — 16 files, 92 tests passed
- `pnpm test:worker` — 12 files, 129 tests passed, including fresh D1 migrations
- `vp check` — 0 errors (21 pre-existing warnings)
- `vp run build` — full client and Worker production build passed, including bundle budgets
- Browser smoke test — board, route chunks, Artifacts repository tree, file endpoint, and deferred editor all loaded without console/page/request errors
