### PR TITLE
feat: expose composable review process profiles

### DIFF
--- a/src/ai/tools/change-requests.ts
+++ b/src/ai/tools/change-requests.ts
@@ -238,7 +238,9 @@ export const makePostCrReview = (agentInstanceId: string, pin: CrPin) =>
         agentInstanceId,
         url,
         data.findings.length,
-        blocking ? 'request_changes' : 'approve',
+        (hasP1 && repo.process_profile !== 'legacy_factory') || blocking
+          ? 'request_changes'
+          : 'approve',
       );
       if (blocking && repo.auto_fix && repo.process_profile === 'legacy_factory') {
         // Native verdicts fire no webhook, so the blocking-review fix

--- a/src/ai/tools/github.ts
+++ b/src/ai/tools/github.ts
@@ -411,11 +411,14 @@ export const makePostReview = (agentInstanceId: string, pin: RepoPin = null) =>
       // as running. The findings count feeds the noise metric on the
       // dashboard (fallback-posted findings still count — they reached the PR).
       const verdict =
-        intended === 'REQUEST_CHANGES'
+        data.findings.map(findingSeverity).includes('P1') &&
+        row.process_profile !== 'legacy_factory'
           ? 'request_changes'
-          : intended === 'APPROVE'
-            ? 'approve'
-            : 'comment';
+          : intended === 'REQUEST_CHANGES'
+            ? 'request_changes'
+            : intended === 'APPROVE'
+              ? 'approve'
+              : 'comment';
       await completeLifecycleReview(agentInstanceId, output.url, data.findings.length, verdict);
       // Factory-PR gate: a blocking verdict on a self-authored PR never fires
       // the pull_request_review webhook trigger (the posted state is COMMENT),

--- a/src/client/pages/settings.tsx
+++ b/src/client/pages/settings.tsx
@@ -331,27 +331,34 @@ function RepoRow({ repo }: { repo: ApiRepoSettings }) {
               <Clapperboard className="size-3" aria-hidden /> Demos
             </Chip>
           </ConfigRow>
-          <ConfigRow label="Intake">
+          <ConfigRow label="Process">
             <Chip
-              on={repo.review_intake === 'factory_only'}
-              title="Review only changes created by the Turbodiff factory"
-              onClick={() => patchRepo.mutate({ review_intake: 'factory_only' })}
+              on={repo.process_profile === 'legacy_factory'}
+              title="Preserve the existing end-to-end factory behavior for factory-created changes"
+              onClick={() => patchRepo.mutate({ process_profile: 'legacy_factory' })}
             >
-              Factory only
+              Legacy factory
             </Chip>
             <Chip
-              on={repo.review_intake === 'on_demand'}
+              on={repo.process_profile === 'review_on_demand'}
               title="Review any open change only when a person explicitly requests it"
-              onClick={() => patchRepo.mutate({ review_intake: 'on_demand' })}
+              onClick={() => patchRepo.mutate({ process_profile: 'review_on_demand' })}
             >
-              On demand
+              Review on demand
             </Chip>
             <Chip
-              on={repo.review_intake === 'all_changes'}
+              on={repo.process_profile === 'automatic_review'}
               title="Automatically review qualifying human, automation, and factory changes"
-              onClick={() => patchRepo.mutate({ review_intake: 'all_changes' })}
+              onClick={() => patchRepo.mutate({ process_profile: 'automatic_review' })}
             >
-              All changes
+              Automatic review
+            </Chip>
+            <Chip
+              on={repo.process_profile === 'review_and_repair'}
+              title="Automatically review writable changes, repair blocking findings, and re-review until clean or handed off"
+              onClick={() => patchRepo.mutate({ process_profile: 'review_and_repair' })}
+            >
+              Review + repair
             </Chip>
           </ConfigRow>
           <ConfigRow label="Check">

--- a/src/data/repositories.ts
+++ b/src/data/repositories.ts
@@ -4,6 +4,7 @@ import { repositories } from './schema.ts';
 import { bigintArray } from './sql.ts';
 import type { ReviewIntakeMode } from '../domain/review-intake.ts';
 import type { ProcessProfileKey } from '../domain/lifecycle-contract.ts';
+import type { AdoptableProcessProfileKey } from '../domain/process-profiles.ts';
 
 // Thin typed layer over the PostgreSQL application schema.
 
@@ -296,6 +297,22 @@ export async function setRepoReviewIntake(id: number, mode: ReviewIntakeMode): P
         : 'legacy_factory';
   await execute(sql`
     UPDATE app.repositories SET review_intake = ${mode}, process_profile = ${profile}
+    WHERE id = ${id}
+  `);
+}
+
+export async function setRepoProcessProfile(
+  id: number,
+  profile: AdoptableProcessProfileKey,
+): Promise<void> {
+  const intake: ReviewIntakeMode =
+    profile === 'legacy_factory'
+      ? 'factory_only'
+      : profile === 'review_on_demand'
+        ? 'on_demand'
+        : 'all_changes';
+  await execute(sql`
+    UPDATE app.repositories SET process_profile = ${profile}, review_intake = ${intake}
     WHERE id = ${id}
   `);
 }

--- a/src/domain/process-profiles.ts
+++ b/src/domain/process-profiles.ts
@@ -104,6 +104,15 @@ export const PROCESS_PROFILES = {
   },
 } satisfies Record<ProcessProfileKey, ProcessProfileContract>;
 
