### PR TITLE
feat: show lifecycle history in the factory cockpit

### DIFF
--- a/src/client/pages/feature.tsx
+++ b/src/client/pages/feature.tsx
@@ -252,6 +252,80 @@ function GoNoGoBoard({ data }: { data: ApiFeatureDetail }) {
   );
 }
 
+function LifecycleHistory({ runs }: { runs: ApiFeatureDetail['lifecycle_runs'] }) {
+  if (runs.length === 0) return null;
+  return (
+    <>
+      <SectionHeading>Factory lifecycle</SectionHeading>
+      <Accordion type="multiple">
+        {runs.map((run) => (
+          <AccordionItem key={run.id} value={String(run.id)}>
+            <AccordionTrigger
+              aside={
+                <span className="font-mono text-xs tracking-[0.08em] text-mute uppercase">
+                  {sentence(run.status.replaceAll('_', ' '))}
+                </span>
+              }
+            >
+              {sentence(run.profile.replaceAll('_', ' '))} · {sentence(run.start_stage)} →{' '}
+              {sentence(run.stop_after_stage)}
+            </AccordionTrigger>
+            <AccordionContent>
+              <ol className="space-y-2">
+                {run.stages.map((stage) => (
+                  <li key={stage.id} className="flex items-start gap-3 text-sm">
+                    <span
+                      className={cn(
+                        'mt-1.5 size-2 shrink-0 rounded-full',
+                        stage.status === 'completed'
+                          ? 'bg-accent-bright'
+                          : stage.status === 'failed'
+                            ? 'bg-danger'
+                            : stage.status === 'running'
+                              ? 'bg-warn animate-pulse'
+                              : 'bg-line-2',
+                      )}
+                    />
+                    <span className="min-w-0">
+                      <span className="text-ink">{sentence(stage.stage)}</span>
+                      {stage.attempt > 1 ? (
+                        <span className="ml-2 font-mono text-xs text-mute">
+                          attempt {stage.attempt}
+                        </span>
+                      ) : null}
+                      <span className="ml-2 text-xs text-mute">{sentence(stage.status)}</span>
+                      {stage.error ? (
+                        <span className="mt-0.5 block text-xs text-danger">{stage.error}</span>
+                      ) : null}
+                    </span>
+                  </li>
+                ))}
+              </ol>
+              {run.handoff_reason ? (
+                <p className="mt-3 text-xs text-mute">Handoff: {run.handoff_reason}</p>
+              ) : null}
+              <details className="mt-3 text-xs text-mute">
+                <summary className="cursor-pointer select-none">
+                  {run.events.length} lifecycle events
+                </summary>
+                <ol className="mt-2 space-y-1 border-l border-line pl-3 font-mono">
+                  {run.events.map((event) => (
+                    <li key={event.key}>
+                      {event.kind}
+                      {event.decision ? ` → ${event.decision}` : ''}
+                      {event.reason ? ` · ${event.reason}` : ''}
+                    </li>
+                  ))}
+                </ol>
+              </details>
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </>
+  );
+}
+
 function CommentFixStatePill({ comment }: { comment: ApiCockpitComment }) {
   if (comment.fix_status === 'fixed') return <Pill tone="on">Fixed</Pill>;
   if (comment.fix_status === 'no_changes') return <Pill tone="neutral">No changes needed</Pill>;
@@ -1062,6 +1136,7 @@ export default function FeaturePage() {
               </>
             ) : null}
 
+            <LifecycleHistory runs={data.lifecycle_runs} />
             <AgentRunLog runs={data.runs} />
           </div>
 

--- a/src/data/lifecycle.ts
+++ b/src/data/lifecycle.ts
@@ -56,6 +56,16 @@ export interface AcceptanceContractRow {
   created_at: string;
 }
 
+export interface LifecycleEventRow {
+  idempotency_key: string;
+  factory_run_id: number | null;
+  change_id: number | null;
+  kind: LifecycleEventKind;
+  payload: JsonValue | null;
+  decision: LifecycleDecision | null;
+  created_at: string;
+}
+
 export async function createFactoryRunWithStage(input: {
   repositoryId: number;
   changeId: number | null;
@@ -165,6 +175,24 @@ export async function getStageRun(id: number): Promise<StageRunRow | null> {
 export async function listStageRuns(factoryRunId: number): Promise<StageRunRow[]> {
   return queryRows<StageRunRow>(sql`
     SELECT * FROM app.stage_runs WHERE factory_run_id = ${factoryRunId} ORDER BY id
+  `);
+}
+
+export async function listFactoryRunsForFeature(featureId: number): Promise<FactoryRunRow[]> {
+  return queryRows<FactoryRunRow>(sql`
+    SELECT DISTINCT fr.*
+    FROM app.factory_runs fr
+    JOIN app.lifecycle_events le ON le.factory_run_id = fr.id
+    WHERE le.payload ->> 'featureId' = ${String(featureId)}
+    ORDER BY fr.created_at, fr.id
+  `);
+}
+
+export async function listLifecycleEvents(factoryRunId: number): Promise<LifecycleEventRow[]> {
+  return queryRows<LifecycleEventRow>(sql`
+    SELECT * FROM app.lifecycle_events
+    WHERE factory_run_id = ${factoryRunId}
+    ORDER BY created_at, idempotency_key
   `);
 }
 

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -60,6 +60,7 @@ import {
   listRepoConnectionLinks,
   listConnections,
   listFixAttemptsForRepoPrs,
+  listFactoryRunsForFeature,
   listInstallationsWithRepos,
   listPlansForInstallations,
   listRecentFeaturesForUsage,
@@ -68,6 +69,8 @@ import {
   listRepoSkillOverrides,
   listReposForTodo,
   listReviewsForRepoPrs,
+  listLifecycleEvents,
+  listStageRuns,
   listMembersWithGithubLogin,
   listPendingInvitations,
   listSkills,
@@ -170,6 +173,7 @@ import { mergePullRequest } from '../services/auto-merge.ts';
 import { enqueueFactoryMessage, enqueueFactoryMessages } from '../services/factory-queue.ts';
 import { DEFAULT_MODEL } from '../domain/personas.ts';
 import { scheduleChangeReview } from '../services/lifecycle.ts';
+import type { LifecycleDecision } from '../domain/lifecycle-contract.ts';
 import {
   ADOPTABLE_PROCESS_PROFILE_KEYS,
   type AdoptableProcessProfileKey,
@@ -216,6 +220,18 @@ import type {
 
 interface DeferredExecution {
   waitUntil(promise: Promise<void>): void;
+}
+
+function lifecycleDecisionReason(decision: LifecycleDecision | null): string | null {
+  if (!decision) return null;
+  switch (decision.kind) {
+    case 'wait':
+    case 'handoff':
+    case 'ignore':
+      return decision.reason;
+    default:
+      return null;
+  }
 }
 
 const fallbackExecution: DeferredExecution = {
@@ -1272,10 +1288,49 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
       criteria: [],
       verification: null,
       runs: [],
+      lifecycle_runs: [],
     };
     // Fetched even when generation never opened a PR — a failed run is
     // exactly the case where an advanced user most wants the full log.
-    base.runs = (await listAgentRunsForFeature(feature.id)).map(serializeAgentRun);
+    const [agentRuns, lifecycleRuns] = await Promise.all([
+      listAgentRunsForFeature(feature.id),
+      listFactoryRunsForFeature(feature.id),
+    ]);
+    base.runs = agentRuns.map(serializeAgentRun);
+    base.lifecycle_runs = await Promise.all(
+      lifecycleRuns.map(async (run) => {
+        const [stages, events] = await Promise.all([
+          listStageRuns(run.id),
+          listLifecycleEvents(run.id),
+        ]);
+        return {
+          id: run.id,
+          profile: run.profile_key,
+          status: run.status,
+          start_stage: run.start_stage,
+          stop_after_stage: run.stop_after_stage,
+          handoff_reason: run.handoff_reason,
+          created_at: run.created_at,
+          completed_at: run.completed_at,
+          stages: stages.map((stage) => ({
+            id: stage.id,
+            stage: stage.stage,
+            attempt: stage.attempt,
+            status: stage.status,
+            error: stage.error,
+            started_at: stage.started_at,
+            completed_at: stage.completed_at,
+          })),
+          events: events.map((event) => ({
+            key: event.idempotency_key,
+            kind: event.kind,
+            decision: event.decision?.kind ?? null,
+            reason: lifecycleDecisionReason(event.decision),
+            created_at: event.created_at,
+          })),
+        };
+      }),
+    );
     if (!feature.pr_number) return c.json(base);
     base.certificate_url = await certificateUrl(feature.id);
 

--- a/src/http/webhooks.worker.test.ts
+++ b/src/http/webhooks.worker.test.ts
@@ -17,6 +17,7 @@ import {
   getFeature,
   getStageRun,
   latestAcceptanceContractForChange,
+  listFactoryRunsForFeature,
   listStageRuns,
   tryRecordFixAttempt,
   tryRecordReview,
@@ -377,6 +378,9 @@ describe('composable feature delivery', () => {
       status: 'handed_off',
       handoff_reason: 'requested stop boundary reached',
     });
+    await expect(listFactoryRunsForFeature(featureId)).resolves.toMatchObject([
+      { id: implementCommands[0].factoryRunId, profile_key: 'idea_to_pr' },
+    ]);
     await expect(listStageRuns(implementCommands[0].factoryRunId)).resolves.toMatchObject([
       { stage: 'implement', status: 'completed', input: { featureId } },
       { stage: 'publish', status: 'completed', change_id: change.id, input: { featureId } },

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -228,6 +228,33 @@ export interface ApiChatList {
   messages: ApiChatMessage[];
 }
 
+export interface ApiLifecycleRun {
+  id: number;
+  profile: ApiProcessProfile;
+  status: 'active' | 'awaiting_human' | 'handed_off' | 'completed' | 'failed' | 'cancelled';
+  start_stage: string;
+  stop_after_stage: string;
+  handoff_reason: string | null;
+  created_at: string;
+  completed_at: string | null;
+  stages: {
+    id: number;
+    stage: string;
+    attempt: number;
+    status: 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+    error: string | null;
+    started_at: string | null;
+    completed_at: string | null;
+  }[];
+  events: {
+    key: string;
+    kind: string;
+    decision: string | null;
+    reason: string | null;
+    created_at: string;
+  }[];
+}
+
 export interface ApiFeatureDetail {
   feature: {
     id: number;
@@ -288,6 +315,8 @@ export interface ApiFeatureDetail {
   verification: ApiVerificationSummary | null;
   // Every generate/verify/fix run recorded for this feature, chronological.
   runs: ApiAgentRun[];
+  // Coordinator-owned lifecycle history, including handoffs and stage retries.
+  lifecycle_runs: ApiLifecycleRun[];
 }
 
 // The cockpit paints its controls, status, evidence, and conversations from


### PR DESCRIPTION
Stack 9/9. Adds lifecycle run, stage-attempt, handoff, and normalized event-decision history to the feature API and cockpit so partial delegation remains transparent and auditable. Depends on https://github.com/Ngineer101/turbodiff/pull/124.