### PR TITLE
feat: support standalone change reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Cloudflare account ([One-time setup](#one-time-setup)).
   gets a report comment with a verdict table and inline screenshots; unmet
   criteria feed the auto-fix loop.
 
-**Review** (where Turbodiff started; standalone intake is part of the target
-composable lifecycle):
+**Review** (where Turbodiff started; also works standalone for existing
+changes through on-demand or automatic repository intake):
 
 - One durable agent instance per PR (`owner--repo--number`), so re-reviews
   continue the same conversation and reconcile against earlier findings.

--- a/db/migrations/0004_review-intake.sql
+++ b/db/migrations/0004_review-intake.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "app"."repositories" ADD COLUMN "review_intake" text DEFAULT 'factory_only' NOT NULL;--> statement-breakpoint
+ALTER TABLE "app"."repositories" ADD CONSTRAINT "repositories_review_intake_check" CHECK (review_intake = ANY (ARRAY['factory_only'::text, 'on_demand'::text, 'all_changes'::text]));

--- a/db/migrations/meta/0004_snapshot.json
+++ b/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,5875 @@
+{
+  "id": "3b7c1d4e-df22-4c02-b479-fd914c6e1e78",
+  "prevId": "ca882b3d-a83f-401b-ae9b-55bdf1189ba3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.account": {
+      "name": "account",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_fkey": {
+          "name": "account_userId_fkey",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_provider_identity_unique": {
+          "name": "account_provider_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": ["accountId", "providerId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.agent_runs": {
+      "name": "agent_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "agent_runs_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fix_attempt_id": {
+          "name": "fix_attempt_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_run_id": {
+          "name": "automation_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_key": {
+          "name": "log_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "agent_runs_automation_idx": {
+          "name": "agent_runs_automation_idx",
+          "columns": [
+            {
+              "expression": "automation_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(automation_run_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_feature_idx": {
+          "name": "agent_runs_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(feature_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_fix_attempt_idx": {
+          "name": "agent_runs_fix_attempt_idx",
+          "columns": [
+            {
+              "expression": "fix_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(fix_attempt_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_plan_idx": {
+          "name": "agent_runs_plan_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(plan_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_plan_id_fkey": {
+          "name": "agent_runs_plan_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_feature_id_fkey": {
+          "name": "agent_runs_feature_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_fix_attempt_id_fkey": {
+          "name": "agent_runs_fix_attempt_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "fix_attempts",
+          "schemaTo": "app",
+          "columnsFrom": ["fix_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_automation_run_id_fkey": {
+          "name": "agent_runs_automation_run_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "automation_runs",
+          "schemaTo": "app",
+          "columnsFrom": ["automation_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_runs_kind_check": {
+          "name": "agent_runs_kind_check",
+          "value": "kind = ANY (ARRAY['plan_analyze'::text, 'plan_refine'::text, 'generate'::text, 'verify'::text, 'fix'::text, 'automation'::text, 'chat'::text, 'resolve_conflict'::text])"
+        },
+        "agent_runs_owner": {
+          "name": "agent_runs_owner",
+          "value": "num_nonnulls(plan_id, feature_id, fix_attempt_id, automation_run_id) >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.agents": {
+      "name": "agents",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "agents_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare/anthropic/claude-sonnet-5'"
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_installation_id_fkey": {
+          "name": "agents_installation_id_fkey",
+          "tableFrom": "agents",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_id_installation_unique": {
+          "name": "agents_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "installation_id"]
+        },
+        "agents_installation_slug_unique": {
+          "name": "agents_installation_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id", "slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agents_slug_format": {
+          "name": "agents_slug_format",
+          "value": "slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.automation_runs": {
+      "name": "automation_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "automation_runs_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "automation_runs_automation_idx": {
+          "name": "automation_runs_automation_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_one_running_idx": {
+          "name": "automation_runs_one_running_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_id_fkey": {
+          "name": "automation_runs_automation_id_fkey",
+          "tableFrom": "automation_runs",
+          "tableTo": "automations",
+          "schemaTo": "app",
+          "columnsFrom": ["automation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "automation_runs_status_check": {
+          "name": "automation_runs_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'pr_opened'::text, 'no_changes'::text, 'checks_failed'::text, 'failed'::text])"
+        },
+        "automation_runs_pr_number_check": {
+          "name": "automation_runs_pr_number_check",
+          "value": "(pr_number IS NULL) OR (pr_number > 0)"
+        },
+        "automation_runs_input_tokens_check": {
+          "name": "automation_runs_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "automation_runs_output_tokens_check": {
+          "name": "automation_runs_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "automation_runs_cache_read_tokens_check": {
+          "name": "automation_runs_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "automation_runs_cache_write_tokens_check": {
+          "name": "automation_runs_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "automation_runs_cost_usd_check": {
+          "name": "automation_runs_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.automations": {
+      "name": "automations",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "automations_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_kind": {
+          "name": "schedule_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_of_day": {
+          "name": "time_of_day",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "automations_due_idx": {
+          "name": "automations_due_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automations_repository_idx": {
+          "name": "automations_repository_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automations_repository_id_fkey": {
+          "name": "automations_repository_id_fkey",
+          "tableFrom": "automations",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "automations_schedule_kind_check": {
+          "name": "automations_schedule_kind_check",
+          "value": "schedule_kind = ANY (ARRAY['hourly'::text, 'daily'::text, 'weekly'::text])"
+        },
+        "automations_day_of_week_check": {
+          "name": "automations_day_of_week_check",
+          "value": "(day_of_week >= 0) AND (day_of_week <= 6)"
+        },
+        "automations_schedule_shape": {
+          "name": "automations_schedule_shape",
+          "value": "((schedule_kind = 'hourly'::text) AND (time_of_day IS NULL) AND (day_of_week IS NULL)) OR ((schedule_kind = 'daily'::text) AND (time_of_day IS NOT NULL) AND (day_of_week IS NULL)) OR ((schedule_kind = 'weekly'::text) AND (time_of_day IS NOT NULL) AND (day_of_week IS NOT NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.change_request_counters": {
+      "name": "change_request_counters",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_number": {
+          "name": "last_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "change_request_counters_repository_id_fkey": {
+          "name": "change_request_counters_repository_id_fkey",
+          "tableFrom": "change_request_counters",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "change_request_counters_last_number_check": {
+          "name": "change_request_counters_last_number_check",
+          "value": "last_number > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.change_requests": {
+      "name": "change_requests",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "change_requests_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_branch": {
+          "name": "source_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "source_head": {
+          "name": "source_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_head": {
+          "name": "target_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_base": {
+          "name": "merge_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mergeable": {
+          "name": "mergeable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_files": {
+          "name": "conflict_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff_key": {
+          "name": "diff_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patch_truncated": {
+          "name": "patch_truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_head": {
+          "name": "merged_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_by": {
+          "name": "opened_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'factory'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "change_requests_feature_idx": {
+          "name": "change_requests_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(feature_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_requests_change_unique": {
+          "name": "change_requests_change_unique",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_requests_open_branches_unique": {
+          "name": "change_requests_open_branches_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'open'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_requests_repo_status_idx": {
+          "name": "change_requests_repo_status_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_requests_feature_id_features_id_fk": {
+          "name": "change_requests_feature_id_features_id_fk",
+          "tableFrom": "change_requests",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "change_requests_change_id_changes_id_fk": {
+          "name": "change_requests_change_id_changes_id_fk",
+          "tableFrom": "change_requests",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": ["change_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_requests_repository_id_fkey": {
+          "name": "change_requests_repository_id_fkey",
+          "tableFrom": "change_requests",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "change_requests_repo_number_unique": {
+          "name": "change_requests_repo_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["repository_id", "number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "change_requests_number_check": {
+          "name": "change_requests_number_check",
+          "value": "number > 0"
+        },
+        "change_requests_status_check": {
+          "name": "change_requests_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'merged'::text, 'closed'::text])"
+        },
+        "change_requests_review_status_check": {
+          "name": "change_requests_review_status_check",
+          "value": "(review_status IS NULL) OR (review_status = ANY (ARRAY['approved'::text, 'changes_requested'::text]))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.changes": {
+      "name": "changes",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "changes_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_key": {
+          "name": "provider_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_branch": {
+          "name": "source_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "source_head": {
+          "name": "source_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_head": {
+          "name": "target_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "changes_repo_status_idx": {
+          "name": "changes_repo_status_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "changes_repository_id_fkey": {
+          "name": "changes_repository_id_fkey",
+          "tableFrom": "changes",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "changes_repo_provider_key_unique": {
+          "name": "changes_repo_provider_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["repository_id", "provider_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "changes_number_check": {
+          "name": "changes_number_check",
+          "value": "number > 0"
+        },
+        "changes_origin_check": {
+          "name": "changes_origin_check",
+          "value": "origin = ANY (ARRAY['human'::text, 'factory'::text, 'automation'::text, 'imported'::text])"
+        },
+        "changes_status_check": {
+          "name": "changes_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'merged'::text, 'closed'::text])"
+        },
+        "changes_capabilities_array_check": {
+          "name": "changes_capabilities_array_check",
+          "value": "jsonb_typeof(capabilities) = 'array'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.chat_messages": {
+      "name": "chat_messages",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "chat_messages_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'done'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "chat_messages_feature_idx": {
+          "name": "chat_messages_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_one_pending_user_idx": {
+          "name": "chat_messages_one_pending_user_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((role = 'user'::text) AND (status = ANY (ARRAY['queued'::text, 'running'::text])))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_feature_id_fkey": {
+          "name": "chat_messages_feature_id_fkey",
+          "tableFrom": "chat_messages",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_messages_role_check": {
+          "name": "chat_messages_role_check",
+          "value": "role = ANY (ARRAY['user'::text, 'assistant'::text])"
+        },
+        "chat_messages_status_check": {
+          "name": "chat_messages_status_check",
+          "value": "status = ANY (ARRAY['queued'::text, 'running'::text, 'done'::text, 'failed'::text])"
+        },
+        "chat_messages_outcome_check": {
+          "name": "chat_messages_outcome_check",
+          "value": "(outcome IS NULL) OR (outcome = ANY (ARRAY['changed'::text, 'no_changes'::text, 'tests_failed'::text]))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.cockpit_comments": {
+      "name": "cockpit_comments",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cockpit_comments_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'additions'"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "fix_attempt_id": {
+          "name": "fix_attempt_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "cockpit_comments_feature_idx": {
+          "name": "cockpit_comments_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cockpit_comments_fix_attempt_idx": {
+          "name": "cockpit_comments_fix_attempt_idx",
+          "columns": [
+            {
+              "expression": "fix_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(fix_attempt_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cockpit_comments_feature_id_fkey": {
+          "name": "cockpit_comments_feature_id_fkey",
+          "tableFrom": "cockpit_comments",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cockpit_comments_fix_attempt_id_fkey": {
+          "name": "cockpit_comments_fix_attempt_id_fkey",
+          "tableFrom": "cockpit_comments",
+          "tableTo": "fix_attempts",
+          "schemaTo": "app",
+          "columnsFrom": ["fix_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cockpit_comments_line_check": {
+          "name": "cockpit_comments_line_check",
+          "value": "line > 0"
+        },
+        "cockpit_comments_side_check": {
+          "name": "cockpit_comments_side_check",
+          "value": "side = ANY (ARRAY['additions'::text, 'deletions'::text])"
+        },
+        "cockpit_comments_status_check": {
+          "name": "cockpit_comments_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'dispatched'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.connections": {
+      "name": "connections",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "connections_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mcp'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_allowlist": {
+          "name": "tool_allowlist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_ciphertext": {
+          "name": "auth_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optional": {
+          "name": "optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "auth_config_ciphertext": {
+          "name": "auth_config_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_expires_at": {
+          "name": "oauth_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_needs_reauth": {
+          "name": "oauth_needs_reauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "oauth_has_refresh_token": {
+          "name": "oauth_has_refresh_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connections_installation_id_fkey": {
+          "name": "connections_installation_id_fkey",
+          "tableFrom": "connections",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_id_installation_unique": {
+          "name": "connections_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "installation_id"]
+        },
+        "connections_installation_name_unique": {
+          "name": "connections_installation_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connections_kind_check": {
+          "name": "connections_kind_check",
+          "value": "kind = ANY (ARRAY['mcp'::text, 'api'::text])"
+        },
+        "connections_auth_type_check": {
+          "name": "connections_auth_type_check",
+          "value": "auth_type = ANY (ARRAY['none'::text, 'bearer'::text, 'api_key'::text, 'client_credentials'::text, 'oauth'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.cr_checks": {
+      "name": "cr_checks",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cr_checks_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cr_checks_change_request_id_fkey": {
+          "name": "cr_checks_change_request_id_fkey",
+          "tableFrom": "cr_checks",
+          "tableTo": "change_requests",
+          "schemaTo": "app",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cr_checks_name_unique": {
+          "name": "cr_checks_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["change_request_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cr_checks_status_check": {
+          "name": "cr_checks_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'passed'::text, 'failed'::text, 'error'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.cr_comments": {
+      "name": "cr_comments",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cr_comments_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'comment'"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "cr_comments_change_request_idx": {
+          "name": "cr_comments_change_request_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cr_comments_change_request_id_fkey": {
+          "name": "cr_comments_change_request_id_fkey",
+          "tableFrom": "cr_comments",
+          "tableTo": "change_requests",
+          "schemaTo": "app",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cr_comments_line_check": {
+          "name": "cr_comments_line_check",
+          "value": "(line IS NULL) OR (line > 0)"
+        },
+        "cr_comments_kind_check": {
+          "name": "cr_comments_kind_check",
+          "value": "kind = ANY (ARRAY['comment'::text, 'finding'::text, 'summary'::text])"
+        },
+        "cr_comments_severity_check": {
+          "name": "cr_comments_severity_check",
+          "value": "(severity IS NULL) OR (severity = ANY (ARRAY['P1'::text, 'P2'::text, 'P3'::text]))"
+        },
+        "cr_comments_location": {
+          "name": "cr_comments_location",
+          "value": "((file IS NULL) AND (line IS NULL)) OR (file IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.factory_version": {
+      "name": "factory_version",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "factory_version_singleton_check": {
+          "name": "factory_version_singleton_check",
+          "value": "id = 1"
+        },
+        "factory_version_positive_check": {
+          "name": "factory_version_positive_check",
+          "value": "version > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.features": {
+      "name": "features",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "features_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptance": {
+          "name": "acceptance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_login": {
+          "name": "coauthor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_id": {
+          "name": "coauthor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_started_at": {
+          "name": "run_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_model": {
+          "name": "runner_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criteria_conflict": {
+          "name": "criteria_conflict",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "acceptance_updated_at": {
+          "name": "acceptance_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_acceptance": {
+          "name": "proposed_acceptance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_session_id": {
+          "name": "chat_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "features_change_request_idx": {
+          "name": "features_change_request_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_request_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_change_idx": {
+          "name": "features_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_generating_created_idx": {
+          "name": "features_generating_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(status = 'generating'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_open_pr_idx": {
+          "name": "features_open_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((status = 'pr_opened'::text) AND (pr_number IS NOT NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_plan_idx": {
+          "name": "features_plan_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(plan_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_repository_created_idx": {
+          "name": "features_repository_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_repository_pr_idx": {
+          "name": "features_repository_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(pr_number IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "features_plan_id_plans_id_fk": {
+          "name": "features_plan_id_plans_id_fk",
+          "tableFrom": "features",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "features_change_request_id_change_requests_id_fk": {
+          "name": "features_change_request_id_change_requests_id_fk",
+          "tableFrom": "features",
+          "tableTo": "change_requests",
+          "schemaTo": "app",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "features_change_id_changes_id_fk": {
+          "name": "features_change_id_changes_id_fk",
+          "tableFrom": "features",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": ["change_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "features_repository_id_fkey": {
+          "name": "features_repository_id_fkey",
+          "tableFrom": "features",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "features_plan_repository_unique": {
+          "name": "features_plan_repository_unique",
+          "nullsNotDistinct": false,
+          "columns": ["plan_id", "repository_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "features_pr_number_check": {
+          "name": "features_pr_number_check",
+          "value": "pr_number > 0"
+        },
+        "features_status_check": {
+          "name": "features_status_check",
+          "value": "status = ANY (ARRAY['queued'::text, 'generating'::text, 'pr_opened'::text, 'no_changes'::text, 'checks_failed'::text, 'failed'::text, 'merged'::text, 'pr_closed'::text, 'abandoned'::text])"
+        },
+        "features_input_tokens_check": {
+          "name": "features_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "features_output_tokens_check": {
+          "name": "features_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "features_cache_read_tokens_check": {
+          "name": "features_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "features_cache_write_tokens_check": {
+          "name": "features_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "features_cost_usd_check": {
+          "name": "features_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.fix_attempts": {
+      "name": "fix_attempts",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "fix_attempts_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "fix_attempts_one_running_idx": {
+          "name": "fix_attempts_one_running_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fix_attempts_pr_idx": {
+          "name": "fix_attempts_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fix_attempts_repository_id_fkey": {
+          "name": "fix_attempts_repository_id_fkey",
+          "tableFrom": "fix_attempts",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "fix_attempts_pr_number_check": {
+          "name": "fix_attempts_pr_number_check",
+          "value": "pr_number > 0"
+        },
+        "fix_attempts_status_check": {
+          "name": "fix_attempts_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'fixed'::text, 'no_changes'::text, 'tests_failed'::text, 'failed'::text])"
+        },
+        "fix_attempts_input_tokens_check": {
+          "name": "fix_attempts_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "fix_attempts_output_tokens_check": {
+          "name": "fix_attempts_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "fix_attempts_cache_read_tokens_check": {
+          "name": "fix_attempts_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "fix_attempts_cache_write_tokens_check": {
+          "name": "fix_attempts_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "fix_attempts_cost_usd_check": {
+          "name": "fix_attempts_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.installation_repo_sync": {
+      "name": "installation_repo_sync",
+      "schema": "app",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncing_until": {
+          "name": "syncing_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "installation_repo_sync_installation_id_fkey": {
+          "name": "installation_repo_sync_installation_id_fkey",
+          "tableFrom": "installation_repo_sync",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.installations": {
+      "name": "installations",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval('app.native_entity_id_seq'::regclass)"
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended": {
+          "name": "suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "installer_github_id": {
+          "name": "installer_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "installations_installer_idx": {
+          "name": "installations_installer_idx",
+          "columns": [
+            {
+              "expression": "installer_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(installer_github_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "installations_id_provider_unique": {
+          "name": "installations_id_provider_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "provider"]
+        },
+        "installations_provider_login_unique": {
+          "name": "installations_provider_login_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider", "account_login"]
+        },
+        "installations_provider_account_unique": {
+          "name": "installations_provider_account_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider", "account_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "installations_account_type_check": {
+          "name": "installations_account_type_check",
+          "value": "account_type = ANY (ARRAY['Organization'::text, 'User'::text])"
+        },
+        "installations_provider_check": {
+          "name": "installations_provider_check",
+          "value": "provider = ANY (ARRAY['github'::text, 'artifacts'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.invitation": {
+      "name": "invitation",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviterId": {
+          "name": "inviterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_email_status_idx": {
+          "name": "invitation_email_status_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_idx": {
+          "name": "invitation_inviter_idx",
+          "columns": [
+            {
+              "expression": "inviterId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_organization_idx": {
+          "name": "invitation_organization_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_pending_email_unique": {
+          "name": "invitation_pending_email_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'pending'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organizationId_fkey": {
+          "name": "invitation_organizationId_fkey",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "schemaTo": "auth",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviterId_fkey": {
+          "name": "invitation_inviterId_fkey",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["inviterId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "role = ANY (ARRAY['owner'::text, 'admin'::text, 'member'::text])"
+        },
+        "invitation_status_check": {
+          "name": "invitation_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'accepted'::text, 'rejected'::text, 'canceled'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.member": {
+      "name": "member",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organizationId_fkey": {
+          "name": "member_organizationId_fkey",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "schemaTo": "auth",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_userId_fkey": {
+          "name": "member_userId_fkey",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member_organization_user_unique": {
+          "name": "member_organization_user_unique",
+          "nullsNotDistinct": false,
+          "columns": ["organizationId", "userId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "role = ANY (ARRAY['owner'::text, 'admin'::text, 'member'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.oauthAccessToken": {
+      "name": "oauthAccessToken",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_expiry_idx": {
+          "name": "oauth_access_token_expiry_idx",
+          "columns": [
+            {
+              "expression": "accessTokenExpiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauthAccessToken_clientId_fkey": {
+          "name": "oauthAccessToken_clientId_fkey",
+          "tableFrom": "oauthAccessToken",
+          "tableTo": "oauthApplication",
+          "schemaTo": "auth",
+          "columnsFrom": ["clientId"],
+          "columnsTo": ["clientId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauthAccessToken_userId_fkey": {
+          "name": "oauthAccessToken_userId_fkey",
+          "tableFrom": "oauthAccessToken",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthAccessToken_accessToken_key": {
+          "name": "oauthAccessToken_accessToken_key",
+          "nullsNotDistinct": false,
+          "columns": ["accessToken"]
+        },
+        "oauthAccessToken_refreshToken_key": {
+          "name": "oauthAccessToken_refreshToken_key",
+          "nullsNotDistinct": false,
+          "columns": ["refreshToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.oauthApplication": {
+      "name": "oauthApplication",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientSecret": {
+          "name": "clientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectUrls": {
+          "name": "redirectUrls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauthApplication_userId_fkey": {
+          "name": "oauthApplication_userId_fkey",
+          "tableFrom": "oauthApplication",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthApplication_clientId_key": {
+          "name": "oauthApplication_clientId_key",
+          "nullsNotDistinct": false,
+          "columns": ["clientId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.oauthConsent": {
+      "name": "oauthConsent",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentGiven": {
+          "name": "consentGiven",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauthConsent_clientId_fkey": {
+          "name": "oauthConsent_clientId_fkey",
+          "tableFrom": "oauthConsent",
+          "tableTo": "oauthApplication",
+          "schemaTo": "auth",
+          "columnsFrom": ["clientId"],
+          "columnsTo": ["clientId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauthConsent_userId_fkey": {
+          "name": "oauthConsent_userId_fkey",
+          "tableFrom": "oauthConsent",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_consent_client_user_unique": {
+          "name": "oauth_consent_client_user_unique",
+          "nullsNotDistinct": false,
+          "columns": ["clientId", "userId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.organization": {
+      "name": "organization",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installationId": {
+          "name": "installationId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_installationId_fkey": {
+          "name": "organization_installationId_fkey",
+          "tableFrom": "organization",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_key": {
+          "name": "organization_slug_key",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "organization_installationId_key": {
+          "name": "organization_installationId_key",
+          "nullsNotDistinct": false,
+          "columns": ["installationId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.plan_repositories": {
+      "name": "plan_repositories",
+      "schema": "app",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "plan_repositories_repository_idx": {
+          "name": "plan_repositories_repository_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plan_repositories_plan_id_fkey": {
+          "name": "plan_repositories_plan_id_fkey",
+          "tableFrom": "plan_repositories",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_repositories_repository_id_fkey": {
+          "name": "plan_repositories_repository_id_fkey",
+          "tableFrom": "plan_repositories",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "plan_repositories_pkey": {
+          "name": "plan_repositories_pkey",
+          "columns": ["plan_id", "repository_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "plan_repositories_position_unique": {
+          "name": "plan_repositories_position_unique",
+          "nullsNotDistinct": false,
+          "columns": ["plan_id", "position"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plan_repositories_position_check": {
+          "name": "plan_repositories_position_check",
+          "value": "(\"position\" >= 0) AND (\"position\" <= 2)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.plans": {
+      "name": "plans",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "plans_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "todo_id": {
+          "name": "todo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptance": {
+          "name": "acceptance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'analyzing'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_login": {
+          "name": "created_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_model": {
+          "name": "runner_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "plans_active_idx": {
+          "name": "plans_active_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(NOT archived)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plans_feature_idx": {
+          "name": "plans_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(feature_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plans_repository_created_idx": {
+          "name": "plans_repository_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plans_todo_id_todos_id_fk": {
+          "name": "plans_todo_id_todos_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "todos",
+          "schemaTo": "app",
+          "columnsFrom": ["todo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plans_feature_id_features_id_fk": {
+          "name": "plans_feature_id_features_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plans_repository_id_fkey": {
+          "name": "plans_repository_id_fkey",
+          "tableFrom": "plans",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plans_todo_unique": {
+          "name": "plans_todo_unique",
+          "nullsNotDistinct": false,
+          "columns": ["todo_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plans_status_check": {
+          "name": "plans_status_check",
+          "value": "status = ANY (ARRAY['analyzing'::text, 'awaiting_answers'::text, 'refining'::text, 'plan_ready'::text, 'approving'::text, 'approved'::text, 'failed'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "push_subscriptions_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_github_id": {
+          "name": "user_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_idx": {
+          "name": "push_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_github_id_fkey": {
+          "name": "push_subscriptions_user_github_id_fkey",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_github_id"],
+          "columnsTo": ["githubId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_key": {
+          "name": "push_subscriptions_endpoint_key",
+          "nullsNotDistinct": false,
+          "columns": ["endpoint"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repo_agents": {
+      "name": "repo_agents",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_agents_agent_tenant_idx": {
+          "name": "repo_agents_agent_tenant_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_agents_repository_tenant_idx": {
+          "name": "repo_agents_repository_tenant_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_agents_repository_tenant_fk": {
+          "name": "repo_agents_repository_tenant_fk",
+          "tableFrom": "repo_agents",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_agents_agent_tenant_fk": {
+          "name": "repo_agents_agent_tenant_fk",
+          "tableFrom": "repo_agents",
+          "tableTo": "agents",
+          "schemaTo": "app",
+          "columnsFrom": ["agent_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repo_agents_pkey": {
+          "name": "repo_agents_pkey",
+          "columns": ["repository_id", "agent_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repo_connections": {
+      "name": "repo_connections",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviews": {
+          "name": "reviews",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "automations": {
+          "name": "automations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_connections_connection_tenant_idx": {
+          "name": "repo_connections_connection_tenant_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_connections_repository_tenant_idx": {
+          "name": "repo_connections_repository_tenant_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_connections_repository_tenant_fk": {
+          "name": "repo_connections_repository_tenant_fk",
+          "tableFrom": "repo_connections",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_connections_connection_tenant_fk": {
+          "name": "repo_connections_connection_tenant_fk",
+          "tableFrom": "repo_connections",
+          "tableTo": "connections",
+          "schemaTo": "app",
+          "columnsFrom": ["connection_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repo_connections_pkey": {
+          "name": "repo_connections_pkey",
+          "columns": ["repository_id", "connection_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repo_skills": {
+      "name": "repo_skills",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_skills_repository_tenant_idx": {
+          "name": "repo_skills_repository_tenant_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_skills_skill_tenant_idx": {
+          "name": "repo_skills_skill_tenant_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_skills_repository_tenant_fk": {
+          "name": "repo_skills_repository_tenant_fk",
+          "tableFrom": "repo_skills",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_skills_skill_tenant_fk": {
+          "name": "repo_skills_skill_tenant_fk",
+          "tableFrom": "repo_skills",
+          "tableTo": "skills",
+          "schemaTo": "app",
+          "columnsFrom": ["skill_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repo_skills_pkey": {
+          "name": "repo_skills_pkey",
+          "columns": ["repository_id", "skill_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repositories": {
+      "name": "repositories",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval('app.native_entity_id_seq'::regclass)"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "artifacts_repo": {
+          "name": "artifacts_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_push_at": {
+          "name": "last_push_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_on_push": {
+          "name": "review_on_push",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_intake": {
+          "name": "review_intake",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'factory_only'"
+        },
+        "blocking_reviews": {
+          "name": "blocking_reviews",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_fix": {
+          "name": "auto_fix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "check_command": {
+          "name": "check_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_command": {
+          "name": "run_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_port": {
+          "name": "app_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_merge": {
+          "name": "auto_merge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "demo_videos": {
+          "name": "demo_videos",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "launchable": {
+          "name": "launchable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_resolve_conflicts": {
+          "name": "auto_resolve_conflicts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "repositories_artifacts_repo_unique": {
+          "name": "repositories_artifacts_repo_unique",
+          "columns": [
+            {
+              "expression": "artifacts_repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(artifacts_repo IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_enabled_idx": {
+          "name": "repositories_enabled_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_installation_idx": {
+          "name": "repositories_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_installation_provider_fk": {
+          "name": "repositories_installation_provider_fk",
+          "tableFrom": "repositories",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id", "provider"],
+          "columnsTo": ["id", "provider"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repositories_id_installation_unique": {
+          "name": "repositories_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "installation_id"]
+        },
+        "repositories_owner_name_unique": {
+          "name": "repositories_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["owner", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "repositories_provider_check": {
+          "name": "repositories_provider_check",
+          "value": "provider = ANY (ARRAY['github'::text, 'artifacts'::text])"
+        },
+        "repositories_app_port_check": {
+          "name": "repositories_app_port_check",
+          "value": "(app_port >= 1) AND (app_port <= 65535)"
+        },
+        "repositories_review_intake_check": {
+          "name": "repositories_review_intake_check",
+          "value": "review_intake = ANY (ARRAY['factory_only'::text, 'on_demand'::text, 'all_changes'::text])"
+        },
+        "repositories_artifacts_shape": {
+          "name": "repositories_artifacts_shape",
+          "value": "((provider = 'artifacts'::text) AND (artifacts_repo IS NOT NULL) AND (default_branch IS NOT NULL)) OR ((provider = 'github'::text) AND (artifacts_repo IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.repository_refs": {
+      "name": "repository_refs",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pushed_at": {
+          "name": "pushed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "repository_refs_head_idx": {
+          "name": "repository_refs_head_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repository_refs_repository_id_fkey": {
+          "name": "repository_refs_repository_id_fkey",
+          "tableFrom": "repository_refs",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repository_refs_pkey": {
+          "name": "repository_refs_pkey",
+          "columns": ["repository_id", "ref"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.reviews": {
+      "name": "reviews",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "reviews_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event": {
+          "name": "trigger_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_url": {
+          "name": "review_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_instance_id": {
+          "name": "agent_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_tier": {
+          "name": "risk_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_count": {
+          "name": "findings_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "reviews_agent_instance_idx": {
+          "name": "reviews_agent_instance_idx",
+          "columns": [
+            {
+              "expression": "agent_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_installation_time_idx": {
+          "name": "reviews_installation_time_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_one_running_instance_idx": {
+          "name": "reviews_one_running_instance_idx",
+          "columns": [
+            {
+              "expression": "agent_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((status = 'running'::text) AND (agent_instance_id IS NOT NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_repo_pr_idx": {
+          "name": "reviews_repo_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_repository_installation_idx": {
+          "name": "reviews_repository_installation_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_running_installation_idx": {
+          "name": "reviews_running_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_repository_tenant_fk": {
+          "name": "reviews_repository_tenant_fk",
+          "tableFrom": "reviews",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reviews_output_tokens_check": {
+          "name": "reviews_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "reviews_cache_read_tokens_check": {
+          "name": "reviews_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "reviews_cache_write_tokens_check": {
+          "name": "reviews_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "reviews_pr_number_check": {
+          "name": "reviews_pr_number_check",
+          "value": "pr_number > 0"
+        },
+        "reviews_status_check": {
+          "name": "reviews_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'completed'::text, 'failed'::text])"
+        },
+        "reviews_input_tokens_check": {
+          "name": "reviews_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "reviews_cost_usd_check": {
+          "name": "reviews_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        },
+        "reviews_risk_tier_check": {
+          "name": "reviews_risk_tier_check",
+          "value": "(risk_tier IS NULL) OR (risk_tier = ANY (ARRAY['trivial'::text, 'lite'::text, 'full'::text]))"
+        },
+        "reviews_findings_count_check": {
+          "name": "reviews_findings_count_check",
+          "value": "(findings_count IS NULL) OR (findings_count >= 0)"
+        },
+        "reviews_completion_shape": {
+          "name": "reviews_completion_shape",
+          "value": "((status = 'running'::text) AND (completed_at IS NULL)) OR (status <> 'running'::text)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.session": {
+      "name": "session",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeOrganizationId": {
+          "name": "activeOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_active_organization_idx": {
+          "name": "session_active_organization_idx",
+          "columns": [
+            {
+              "expression": "activeOrganizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"activeOrganizationId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_expires_at_idx": {
+          "name": "session_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_fkey": {
+          "name": "session_userId_fkey",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_fk": {
+          "name": "session_active_organization_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "schemaTo": "auth",
+          "columnsFrom": ["activeOrganizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_key": {
+          "name": "session_token_key",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.skills": {
+      "name": "skills",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "skills_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skills_installation_id_fkey": {
+          "name": "skills_installation_id_fkey",
+          "tableFrom": "skills",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_id_installation_unique": {
+          "name": "skills_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "installation_id"]
+        },
+        "skills_installation_slug_unique": {
+          "name": "skills_installation_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id", "slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "skills_slug_format": {
+          "name": "skills_slug_format",
+          "value": "slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.todo_repositories": {
+      "name": "todo_repositories",
+      "schema": "app",
+      "columns": {
+        "todo_id": {
+          "name": "todo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "todo_repositories_repository_idx": {
+          "name": "todo_repositories_repository_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "todo_repositories_todo_id_fkey": {
+          "name": "todo_repositories_todo_id_fkey",
+          "tableFrom": "todo_repositories",
+          "tableTo": "todos",
+          "schemaTo": "app",
+          "columnsFrom": ["todo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "todo_repositories_repository_id_fkey": {
+          "name": "todo_repositories_repository_id_fkey",
+          "tableFrom": "todo_repositories",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "todo_repositories_pkey": {
+          "name": "todo_repositories_pkey",
+          "columns": ["todo_id", "repository_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "todo_repositories_position_unique": {
+          "name": "todo_repositories_position_unique",
+          "nullsNotDistinct": false,
+          "columns": ["todo_id", "position"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "todo_repositories_position_check": {
+          "name": "todo_repositories_position_check",
+          "value": "(\"position\" >= 0) AND (\"position\" <= 2)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.todos": {
+      "name": "todos",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "todos_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_login": {
+          "name": "created_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "todos_installation_unplanned_idx": {
+          "name": "todos_installation_unplanned_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(plan_id IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "todos_plan_unique": {
+          "name": "todos_plan_unique",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(plan_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "todos_plan_id_plans_id_fk": {
+          "name": "todos_plan_id_plans_id_fk",
+          "tableFrom": "todos",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "todos_installation_id_fkey": {
+          "name": "todos_installation_id_fkey",
+          "tableFrom": "todos",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.user": {
+      "name": "user",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubId": {
+          "name": "githubId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_github_id_unique": {
+          "name": "user_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["githubId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user_installation_access": {
+      "name": "user_installation_access",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_ids": {
+          "name": "installation_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_installation_access_user_id_fkey": {
+          "name": "user_installation_access_user_id_fkey",
+          "tableFrom": "user_installation_access",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_installation_access_no_null_ids": {
+          "name": "user_installation_access_no_null_ids",
+          "value": "array_position(installation_ids, NULL::bigint) IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.user_tokens": {
+      "name": "user_tokens",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_ciphertext": {
+          "name": "refresh_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.verification": {
+      "name": "verification",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_expires_at_idx": {
+          "name": "verification_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.verifications": {
+      "name": "verifications",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "verifications_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo": {
+          "name": "demo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "verifications_feature_idx": {
+          "name": "verifications_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verifications_one_running_idx": {
+          "name": "verifications_one_running_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verifications_running_created_idx": {
+          "name": "verifications_running_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verifications_feature_id_fkey": {
+          "name": "verifications_feature_id_fkey",
+          "tableFrom": "verifications",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verifications_status_check": {
+          "name": "verifications_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'passed'::text, 'failed'::text, 'error'::text, 'skipped'::text])"
+        },
+        "verifications_input_tokens_check": {
+          "name": "verifications_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "verifications_output_tokens_check": {
+          "name": "verifications_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "verifications_cache_read_tokens_check": {
+          "name": "verifications_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "verifications_cache_write_tokens_check": {
+          "name": "verifications_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "verifications_cost_usd_check": {
+          "name": "verifications_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "app": "app",
+    "auth": "auth"
+  },
+  "sequences": {
+    "app.native_entity_id_seq": {
+      "name": "native_entity_id_seq",
+      "schema": "app",
+      "increment": "1",
+      "startWith": "4000000000000000",
+      "minValue": "1",
+      "maxValue": "9007199254740991",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1788102390263,
       "tag": "0003_canonical-changes",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1788106042210,
+      "tag": "0004_review-intake",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -164,7 +164,7 @@ app.post('/api/auth/sign-up/email', handleEmailSignUp);
 app.on(['GET', 'POST'], '/api/auth/*', (c) => withAuth((instance) => instance.handler(c.req.raw)));
 
 // SPA data plane (session cookie auth, JSON in/out).
-app.route('/api', createApiRoutes());
+app.route('/api', createApiRoutes({ dispatchReview: dispatchReviewAgent }));
 
 // SPA shell + landing + OAuth sign-in (session cookie auth).
 app.route('/', createUiRoutes());

--- a/src/client/pages/settings.tsx
+++ b/src/client/pages/settings.tsx
@@ -15,7 +15,7 @@ import {
 } from 'lucide-react';
 import { useEffect, useState, type FormEvent, type ReactNode } from 'react';
 import { toast } from 'sonner';
-import type { ApiCloneCredential, ApiRepoSettings, ApiSettings } from '../../shared/api-types.ts';
+import type { ApiRepoSettings, ApiSettings } from '../../shared/api-types.ts';
 import { cloneCommand } from '../../shared/projects.ts';
 import { api, ApiError } from '../lib/api.ts';
 import { pushSupported, subscribeToPush, unsubscribeFromPush } from '../lib/push.ts';
@@ -331,6 +331,29 @@ function RepoRow({ repo }: { repo: ApiRepoSettings }) {
               <Clapperboard className="size-3" aria-hidden /> Demos
             </Chip>
           </ConfigRow>
+          <ConfigRow label="Intake">
+            <Chip
+              on={repo.review_intake === 'factory_only'}
+              title="Review only changes created by the Turbodiff factory"
+              onClick={() => patchRepo.mutate({ review_intake: 'factory_only' })}
+            >
+              Factory only
+            </Chip>
+            <Chip
+              on={repo.review_intake === 'on_demand'}
+              title="Review any open change only when a person explicitly requests it"
+              onClick={() => patchRepo.mutate({ review_intake: 'on_demand' })}
+            >
+              On demand
+            </Chip>
+            <Chip
+              on={repo.review_intake === 'all_changes'}
+              title="Automatically review qualifying human, automation, and factory changes"
+              onClick={() => patchRepo.mutate({ review_intake: 'all_changes' })}
+            >
+              All changes
+            </Chip>
+          </ConfigRow>
           <ConfigRow label="Check">
             <CheckCommandForm repo={repo} />
           </ConfigRow>
@@ -354,7 +377,7 @@ function NotificationsSettings() {
       setLoading(false);
       return;
     }
-    navigator.serviceWorker.ready
+    void navigator.serviceWorker.ready
       .then((r) => r.pushManager.getSubscription())
       .then((sub) => setEnabled(Notification.permission === 'granted' && sub !== null))
       .finally(() => setLoading(false));

--- a/src/data/change-requests.ts
+++ b/src/data/change-requests.ts
@@ -119,6 +119,14 @@ export async function getChangeRequestByRepoNumber(
   `);
 }
 
+export async function getChangeRequestByChangeId(
+  changeId: number,
+): Promise<ChangeRequestRow | null> {
+  return queryOne<ChangeRequestRow>(sql`
+    SELECT * FROM app.change_requests WHERE change_id = ${changeId}
+  `);
+}
+
 export async function getOpenChangeRequest(
   repositoryId: number,
   sourceBranch: string,

--- a/src/data/repositories.ts
+++ b/src/data/repositories.ts
@@ -2,6 +2,7 @@ import { inArray, sql } from 'drizzle-orm';
 import { execute, queryOne, queryRows, withDatabase, withTransaction } from './database.ts';
 import { repositories } from './schema.ts';
 import { bigintArray } from './sql.ts';
+import type { ReviewIntakeMode } from '../domain/review-intake.ts';
 
 // Thin typed layer over the PostgreSQL application schema.
 
@@ -26,6 +27,7 @@ export interface RepositoryRow {
   last_push_at: string | null; // maintained by Artifacts event ingestion
   enabled: boolean;
   review_on_push: boolean; // re-dispatch tiered agents on pushes to open PRs
+  review_intake: ReviewIntakeMode;
   blocking_reviews: boolean; // P1 → REQUEST_CHANGES, clean → APPROVE
   auto_fix: boolean; // dispatch the fix agent when a blocking review lands
   auto_merge: boolean; // merge factory PRs when verification + review are clean
@@ -281,6 +283,10 @@ export async function setRepoEnabled(id: number, enabled: boolean): Promise<void
 
 export async function setRepoReviewOnPush(id: number, on: boolean): Promise<void> {
   await execute(sql`UPDATE app.repositories SET review_on_push = ${on} WHERE id = ${id}`);
+}
+
+export async function setRepoReviewIntake(id: number, mode: ReviewIntakeMode): Promise<void> {
+  await execute(sql`UPDATE app.repositories SET review_intake = ${mode} WHERE id = ${id}`);
 }
 
 export async function setRepoBlockingReviews(id: number, on: boolean): Promise<void> {

--- a/src/data/schema.ts
+++ b/src/data/schema.ts
@@ -279,6 +279,7 @@ export const repositories = appSchema.table(
     enabled: boolean().default(true).notNull(),
     model: text(),
     reviewOnPush: boolean('review_on_push').default(false).notNull(),
+    reviewIntake: text('review_intake').default('factory_only').notNull(),
     blockingReviews: boolean('blocking_reviews').default(false).notNull(),
     autoFix: boolean('auto_fix').default(false).notNull(),
     checkCommand: text('check_command'),
@@ -318,6 +319,10 @@ export const repositories = appSchema.table(
       sql`provider = ANY (ARRAY['github'::text, 'artifacts'::text])`,
     ),
     check('repositories_app_port_check', sql`(app_port >= 1) AND (app_port <= 65535)`),
+    check(
+      'repositories_review_intake_check',
+      sql`review_intake = ANY (ARRAY['factory_only'::text, 'on_demand'::text, 'all_changes'::text])`,
+    ),
     check(
       'repositories_artifacts_shape',
       sql`((provider = 'artifacts'::text) AND (artifacts_repo IS NOT NULL) AND (default_branch IS NOT NULL)) OR ((provider = 'github'::text) AND (artifacts_repo IS NULL))`,

--- a/src/domain/review-intake.test.ts
+++ b/src/domain/review-intake.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { decideReviewIntake, REVIEW_INTAKE_MODES } from './review-intake.ts';
+
+describe('review intake policy', () => {
+  it('CMP-001/CMP-002: keeps existing repositories factory-only by default', () => {
+    expect(
+      decideReviewIntake({
+        mode: 'factory_only',
+        origin: 'human',
+        event: 'opened',
+        draft: false,
+      }),
+    ).toEqual({ kind: 'ignore', reason: 'repository admits factory changes only' });
+    expect(
+      decideReviewIntake({
+        mode: 'factory_only',
+        origin: 'factory',
+        event: 'opened',
+        draft: false,
+      }),
+    ).toEqual({ kind: 'admit' });
+  });
+
+  it('REV-001/REV-002: makes on-demand intake explicit for every origin', () => {
+    for (const origin of ['human', 'factory'] as const) {
+      expect(
+        decideReviewIntake({ mode: 'on_demand', origin, event: 'opened', draft: false }),
+      ).toMatchObject({ kind: 'ignore' });
+      expect(
+        decideReviewIntake({ mode: 'on_demand', origin, event: 'manual', draft: false }),
+      ).toEqual({ kind: 'admit' });
+    }
+  });
+
+  it('REV-003/CMP-003: admits every origin in all-changes mode', () => {
+    for (const origin of ['human', 'factory', 'automation', 'imported'] as const) {
+      expect(
+        decideReviewIntake({ mode: 'all_changes', origin, event: 'opened', draft: false }),
+      ).toEqual({ kind: 'admit' });
+    }
+  });
+
+  it('REV-004: never admits drafts, including explicit requests', () => {
+    for (const mode of REVIEW_INTAKE_MODES) {
+      expect(decideReviewIntake({ mode, origin: 'human', event: 'manual', draft: true })).toEqual({
+        kind: 'ignore',
+        reason: 'change is draft',
+      });
+    }
+  });
+});

--- a/src/domain/review-intake.ts
+++ b/src/domain/review-intake.ts
@@ -1,0 +1,31 @@
+import type { ChangeOrigin } from './lifecycle-contract.ts';
+
+export const REVIEW_INTAKE_MODES = ['factory_only', 'on_demand', 'all_changes'] as const;
+export type ReviewIntakeMode = (typeof REVIEW_INTAKE_MODES)[number];
+export type ReviewIntakeEvent = 'opened' | 'updated' | 'manual';
+
+export type ReviewIntakeDecision = { kind: 'admit' } | { kind: 'ignore'; reason: string };
+
+export function decideReviewIntake(input: {
+  mode: ReviewIntakeMode;
+  origin: ChangeOrigin;
+  event: ReviewIntakeEvent;
+  draft: boolean;
+}): ReviewIntakeDecision {
+  if (input.draft) return { kind: 'ignore', reason: 'change is draft' };
+
+  if (input.event === 'manual') {
+    if (input.mode === 'factory_only' && input.origin !== 'factory') {
+      return { kind: 'ignore', reason: 'repository admits factory changes only' };
+    }
+    return { kind: 'admit' };
+  }
+
+  if (input.mode === 'on_demand') {
+    return { kind: 'ignore', reason: 'review requires an explicit request' };
+  }
+  if (input.mode === 'factory_only' && input.origin !== 'factory') {
+    return { kind: 'ignore', reason: 'repository admits factory changes only' };
+  }
+  return { kind: 'admit' };
+}

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -18,6 +18,8 @@ import {
   hasPendingChatTurn,
   listChatMessages,
   getChangeRequest,
+  getChangeRequestByChangeId,
+  getChange,
   getRepoByFullName,
   listCrChecks,
   listCrComments,
@@ -90,6 +92,7 @@ import {
   setRepoDemoVideos,
   setRepoEnabled,
   setRepoReviewOnPush,
+  setRepoReviewIntake,
   setRepoSkillEnabled,
   setTaskRunnerModel,
   setTodoRepositories,
@@ -166,6 +169,9 @@ import { checkMergeability, dispatchConflictResolution } from '../services/merge
 import { mergePullRequest } from '../services/auto-merge.ts';
 import { enqueueFactoryMessage, enqueueFactoryMessages } from '../services/factory-queue.ts';
 import { DEFAULT_MODEL } from '../domain/personas.ts';
+import { decideReviewIntake } from '../domain/review-intake.ts';
+import { dispatchChangeReviews, type ReviewDispatcher } from '../services/change-review.ts';
+import { computeRiskTier } from '../services/review-policy.ts';
 import {
   isBoolean,
   isJsonArray,
@@ -299,6 +305,8 @@ export interface ApiRouteDependencies {
   orgAdmin?: typeof userIsGithubOrgAdmin;
   // Injectable for tests (the worker-test fixture has no queue binding).
   enqueueFactory?: typeof enqueueFactoryMessage;
+  dispatchReview?: ReviewDispatcher;
+  computeRisk?: typeof computeRiskTier;
 }
 
 export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
@@ -307,6 +315,8 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
   const canPushToRepo = dependencies.canPushToRepo ?? userCanPushToRepo;
   const orgAdmin = dependencies.orgAdmin ?? userIsGithubOrgAdmin;
   const enqueueFactory = dependencies.enqueueFactory ?? enqueueFactoryMessage;
+  const dispatchReview = dependencies.dispatchReview;
+  const computeRisk = dependencies.computeRisk ?? computeRiskTier;
 
   // Every API response exposes its Worker time to DevTools. Slow paths emit a
   // structured event into Workers Observability with a stable 250ms budget.
@@ -1196,6 +1206,41 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
   });
 
   // --- Factory PR cockpit ---
+
+  // Explicit review entry point for any canonical change. This is the
+  // partial-adoption path: a team can hand Turbodiff an existing PR without a
+  // feature, plan, generation run, or commitment to downstream automation.
+  app.post('/changes/:id/review', async (c) => {
+    const id = Number(c.req.param('id'));
+    const change = Number.isInteger(id) ? await getChange(id) : null;
+    const repo = change ? await getRepoById(change.repository_id) : null;
+    if (!change || !repo || !c.get('user').installationIds.includes(repo.installation_id)) {
+      return c.json({ error: 'unknown change' }, 404);
+    }
+    const deniedCapability = await requireCapability(c, repo.installation_id, 'settings', orgAdmin);
+    if (deniedCapability) return deniedCapability;
+
+    const intake = decideReviewIntake({
+      mode: repo.review_intake,
+      origin: change.origin,
+      event: 'manual',
+      draft: change.draft,
+    });
+    if (intake.kind === 'ignore') return c.json({ error: intake.reason }, 409);
+
+    if (repo.provider === 'artifacts') {
+      const cr = await getChangeRequestByChangeId(change.id);
+      if (!cr) return c.json({ error: 'native change request is unavailable' }, 409);
+      await enqueueFactory({ kind: 'cr_review', changeRequestId: cr.id });
+      return c.json({ ok: true, change_id: change.id });
+    }
+    if (!dispatchReview) return c.json({ error: 'review dispatcher unavailable' }, 503);
+
+    const result = await dispatchChangeReviews(change, repo, 'manual', dispatchReview, computeRisk);
+    if (result.kind === 'failed') return c.json({ error: result.reason }, 502);
+    if (result.kind === 'skipped') return c.json({ error: result.reason }, 409);
+    return c.json({ ok: true, change_id: change.id, tier: result.tier, agents: result.agents });
+  });
 
   app.get('/factory/features/:id', async (c) => {
     const id = Number(c.req.param('id'));
@@ -2733,6 +2778,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
             provider: r.provider,
             enabled: r.enabled,
             review_on_push: r.review_on_push,
+            review_intake: r.review_intake,
             blocking_reviews: r.blocking_reviews,
             auto_fix: r.auto_fix,
             auto_merge: r.auto_merge,
@@ -2922,6 +2968,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
       .json<{
         enabled?: boolean;
         review_on_push?: boolean;
+        review_intake?: 'factory_only' | 'on_demand' | 'all_changes';
         blocking_reviews?: boolean;
         auto_fix?: boolean;
         auto_merge?: boolean;
@@ -2931,8 +2978,20 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
       }>()
       .catch(() => null);
     if (!body) return c.json({ error: 'invalid JSON body' }, 400);
+    if (
+      body.review_intake !== undefined &&
+      body.review_intake !== 'factory_only' &&
+      body.review_intake !== 'on_demand' &&
+      body.review_intake !== 'all_changes'
+    ) {
+      return c.json(
+        { error: 'review_intake must be factory_only, on_demand, or all_changes' },
+        400,
+      );
+    }
     if (isBoolean(body.enabled)) await setRepoEnabled(repo.id, body.enabled);
     if (isBoolean(body.review_on_push)) await setRepoReviewOnPush(repo.id, body.review_on_push);
+    if (body.review_intake) await setRepoReviewIntake(repo.id, body.review_intake);
     if (isBoolean(body.blocking_reviews))
       await setRepoBlockingReviews(repo.id, body.blocking_reviews);
     if (isBoolean(body.auto_fix)) await setRepoAutoFix(repo.id, body.auto_fix);

--- a/src/http/api.worker.test.ts
+++ b/src/http/api.worker.test.ts
@@ -10,6 +10,7 @@ import type { AuthedUser } from '../services/auth.ts';
 import type { ApiBoard, ApiUsage } from '../shared/api-types.ts';
 import { isJsonObject, isString, parseJson } from '../shared/json.ts';
 import { createApiRoutes, type ApiRouteDependencies } from './api.ts';
+import { ensureBuiltinAgents, upsertChange } from '../data/db.ts';
 
 type Authenticate = NonNullable<ApiRouteDependencies['authenticate']>;
 
@@ -127,6 +128,92 @@ describe('API authentication and CSRF', () => {
     expect(response.status).toBe(403);
     expect(await response.json()).toEqual({ error: 'cross-origin request rejected' });
     expect(authenticate).not.toHaveBeenCalled();
+  });
+});
+
+describe('on-demand change review', () => {
+  it('dispatches an existing human PR without requiring a feature', async () => {
+    const configured = await authenticatedApi().request('https://turbodiff.test/api/repos/101', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ review_intake: 'on_demand' }),
+    });
+    expect(configured.status).toBe(200);
+    await ensureBuiltinAgents(1001);
+    const change = await upsertChange({
+      repositoryId: 101,
+      providerKey: 'github:42',
+      number: 42,
+      origin: 'human',
+      title: 'Existing pull request',
+      externalUrl: 'https://github.com/acme/api/pull/42',
+      sourceBranch: 'contributor/topic',
+      targetBranch: 'main',
+      status: 'open',
+      sourceHead: 'a'.repeat(40),
+      targetHead: 'b'.repeat(40),
+      draft: false,
+      capabilities: ['read_change', 'publish_review'],
+    });
+    const dispatchReview = vi.fn<NonNullable<ApiRouteDependencies['dispatchReview']>>(
+      async () => true,
+    );
+    const app = apiApp({
+      authenticate: async () => acmeUser,
+      canPushToRepo: async () => true,
+      orgAdmin: async () => true,
+      computeRisk: async () => 'full',
+      dispatchReview,
+    });
+
+    const response = await app.request(`https://turbodiff.test/api/changes/${change.id}/review`, {
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      change_id: change.id,
+      tier: 'full',
+      agents: ['review'],
+    });
+    expect(dispatchReview).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps human PRs out of the legacy factory-only profile', async () => {
+    const change = await upsertChange({
+      repositoryId: 101,
+      providerKey: 'github:43',
+      number: 43,
+      origin: 'human',
+      title: 'Existing pull request',
+      externalUrl: 'https://github.com/acme/api/pull/43',
+      sourceBranch: 'contributor/topic',
+      targetBranch: 'main',
+      status: 'open',
+      sourceHead: null,
+      targetHead: null,
+      draft: false,
+      capabilities: ['read_change', 'publish_review'],
+    });
+    const dispatchReview = vi.fn<NonNullable<ApiRouteDependencies['dispatchReview']>>(
+      async () => true,
+    );
+    const app = apiApp({
+      authenticate: async () => acmeUser,
+      canPushToRepo: async () => true,
+      orgAdmin: async () => true,
+      computeRisk: async () => 'full',
+      dispatchReview,
+    });
+
+    const response = await app.request(`https://turbodiff.test/api/changes/${change.id}/review`, {
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: 'repository admits factory changes only' });
+    expect(dispatchReview).not.toHaveBeenCalled();
   });
 });
 

--- a/src/http/webhooks.worker.test.ts
+++ b/src/http/webhooks.worker.test.ts
@@ -70,7 +70,9 @@ async function postWebhook(app: Hono, event: string, payload: JsonObject): Promi
   });
 }
 
-async function seedRepo(opts: { autoFix?: boolean } = {}): Promise<void> {
+async function seedRepo(
+  opts: { autoFix?: boolean; reviewIntake?: 'factory_only' | 'on_demand' | 'all_changes' } = {},
+): Promise<void> {
   await testDatabase().batch([
     testDatabase().prepare(
       `INSERT INTO installations (id, account_login, account_id, account_type)
@@ -78,10 +80,11 @@ async function seedRepo(opts: { autoFix?: boolean } = {}): Promise<void> {
     ),
     testDatabase()
       .prepare(
-        `INSERT INTO repositories (id, installation_id, owner, name, review_on_push, auto_fix)
-       VALUES (101, 1001, 'acme', 'api', TRUE, ?1)`,
+        `INSERT INTO repositories
+          (id, installation_id, owner, name, review_on_push, auto_fix, review_intake)
+       VALUES (101, 1001, 'acme', 'api', TRUE, ?1, ?2)`,
       )
-      .bind(opts.autoFix ?? false),
+      .bind(opts.autoFix ?? false, opts.reviewIntake ?? 'factory_only'),
   ]);
 }
 
@@ -298,7 +301,9 @@ describe('factory PR webhook decisions', () => {
     });
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({ skipped: 'not a factory PR' });
+    expect(await response.json()).toMatchObject({
+      skipped: 'repository admits factory changes only',
+    });
     expect(dispatch).not.toHaveBeenCalled();
     const change = await getChangeByProviderKey(101, 'github:42');
     expect(change).toMatchObject({
@@ -337,6 +342,33 @@ describe('factory PR webhook decisions', () => {
     const refreshed = await getChangeByProviderKey(101, 'github:42');
     expect(refreshed?.id).toBe(change?.id);
     expect(refreshed?.source_head).toBe('c'.repeat(40));
+  });
+
+  it('automatically reviews a human PR only after all-changes intake is selected', async () => {
+    await seedRepo({ reviewIntake: 'all_changes' });
+    await ensureBuiltinAgents(1001);
+    const dispatch = vi.fn<ReviewDispatcher>(async () => true);
+    const response = await postWebhook(webhookApp(dispatch), 'pull_request', {
+      action: 'opened',
+      number: 77,
+      pull_request: {
+        draft: false,
+        html_url: 'https://github.com/acme/api/pull/77',
+        title: 'Human contribution',
+        user: { login: 'contributor', type: 'User' },
+        head: {
+          ref: 'contribution',
+          sha: 'd'.repeat(40),
+          repo: { full_name: 'contributor/api' },
+        },
+        base: { ref: 'main', sha: 'e'.repeat(40) },
+      },
+      repository: { id: 101, full_name: 'acme/api' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ tier: 'full', agents: ['review'] });
+    expect(dispatch).toHaveBeenCalledTimes(1);
   });
 
   it('dispatches a factory PR once and debounces a push while its review is active', async () => {

--- a/src/services/artifacts.ts
+++ b/src/services/artifacts.ts
@@ -25,6 +25,7 @@ import { deleteRepositoryRef, recordRepositoryRef } from '../data/performance.ts
 import { listChangeRequestsForRepo } from '../data/db.ts';
 import { refreshChangeRequest } from './change-requests.ts';
 import { enqueueFactoryMessage } from './factory-queue.ts';
+import { decideReviewIntake } from '../domain/review-intake.ts';
 
 // Artifacts-hosted project lifecycle (docs/artifacts-provider.md):
 // provisioning (repo + synthetic tenancy + initial commit), user clone
@@ -188,7 +189,15 @@ export async function applyArtifactsEvent(event: ArtifactsEvent): Promise<string
         await refreshChangeRequest(row, cr);
         refreshed += 1;
         if (cr.source_branch === branch && row.review_on_push) {
-          await enqueueFactoryMessage({ kind: 'cr_review', changeRequestId: cr.id });
+          const intake = decideReviewIntake({
+            mode: row.review_intake,
+            origin: cr.opened_by === 'factory' ? 'factory' : 'human',
+            event: 'updated',
+            draft: false,
+          });
+          if (intake.kind === 'admit') {
+            await enqueueFactoryMessage({ kind: 'cr_review', changeRequestId: cr.id });
+          }
         }
       } catch (err) {
         console.error(`turbodiff: push-triggered refresh of CR ${cr.id} failed:`, err);

--- a/src/services/change-requests.ts
+++ b/src/services/change-requests.ts
@@ -21,6 +21,7 @@ import {
 import { enqueueFactoryMessage } from './factory-queue.ts';
 import { autoMergeDecline } from '../domain/merge-policy.ts';
 import { splitDiffSegments } from '../domain/review-diff.ts';
+import { decideReviewIntake } from '../domain/review-intake.ts';
 
 // Native change-request orchestration (docs/artifacts-provider.md): the
 // forge layer for Artifacts-hosted repos. Rows in PostgreSQL (data/change-requests),
@@ -105,7 +106,15 @@ export async function openNativeChangeRequest(input: {
     );
   }
   const refreshed = await refreshChangeRequest(input.repo, cr);
-  await enqueueFactoryMessage({ kind: 'cr_review', changeRequestId: cr.id });
+  const intake = decideReviewIntake({
+    mode: input.repo.review_intake,
+    origin: input.openedBy === 'factory' ? 'factory' : 'human',
+    event: 'opened',
+    draft: false,
+  });
+  if (intake.kind === 'admit') {
+    await enqueueFactoryMessage({ kind: 'cr_review', changeRequestId: cr.id });
+  }
   return refreshed;
 }
 

--- a/src/services/change-review.ts
+++ b/src/services/change-review.ts
@@ -1,0 +1,119 @@
+import {
+  getInstallation,
+  hasActiveReview,
+  listAgentsForRepo,
+  reviewedRecently,
+  type AgentRow,
+  type ChangeRow,
+  type RepositoryRow,
+} from '../data/db.ts';
+import {
+  agentsForTier,
+  computeRiskTier,
+  remainingDailyBudget,
+  tierModelOverride,
+  type RiskTier,
+} from './review-policy.ts';
+
+export type DispatchOptions = { riskTier?: string; modelOverride?: string };
+
+export type ReviewDispatcher = (
+  agent: AgentRow,
+  repo: RepositoryRow,
+  prNumber: number,
+  prUrl: string,
+  trigger: string,
+  opts?: DispatchOptions,
+) => Promise<boolean>;
+
+export type ChangeReviewDispatchResult =
+  | { kind: 'dispatched'; tier: RiskTier; agents: string[] }
+  | { kind: 'skipped'; reason: string }
+  | { kind: 'failed'; reason: string };
+
+const PUSH_DEBOUNCE_MINUTES = 10;
+
+export async function dispatchChangeReviews(
+  change: ChangeRow,
+  repo: RepositoryRow,
+  trigger: string,
+  dispatch: ReviewDispatcher,
+  computeRisk: typeof computeRiskTier = computeRiskTier,
+  debounce = false,
+): Promise<ChangeReviewDispatchResult> {
+  if (change.status !== 'open') return { kind: 'skipped', reason: 'change is not open' };
+  if (change.draft) return { kind: 'skipped', reason: 'change is draft' };
+  if (!change.capabilities.includes('read_change')) {
+    return { kind: 'skipped', reason: 'provider cannot read the change' };
+  }
+  if (!change.capabilities.includes('publish_review')) {
+    return { kind: 'skipped', reason: 'provider cannot publish a review' };
+  }
+  if (!repo.enabled) return { kind: 'skipped', reason: 'factory disabled for repo' };
+
+  const installation = await getInstallation(repo.installation_id);
+  if (!installation || installation.suspended) {
+    return { kind: 'skipped', reason: 'installation missing or suspended' };
+  }
+
+  const enabled = (await listAgentsForRepo(repo)).filter((agent) => agent.enabled);
+  if (enabled.length === 0) return { kind: 'skipped', reason: 'no agents enabled' };
+
+  let tier: RiskTier = 'full';
+  try {
+    tier = await computeRisk(repo.installation_id, repo.owner, repo.name, change.number);
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: 'review_risk_tier_failed',
+        repository_id: repo.id,
+        change_id: change.id,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  }
+  let agents = agentsForTier(tier, enabled);
+  const modelOverride = tierModelOverride(tier);
+
+  if (debounce) {
+    const idle: typeof agents = [];
+    for (const agent of agents) {
+      const busy =
+        (await hasActiveReview(repo.id, change.number, agent.slug)) ||
+        (await reviewedRecently(repo.id, change.number, agent.slug, PUSH_DEBOUNCE_MINUTES));
+      if (!busy) idle.push(agent);
+    }
+    agents = idle;
+    if (agents.length === 0) {
+      return { kind: 'skipped', reason: 'all agents busy or within push debounce' };
+    }
+  }
+
+  const budget = await remainingDailyBudget(repo.installation_id, installation.account_login);
+  if (budget <= 0) return { kind: 'skipped', reason: 'daily review limit reached' };
+  if (agents.length > budget) {
+    console.warn(
+      JSON.stringify({
+        event: 'review_budget_truncated',
+        repository_id: repo.id,
+        change_id: change.id,
+        available: budget,
+        requested: agents.length,
+      }),
+    );
+  }
+
+  const dispatched: string[] = [];
+  const url =
+    change.external_url ?? `https://github.com/${repo.owner}/${repo.name}/pull/${change.number}`;
+  for (const agent of agents.slice(0, budget)) {
+    const options: DispatchOptions = { riskTier: tier };
+    if (modelOverride) options.modelOverride = modelOverride;
+    if (await dispatch(agent, repo, change.number, url, trigger, options)) {
+      dispatched.push(agent.slug);
+    }
+  }
+  return dispatched.length > 0
+    ? { kind: 'dispatched', tier, agents: dispatched }
+    : { kind: 'failed', reason: 'dispatch failed' };
+}

--- a/src/services/github-webhooks.ts
+++ b/src/services/github-webhooks.ts
@@ -7,37 +7,28 @@ import {
   getFeatureByRepoPr,
   getInstallation,
   getRepoById,
-  hasActiveReview,
-  listAgentsForRepo,
   removeRepositories,
-  reviewedRecently,
   setInstallationSuspended,
   updateFeature,
   upsertChange,
   changeProviderKey,
   upsertInstallation,
-  type AgentRow,
-  type RepositoryRow,
 } from '../data/db.ts';
 import { FIX_MAX_ATTEMPTS, type FixQueueMessage } from '../shared/factory-messages.ts';
 import { enqueueFactoryMessage } from './factory-queue.ts';
 import { ensureOrganizationForInstallation, ensureOwnerMember } from './access-control.ts';
-import {
-  agentsForTier,
-  computeRiskTier,
-  tierModelOverride,
-  type RiskTier,
-  remainingDailyBudget,
-} from './review-policy.ts';
+import { computeRiskTier } from './review-policy.ts';
 import type { JsonValue } from '../shared/json.ts';
 import type { ChangeCapability, ChangeOrigin } from '../domain/lifecycle-contract.ts';
+import { decideReviewIntake } from '../domain/review-intake.ts';
+import { dispatchChangeReviews, type ReviewDispatcher } from './change-review.ts';
+
+export type { DispatchOptions, ReviewDispatcher } from './change-review.ts';
 
 // GitHub App webhook receiver. Two jobs:
 //   1. Mirror installation / repository-selection changes into PostgreSQL.
-//   2. Drive the factory's review/fix loop: auto-dispatch the repo-enabled
-//      agents when a FACTORY-GENERATED PR opens or gets pushed to, and enqueue
-//      a fix run when one of turbodiff's own blocking reviews lands.
-// Human-opened PRs are never reviewed — reviews exist to gate factory output.
+//   2. Drive the configured review/fix intake: legacy repositories admit only
+//      factory changes; composable profiles may admit human and automation PRs.
 
 interface WebhookAccount {
   login: string;
@@ -111,17 +102,6 @@ export interface WebhookHandlerResult {
   body: HandlerBody;
   status?: 502;
 }
-
-export type DispatchOptions = { riskTier?: string; modelOverride?: string };
-
-export type ReviewDispatcher = (
-  agent: AgentRow,
-  repo: RepositoryRow,
-  prNumber: number,
-  prUrl: string,
-  trigger: string,
-  opts?: DispatchOptions,
-) => Promise<boolean>;
 
 export type FixEnqueuer = (message: FixQueueMessage) => Promise<void>;
 
@@ -256,9 +236,6 @@ async function handleInstallationRepositories(p: InstallationEvent): Promise<Web
   };
 }
 
-// A push burst re-dispatches an agent at most once per window.
-const PUSH_DEBOUNCE_MINUTES = 10;
-
 function githubChangeCapabilities(p: PullRequestEvent): ChangeCapability[] {
   const capabilities: ChangeCapability[] = [
     'read_change',
@@ -339,78 +316,35 @@ async function handlePullRequest(
   if (p.action !== 'opened' && p.action !== 'ready_for_review' && p.action !== 'synchronize') {
     return { body: { ok: true, ignored: p.action } };
   }
-  if (p.pull_request.draft) return { body: { ok: true, skipped: 'draft' } };
-
-  if (!repo.enabled) return { body: { ok: true, skipped: 'factory disabled for repo' } };
   if (p.action === 'synchronize' && !repo.review_on_push) {
     return { body: { ok: true, skipped: 'push reviews disabled for repo' } };
   }
 
-  // Reviews gate factory output only: a PR gets auto-reviewed only when it
-  // belongs to a feature this factory generated. Human-opened PRs are never
-  // dispatched (the standalone auto-review product was retired).
-  if (!feature) return { body: { ok: true, skipped: 'not a factory PR' } };
+  const intake = decideReviewIntake({
+    mode: repo.review_intake,
+    origin: change.origin,
+    event: p.action === 'synchronize' ? 'updated' : 'opened',
+    draft: change.draft,
+  });
+  if (intake.kind === 'ignore') return { body: { ok: true, skipped: intake.reason } };
 
-  const installation = await getInstallation(repo.installation_id);
-  if (!installation || installation.suspended) {
-    return { body: { ok: true, skipped: 'installation missing or suspended' } };
-  }
-
-  const enabled = (await listAgentsForRepo(repo)).filter((a) => a.enabled);
-  if (enabled.length === 0) return { body: { ok: true, skipped: 'no agents enabled' } };
-
-  // Classify the PR before spending budget: small mechanical changes get one
-  // generalist, only large or security-sensitive ones the full fleet. Fail
-  // open to 'full' — a tiering hiccup must widen review, never skip it.
-  let tier: RiskTier = 'full';
-  try {
-    tier = await computeRisk(repo.installation_id, repo.owner, repo.name, p.number);
-  } catch (err) {
-    console.warn(
-      `turbodiff: risk tier computation failed for ${p.repository.full_name}#${p.number}, defaulting to full:`,
-      err,
-    );
-  }
-  let agents = agentsForTier(tier, enabled);
-  const modelOverride = tierModelOverride(tier);
-
-  // Pushes re-review with awareness (the agent reconciles against existing
-  // threads), but debounced: skip agents mid-review or dispatched within the
-  // window, so a burst of pushes costs one re-review, not one per push.
-  if (p.action === 'synchronize') {
-    const idle: typeof agents = [];
-    for (const agent of agents) {
-      const busy =
-        (await hasActiveReview(repo.id, p.number, agent.slug)) ||
-        (await reviewedRecently(repo.id, p.number, agent.slug, PUSH_DEBOUNCE_MINUTES));
-      if (!busy) idle.push(agent);
-    }
-    agents = idle;
-    if (agents.length === 0) {
-      return { body: { ok: true, skipped: 'all agents busy or within push debounce' } };
-    }
-  }
-
-  // The daily cap counts agent-runs, so N selected agents consume N units.
-  const budget = await remainingDailyBudget(repo.installation_id, installation.account_login);
-  if (budget <= 0) return { body: { ok: true, skipped: 'daily review limit reached' } };
-  if (agents.length > budget) {
-    console.warn(
-      `turbodiff: daily cap leaves budget for ${budget} of ${agents.length} agents on ${p.repository.full_name}#${p.number}`,
-    );
-  }
-
-  const dispatched: string[] = [];
-  for (const agent of agents.slice(0, budget)) {
-    const opts: DispatchOptions = { riskTier: tier };
-    if (modelOverride) opts.modelOverride = modelOverride;
-    if (await dispatch(agent, repo, p.number, p.pull_request.html_url, p.action, opts)) {
-      dispatched.push(agent.slug);
-    }
-  }
-  if (dispatched.length === 0) return { body: { error: 'dispatch failed' }, status: 502 };
+  const result = await dispatchChangeReviews(
+    change,
+    repo,
+    p.action,
+    dispatch,
+    computeRisk,
+    p.action === 'synchronize',
+  );
+  if (result.kind === 'failed') return { body: { error: result.reason }, status: 502 };
+  if (result.kind === 'skipped') return { body: { ok: true, skipped: result.reason } };
   return {
-    body: { ok: true, review: `${p.repository.full_name}#${p.number}`, tier, agents: dispatched },
+    body: {
+      ok: true,
+      review: `${p.repository.full_name}#${p.number}`,
+      tier: result.tier,
+      agents: result.agents,
+    },
   };
 }
 

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -338,6 +338,7 @@ export interface ApiRepoSettings {
   provider: string; // 'github' | 'artifacts'
   enabled: boolean;
   review_on_push: boolean;
+  review_intake: 'factory_only' | 'on_demand' | 'all_changes';
   blocking_reviews: boolean;
   auto_fix: boolean;
   auto_merge: boolean;


### PR DESCRIPTION
Stack 3/9. Adds factory-only, on-demand, and all-change intake modes plus an authenticated review endpoint for existing human or automated changes. Depends on https://github.com/Ngineer101/turbodiff/pull/118.