+export const ADOPTABLE_PROCESS_PROFILE_KEYS = [
+  'legacy_factory',
+  'review_on_demand',
+  'automatic_review',
+  'review_and_repair',
+] as const satisfies readonly ProcessProfileKey[];
+
+export type AdoptableProcessProfileKey = (typeof ADOPTABLE_PROCESS_PROFILE_KEYS)[number];
+
 export function processProfile(key: ProcessProfileKey): ProcessProfileContract {
   return PROCESS_PROFILES[key];
 }

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -92,6 +92,7 @@ import {
   setRepoEnabled,
   setRepoReviewOnPush,
   setRepoReviewIntake,
+  setRepoProcessProfile,
   setRepoSkillEnabled,
   setTaskRunnerModel,
   setTodoRepositories,
@@ -169,6 +170,10 @@ import { mergePullRequest } from '../services/auto-merge.ts';
 import { enqueueFactoryMessage, enqueueFactoryMessages } from '../services/factory-queue.ts';
 import { DEFAULT_MODEL } from '../domain/personas.ts';
 import { scheduleChangeReview } from '../services/lifecycle.ts';
+import {
+  ADOPTABLE_PROCESS_PROFILE_KEYS,
+  type AdoptableProcessProfileKey,
+} from '../domain/process-profiles.ts';
 import {
   isBoolean,
   isJsonArray,
@@ -2786,6 +2791,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
             enabled: r.enabled,
             review_on_push: r.review_on_push,
             review_intake: r.review_intake,
+            process_profile: r.process_profile,
             blocking_reviews: r.blocking_reviews,
             auto_fix: r.auto_fix,
             auto_merge: r.auto_merge,
@@ -2976,6 +2982,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         enabled?: boolean;
         review_on_push?: boolean;
         review_intake?: 'factory_only' | 'on_demand' | 'all_changes';
+        process_profile?: AdoptableProcessProfileKey;
         blocking_reviews?: boolean;
         auto_fix?: boolean;
         auto_merge?: boolean;
@@ -2996,9 +3003,19 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         400,
       );
     }
+    if (
+      body.process_profile !== undefined &&
+      !ADOPTABLE_PROCESS_PROFILE_KEYS.includes(body.process_profile)
+    ) {
+      return c.json(
+        { error: `process_profile must be ${ADOPTABLE_PROCESS_PROFILE_KEYS.join(', ')}` },
+        400,
+      );
+    }
     if (isBoolean(body.enabled)) await setRepoEnabled(repo.id, body.enabled);
     if (isBoolean(body.review_on_push)) await setRepoReviewOnPush(repo.id, body.review_on_push);
     if (body.review_intake) await setRepoReviewIntake(repo.id, body.review_intake);
+    if (body.process_profile) await setRepoProcessProfile(repo.id, body.process_profile);
     if (isBoolean(body.blocking_reviews))
       await setRepoBlockingReviews(repo.id, body.blocking_reviews);
     if (isBoolean(body.auto_fix)) await setRepoAutoFix(repo.id, body.auto_fix);

--- a/src/http/api.worker.test.ts
+++ b/src/http/api.worker.test.ts
@@ -10,7 +10,13 @@ import type { AuthedUser } from '../services/auth.ts';
 import type { ApiBoard, ApiUsage } from '../shared/api-types.ts';
 import { isJsonObject, isString, parseJson } from '../shared/json.ts';
 import { createApiRoutes, type ApiRouteDependencies } from './api.ts';
-import { ensureBuiltinAgents, getFactoryRun, getStageRun, upsertChange } from '../data/db.ts';
+import {
+  ensureBuiltinAgents,
+  getFactoryRun,
+  getRepoById,
+  getStageRun,
+  upsertChange,
+} from '../data/db.ts';
 import type { FactoryMessage } from '../shared/factory-messages.ts';
 
 type Authenticate = NonNullable<ApiRouteDependencies['authenticate']>;
@@ -137,9 +143,13 @@ describe('on-demand change review', () => {
     const configured = await authenticatedApi().request('https://turbodiff.test/api/repos/101', {
       method: 'PATCH',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ review_intake: 'on_demand' }),
+      body: JSON.stringify({ process_profile: 'review_on_demand' }),
     });
     expect(configured.status).toBe(200);
+    await expect(getRepoById(101)).resolves.toMatchObject({
+      process_profile: 'review_on_demand',
+      review_intake: 'on_demand',
+    });
     await ensureBuiltinAgents(1001);
     const change = await upsertChange({
       repositoryId: 101,

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -4,6 +4,16 @@
 
 export type ReviewState = 'running' | 'completed' | 'stalled' | 'failed';
 
+export type ApiProcessProfile =
+  | 'review_on_demand'
+  | 'automatic_review'
+  | 'review_and_repair'
+  | 'idea_to_pr'
+  | 'assisted_delivery'
+  | 'full_delivery'
+  | 'native_turnkey'
+  | 'legacy_factory';
+
 // One review row, pre-digested for display: the worker computes state (which
 // needs the stall clock) and totals; the client only formats.
 export interface ApiReview {
@@ -339,6 +349,7 @@ export interface ApiRepoSettings {
   enabled: boolean;
   review_on_push: boolean;
   review_intake: 'factory_only' | 'on_demand' | 'all_changes';
+  process_profile: ApiProcessProfile;
   blocking_reviews: boolean;
   auto_fix: boolean;
   auto_merge: boolean;


### PR DESCRIPTION
Stack 7/9. Adds repository-level profile selection with atomic intake mapping and preserves legacy behavior by default. Review verdict semantics now drive lifecycle repair independently of GitHub blocking-review presentation. Depends on https://github.com/Ngineer101/turbodiff/pull/122.