### PR TITLE
Fix dashboard auth recovery after PostgreSQL migration

### DIFF
--- a/src/client/components/app-shell.tsx
+++ b/src/client/components/app-shell.tsx
@@ -59,6 +59,71 @@ const BOTTOM_NAV = [
   { to: '/settings', label: 'Settings', short: 'Settings', icon: Settings },
 ] as const;
 
+function GithubRecoveryBanner({ me }: { me: ApiMe }) {
+  if (me.github_status === 'ready') return null;
+
+  let message: ReactNode;
+  let action: ReactNode;
+  switch (me.github_status) {
+    case 'not_connected':
+      message = <>GitHub isn&rsquo;t connected — the factory can&rsquo;t reach repositories yet.</>;
+      action = (
+        <a href="/onboarding" className="font-medium text-accent-bright hover:underline">
+          Connect GitHub &rarr;
+        </a>
+      );
+      break;
+    case 'reauthorization_required':
+      message = (
+        <>Your GitHub authorization is missing or expired. Your Turbodiff account is safe.</>
+      );
+      action = (
+        <a
+          href="/auth/connect/github?next=/onboarding"
+          className="font-medium text-accent-bright hover:underline"
+        >
+          Re-authorize GitHub &rarr;
+        </a>
+      );
+      break;
+    case 'temporarily_unavailable':
+      message = <>GitHub access couldn&rsquo;t be verified. Native projects remain available.</>;
+      action = (
+        <a href="/onboarding" className="font-medium text-accent-bright hover:underline">
+          Retry or re-authorize &rarr;
+        </a>
+      );
+      break;
+    case 'app_not_installed':
+      message = <>GitHub is connected, but no GitHub App installation is available to you.</>;
+      action = (
+        <a
+          href={`https://github.com/apps/${me.github_app_slug}/installations/new`}
+          className="font-medium text-accent-bright hover:underline"
+        >
+          Install or configure the GitHub App &rarr;
+        </a>
+      );
+      break;
+    case 'syncing':
+      message = <>Restoring your GitHub installations and repositories after sign-in.</>;
+      action = (
+        <a href="/onboarding" className="font-medium text-accent-bright hover:underline">
+          View recovery status &rarr;
+        </a>
+      );
+      break;
+  }
+
+  return (
+    <div className="mb-5 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-xl border border-line-2/70 bg-surface/60 px-4 py-3 text-[0.85rem] text-ink-dim">
+      <Lamp tone={me.github_status === 'syncing' ? 'go' : 'hold'} />
+      {message}
+      {action}
+    </div>
+  );
+}
+
 function Logo() {
   return (
     <Link
@@ -346,17 +411,7 @@ export function AppShell({ me, children }: { me: ApiMe; children: ReactNode }) {
                   : 'max-w-4xl',
           )}
         >
-          {/* Password account without GitHub: every station reads empty until
-              a GitHub account is connected, so say why once, up top. */}
-          {!me.github_connected && (
-            <div className="mb-5 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-xl border border-line-2/70 bg-surface/60 px-4 py-3 text-[0.85rem] text-ink-dim">
-              <Lamp tone="hold" />
-              GitHub isn&rsquo;t connected — the factory can&rsquo;t reach any repositories yet.
-              <a href="/onboarding" className="font-medium text-accent-bright hover:underline">
-                Connect GitHub &rarr;
-              </a>
-            </div>
-          )}
+          <GithubRecoveryBanner me={me} />
           {children}
         </div>
       </main>

--- a/src/client/lib/api.ts
+++ b/src/client/lib/api.ts
@@ -1,5 +1,6 @@
-// Thin fetch wrapper for the Worker's /api routes. Session-cookie authed:
-// a 401 means the cookie is missing/expired, so restart OAuth.
+// Thin fetch wrapper for the Worker's /api routes. Recoverable GitHub account
+// states are 200 responses on /api/me; a 401 now means the application session
+// itself is missing/expired.
 
 export class ApiError extends Error {
   status: number;
@@ -15,6 +16,16 @@ export class ApiError extends Error {
 // entries fall out first.
 const ETAG_CACHE_MAX = 50;
 const etagCache = new Map<string, { etag: string; data: unknown }>();
+let redirectingToLogin = false;
+
+function restartAuthentication(): void {
+  if (redirectingToLogin) return;
+  redirectingToLogin = true;
+  // Never hydrate a new/renewed session with another user's account-scoped
+  // payloads. Sidebar preferences use separate keys and remain intact.
+  window.localStorage.removeItem('turbodiff.queryCache');
+  window.location.replace('/auth/login?expired=1');
+}
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const baseHeaders: Record<string, string> = init?.body
@@ -28,7 +39,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     headers: { ...baseHeaders, ...init?.headers },
   });
   if (res.status === 401) {
-    window.location.href = '/auth/login';
+    restartAuthentication();
     throw new ApiError('signed out', 401);
   }
   if (res.status === 304 && cached) {

--- a/src/client/lib/queries.ts
+++ b/src/client/lib/queries.ts
@@ -65,7 +65,16 @@ export function taskIsLive(p: ApiPlan): boolean {
 export const meQuery = queryOptions({
   queryKey: ['me'],
   queryFn: () => api.get<ApiMe>('/api/me'),
-  staleTime: Infinity,
+  staleTime: 60_000,
+  refetchInterval: (query) => {
+    const status = query.state.data?.github_status;
+    if (status === 'syncing') return 2_000;
+    if (status === 'reauthorization_required') return 5_000;
+    if (status === 'temporarily_unavailable') return 15_000;
+    // Detect a provider credential that disappeared after the last durable
+    // membership snapshot without making navigation wait on GitHub.
+    return 60_000;
+  },
 });
 
 export const boardQuery = queryOptions({

--- a/src/client/lib/use-live-refresh.ts
+++ b/src/client/lib/use-live-refresh.ts
@@ -10,6 +10,10 @@ import { api } from './api.ts';
 // the page being looked at. The per-query 30s intervals in queries.ts remain
 // as a slow fallback; this hook is what makes changes land in seconds.
 const FALLBACK_POLL_MS = 30_000;
+// A socket that never opens is commonly an auth/proxy rejection. Five
+// exponential attempts are enough to ride out a deploy without creating an
+// endless request storm; the authenticated version poll remains the fallback.
+const MAX_UNOPENED_ATTEMPTS = 5;
 
 // Query keys that mirror live factory state.
 const LIVE_KEYS = ['board', 'task', 'feature', 'chat', 'automation-runs', 'automation-run'];
@@ -65,6 +69,7 @@ export function useLiveRefresh(installationIds: number[]): void {
         if (opened) connected = Math.max(0, connected - 1);
         updateConnectionState();
         if (stopped) return;
+        if (!opened && attempt >= MAX_UNOPENED_ATTEMPTS - 1) return;
         const delay = Math.min(30_000, 1_000 * 2 ** Math.min(attempt, 5));
         const timer = window.setTimeout(() => {
           reconnectTimers.delete(timer);

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -349,7 +349,6 @@ if ('requestIdleCallback' in window) {
 // real content immediately and revalidates in the background. Heavy or
 // fast-moving payloads (diffs, file contents, chat) stay memory-only.
 const PERSISTED_KEYS = new Set([
-  'me',
   'board',
   'agents',
   'skills',
@@ -359,7 +358,7 @@ const PERSISTED_KEYS = new Set([
   'usage',
 ]);
 // Bump to drop persisted caches whose shape no longer matches the client.
-const PERSIST_BUSTER = 'v2';
+const PERSIST_BUSTER = 'v3';
 const persistOptions: PersistQueryClientOptions = {
   queryClient,
   persister: createSyncStoragePersister({

--- a/src/client/pages/onboarding.tsx
+++ b/src/client/pages/onboarding.tsx
@@ -1,9 +1,9 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { ArrowRight } from 'lucide-react';
+import { ArrowRight, RefreshCw } from 'lucide-react';
 import { meQuery } from '../lib/queries.ts';
 import { Lamp } from '../components/identity.tsx';
 import { Card } from '../components/ui/card.tsx';
-import { buttonVariants } from '../components/ui/button.tsx';
+import { Button, buttonVariants } from '../components/ui/button.tsx';
 import { cn } from '../lib/utils.ts';
 
 // lucide-react dropped brand icons; GitHub's mark is inlined.
@@ -22,7 +22,7 @@ function GitHubMark({ className }: { className?: string }) {
 // AppShell chrome (see main.tsx) so the only ways out are connect or skip.
 
 export function OnboardingPage() {
-  const { data: me } = useSuspenseQuery(meQuery);
+  const { data: me, refetch, isFetching } = useSuspenseQuery(meQuery);
   // The connect flow round-trips through GitHub; better-auth redirects
   // failures back here with ?error=link_failed.
   const linkFailed = new URLSearchParams(window.location.search).has('error');
@@ -51,32 +51,7 @@ export function OnboardingPage() {
       )}
 
       <Card className="mt-6 space-y-4">
-        {me.github_connected ? (
-          <>
-            <div className="flex items-center gap-2 text-[0.85rem] text-ink-dim">
-              <Lamp tone="go" />
-              GitHub connected as <span className="font-mono text-ink">@{me.login}</span>
-            </div>
-            <p className="text-[0.85rem] text-mute">
-              One step left: install the GitHub App on the organizations or accounts whose
-              repositories the factory should work on.
-            </p>
-            <a
-              href={`https://github.com/apps/${me.github_app_slug}/installations/new`}
-              className={cn(buttonVariants({ variant: 'default' }), 'w-full')}
-            >
-              <GitHubMark className="size-4" />
-              Install the GitHub App
-            </a>
-            <p className="text-xs text-mute">
-              Or skip GitHub entirely:{' '}
-              <a href="/projects/new" className="text-accent-bright hover:underline">
-                create a turbodiff-hosted project
-              </a>{' '}
-              — the factory builds, reviews, and merges it natively.
-            </p>
-          </>
-        ) : (
+        {me.github_status === 'not_connected' ? (
           <>
             <div className="flex items-center gap-2 text-[0.85rem] text-ink-dim">
               <Lamp tone="hold" />
@@ -94,6 +69,98 @@ export function OnboardingPage() {
               in the app.
             </p>
           </>
+        ) : me.github_status === 'reauthorization_required' ? (
+          <>
+            <div className="flex items-center gap-2 text-[0.85rem] text-ink-dim">
+              <Lamp tone="hold" />
+              GitHub authorization needs to be renewed
+            </div>
+            <p className="text-[0.85rem] text-mute">
+              Your Turbodiff account is intact, but its GitHub credential is missing or expired.
+              Re-authorize to restore repository access.
+            </p>
+            <a
+              href="/auth/connect/github?next=/onboarding"
+              className={cn(buttonVariants({ variant: 'default' }), 'w-full')}
+            >
+              <GitHubMark className="size-4" />
+              Re-authorize GitHub
+            </a>
+          </>
+        ) : me.github_status === 'temporarily_unavailable' ? (
+          <>
+            <div className="flex items-center gap-2 text-[0.85rem] text-ink-dim">
+              <Lamp tone="hold" />
+              GitHub access could not be verified
+            </div>
+            <p className="text-[0.85rem] text-mute">
+              This is usually temporary. Retry the check, or re-authorize GitHub if it continues.
+              Native Turbodiff projects remain available.
+            </p>
+            <Button
+              type="button"
+              className="w-full"
+              loading={isFetching}
+              onClick={() => void refetch()}
+            >
+              <RefreshCw className="size-4" aria-hidden />
+              Try again
+            </Button>
+            <a
+              href="/auth/connect/github?next=/onboarding"
+              className={cn(buttonVariants({ variant: 'secondary' }), 'w-full')}
+            >
+              Re-authorize GitHub
+            </a>
+          </>
+        ) : me.github_status === 'app_not_installed' ? (
+          <>
+            <div className="flex items-center gap-2 text-[0.85rem] text-ink-dim">
+              <Lamp tone="go" />
+              GitHub connected as <span className="font-mono text-ink">@{me.login}</span>
+            </div>
+            <p className="text-[0.85rem] text-mute">
+              No GitHub App installation is available to this account yet. Install it on the
+              organizations or accounts the factory should use, or ask an organization owner to
+              grant you access.
+            </p>
+            <a
+              href={`https://github.com/apps/${me.github_app_slug}/installations/new`}
+              className={cn(buttonVariants({ variant: 'default' }), 'w-full')}
+            >
+              <GitHubMark className="size-4" />
+              Install or configure the GitHub App
+            </a>
+            <p className="text-xs text-mute">
+              Or skip GitHub entirely:{' '}
+              <a href="/projects/new" className="text-accent-bright hover:underline">
+                create a turbodiff-hosted project
+              </a>{' '}
+              — the factory builds, reviews, and merges it natively.
+            </p>
+          </>
+        ) : me.github_status === 'syncing' ? (
+          <>
+            <div className="flex items-center gap-2 text-[0.85rem] text-ink-dim">
+              <RefreshCw className="size-4 animate-spin text-accent-bright" aria-hidden />
+              Restoring GitHub repositories for <span className="font-mono">@{me.login}</span>
+            </div>
+            <p className="text-[0.85rem] text-mute">
+              Turbodiff found your GitHub App installations and is rebuilding the local repository
+              mirror. This page will update automatically.
+            </p>
+          </>
+        ) : (
+          <>
+            <div className="flex items-center gap-2 text-[0.85rem] text-ink-dim">
+              <Lamp tone="go" />
+              GitHub ready as <span className="font-mono text-ink">@{me.login}</span>
+            </div>
+            <p className="text-[0.85rem] text-mute">
+              Your account and GitHub App installations are connected. The factory is ready to use
+              the repositories you selected on GitHub.
+            </p>
+          </>
         )}
       </Card>
 
@@ -101,7 +168,7 @@ export function OnboardingPage() {
         href="/"
         className="mt-5 inline-flex items-center gap-1.5 self-start text-[0.85rem] text-mute hover:text-ink"
       >
-        {me.github_connected ? 'Go to the board' : 'Skip for now'}
+        {me.github_status === 'not_connected' ? 'Skip for now' : 'Go to the board'}
         <ArrowRight className="size-3.5" aria-hidden />
       </a>
     </div>

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -391,6 +391,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
     if (!user) return c.json({ error: 'unauthorized' }, 401);
     c.set('user', user);
     if (user.membershipRefresh) deferredExecution(c).waitUntil(user.membershipRefresh());
+    if (user.repositoryRepair) deferredExecution(c).waitUntil(user.repositoryRepair());
     await next();
   });
 
@@ -421,6 +422,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
       login: user.githubConnected ? user.session.login : null,
       name: user.name,
       github_connected: user.githubConnected,
+      github_status: user.githubStatus,
       github_app_slug: env.GITHUB_APP_SLUG,
       vapid_public_key: env.VAPID_PUBLIC_KEY,
       installation_ids: user.installationIds,

--- a/src/http/api.worker.test.ts
+++ b/src/http/api.worker.test.ts
@@ -25,6 +25,7 @@ const acmeUser: AuthedUser = {
   session: { authUserId: 'user-3001', userId: 3001, login: 'octocat' },
   installationIds: [1001],
   githubConnected: true,
+  githubStatus: 'ready',
   name: 'octocat',
 };
 
@@ -119,6 +120,56 @@ describe('API authentication and CSRF', () => {
     const response = await apiApp().request('https://turbodiff.test/api/me');
     expect(response.status).toBe(401);
     expect(await response.json()).toEqual({ error: 'unauthorized' });
+  });
+
+  it('keeps a migrated user signed in when GitHub needs re-authorization', async () => {
+    const response = await apiApp({
+      authenticate: async () => ({
+        ...acmeUser,
+        installationIds: [],
+        githubStatus: 'reauthorization_required',
+      }),
+    }).request('https://turbodiff.test/api/me');
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      login: 'octocat',
+      github_connected: true,
+      github_status: 'reauthorization_required',
+      installation_ids: [],
+    });
+  });
+
+  it('guides a new connected user to install the GitHub App', async () => {
+    const response = await apiApp({
+      authenticate: async () => ({
+        ...acmeUser,
+        installationIds: [],
+        githubStatus: 'app_not_installed',
+      }),
+    }).request('https://turbodiff.test/api/me');
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      github_connected: true,
+      github_status: 'app_not_installed',
+      installation_ids: [],
+    });
+  });
+
+  it('starts repository repair without delaying the migrated user response', async () => {
+    const repositoryRepair = vi.fn(async () => {});
+    const response = await apiApp({
+      authenticate: async () => ({
+        ...acmeUser,
+        githubStatus: 'syncing',
+        repositoryRepair,
+      }),
+    }).request('https://turbodiff.test/api/me');
+
+    expect(response.status).toBe(200);
+    expect(repositoryRepair).toHaveBeenCalledOnce();
+    expect(await response.json()).toMatchObject({ github_status: 'syncing' });
   });
 
   it('rejects a cross-origin mutation before invoking authentication', async () => {
@@ -1044,6 +1095,7 @@ describe('push subscriptions', () => {
       session: { authUserId: 'email-user', userId: 0, login: '' },
       installationIds: [],
       githubConnected: false,
+      githubStatus: 'not_connected',
       name: 'Email User',
     };
     const response = await apiApp({ authenticate: async () => emailUser }).request(

--- a/src/http/auth-email.worker.test.ts
+++ b/src/http/auth-email.worker.test.ts
@@ -7,6 +7,7 @@ import { testDatabase } from '../test/database-fixture.ts';
 import { Hono } from 'hono';
 import { describe, expect, it } from 'vite-plus/test';
 import type { JsonObject } from '../shared/json.ts';
+import { requireUser } from '../services/auth.ts';
 import { handleEmailSignUp } from './auth-email.ts';
 
 async function signUp(body: JsonObject): Promise<Response> {
@@ -35,6 +36,18 @@ describe('email/password sign-up', () => {
       .bind('pat@example.test')
       .first<{ name: string; login: string | null; githubId: number | null }>();
     expect(user).toEqual({ name: 'Pat', login: null, githubId: null });
+
+    const cookie = response.headers.get('set-cookie')?.split(';', 1)[0];
+    const sessionUser = await requireUser(
+      new Request('https://turbodiff.test/api/me', {
+        headers: { cookie: cookie ?? '' },
+      }),
+    );
+    expect(sessionUser).toMatchObject({
+      githubConnected: false,
+      githubStatus: 'not_connected',
+      installationIds: [],
+    });
   });
 
   it('drops forged GitHub identity fields from the sign-up body', async () => {
@@ -55,5 +68,37 @@ describe('email/password sign-up', () => {
       .bind('mallory@example.test')
       .first<{ login: string | null; githubId: number | null }>();
     expect(user).toEqual({ login: null, githubId: null });
+  });
+
+  it('keeps a migrated session recoverable when its GitHub account row is missing', async () => {
+    const response = await signUp({
+      name: 'Migrated User',
+      email: 'migrated@example.test',
+      password: 'a-long-password',
+    });
+    expect(response.status).toBe(200);
+    const cookie = response.headers.get('set-cookie')?.split(';', 1)[0];
+    expect(cookie).toContain('turbodiff.session_token');
+
+    // This is the migration failure shape: the durable user/session made it
+    // to PostgreSQL, including the GitHub identity fields, but the provider
+    // account/token row did not.
+    await testDatabase()
+      .prepare('UPDATE "user" SET login = ?1, "githubId" = ?2 WHERE email = ?3')
+      .bind('migrated-user', 987654, 'migrated@example.test')
+      .run();
+
+    const user = await requireUser(
+      new Request('https://turbodiff.test/api/me', {
+        headers: { cookie: cookie ?? '' },
+      }),
+    );
+
+    expect(user).toMatchObject({
+      githubConnected: true,
+      githubStatus: 'reauthorization_required',
+      installationIds: [],
+      session: { userId: 987654, login: 'migrated-user' },
+    });
   });
 });

--- a/src/http/auth-page.tsx
+++ b/src/http/auth-page.tsx
@@ -71,6 +71,12 @@ const CSS = `
 		border: 1px solid rgba(248, 81, 73, 0.4); border-radius: 8px;
 	}
 	.error.show { display: block; }
+	.notice {
+		margin-bottom: 1rem; padding: 0.65rem 0.75rem;
+		font-size: 0.82rem; color: var(--ink);
+		background: rgba(63, 185, 80, 0.08);
+		border: 1px solid rgba(63, 185, 80, 0.35); border-radius: 8px;
+	}
 	.submit {
 		width: 100%; padding: 0.6rem 0; margin-top: 0.2rem;
 		font: 500 0.9rem/1 "IBM Plex Sans", system-ui, sans-serif;
@@ -168,7 +174,7 @@ function GitHubIcon() {
   );
 }
 
-function AuthPage({ next }: { next?: string }) {
+function AuthPage({ next, notice }: { next?: string; notice?: string }) {
   const githubHref = next
     ? `/auth/login/github?next=${encodeURIComponent(next)}`
     : '/auth/login/github';
@@ -195,6 +201,11 @@ function AuthPage({ next }: { next?: string }) {
 
         <main>
           <div class="panel">
+            {notice ? (
+              <p class="notice" role="status">
+                {notice}
+              </p>
+            ) : null}
             <a class="github" href={githubHref}>
               <GitHubIcon />
               Continue with GitHub
@@ -263,6 +274,6 @@ function AuthPage({ next }: { next?: string }) {
   );
 }
 
-export function renderAuthPage(next?: string): string {
-  return `<!doctype html>${(<AuthPage next={next} />).toString()}`;
+export function renderAuthPage(next?: string, notice?: string): string {
+  return `<!doctype html>${(<AuthPage next={next} notice={notice} />).toString()}`;
 }

--- a/src/http/mcp.worker.test.ts
+++ b/src/http/mcp.worker.test.ts
@@ -20,6 +20,7 @@ const acmeUser: AuthedUser = {
   session: { authUserId: 'user-3001', userId: 3001, login: 'octocat' },
   installationIds: [1001],
   githubConnected: true,
+  githubStatus: 'ready',
   name: 'octocat',
 };
 

--- a/src/http/ui.ts
+++ b/src/http/ui.ts
@@ -208,9 +208,19 @@ export function createUiRoutes() {
     // landing on / would strand the client's OAuth flow.
     const query = new URL(c.req.url).searchParams;
     const oauthAuthorize = query.has('client_id') && query.has('redirect_uri');
+    const renewSession = query.get('expired') === '1';
     const next = oauthAuthorize ? `/api/auth/mcp/authorize?${query.toString()}` : '/';
-    if (await hasSession(c)) return c.redirect(next);
-    return c.html(renderAuthPage(oauthAuthorize ? next : undefined));
+    // An API 401 can arrive while a cookie-cached shell session still exists.
+    // Do not redirect that recovery request back to the dashboard.
+    if (!renewSession && (await hasSession(c))) return c.redirect(next);
+    return c.html(
+      renderAuthPage(
+        oauthAuthorize ? next : undefined,
+        renewSession
+          ? 'Your Turbodiff session needs to be renewed. Sign in to continue.'
+          : undefined,
+      ),
+    );
   });
 
   app.get('/auth/login/github', async (c) => {

--- a/src/integrations/github/client.ts
+++ b/src/integrations/github/client.ts
@@ -2,6 +2,16 @@ import type { JsonValue } from '../../shared/json.ts';
 
 const API = 'https://api.github.com';
 
+export class GitHubApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'GitHubApiError';
+  }
+}
+
 function apiUrl(pathOrUrl: string): string {
   if (pathOrUrl.startsWith('/')) return `${API}${pathOrUrl}`;
   const url = new URL(pathOrUrl);
@@ -33,7 +43,8 @@ export async function githubRequest(
   const response = await fetch(apiUrl(pathOrUrl), { ...requestInit, headers });
   // 304 is a success for conditional requests, not an error.
   if (!response.ok && !(allow304 && response.status === 304)) {
-    throw new Error(
+    throw new GitHubApiError(
+      response.status,
       `GitHub API ${response.status} on ${pathOrUrl}: ${(await response.text()).slice(0, 500)}`,
     );
   }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,6 +1,7 @@
 import { env } from 'cloudflare:workers';
 import { sql } from 'drizzle-orm';
 import { queryOne } from '../data/database.ts';
+import { ensureBuiltinAgents } from '../data/db.ts';
 import { withAuth, type AuthUser } from '../integrations/auth/better-auth.ts';
 import {
   installationAccessSnapshot,
@@ -12,7 +13,9 @@ import {
   fetchUserInstallationIds,
   fetchUserOrgRole,
 } from '../integrations/github/app.ts';
+import { GitHubApiError } from '../integrations/github/client.ts';
 import { isNumber, isString } from '../shared/json.ts';
+import { syncInstallationRepos } from './repository-sync.ts';
 
 // Application authorization on top of better-auth sessions. The session
 // (who you are) is durable and only ends by explicit sign-out or 30-day
@@ -31,6 +34,7 @@ export type AuthedUser = {
   session: { authUserId: string; userId: number; login: string };
   installationIds: number[];
   githubConnected: boolean;
+  githubStatus: GitHubStatus;
   // Display identity for the shell — the GitHub login when connected, the
   // sign-up name otherwise.
   name: string;
@@ -38,10 +42,22 @@ export type AuthedUser = {
   // snapshot after responding. HTTP middleware attaches this to waitUntil;
   // non-HTTP callers simply use the bounded stale snapshot.
   membershipRefresh?: () => Promise<void>;
+  // A fresh GitHub membership answer may be the first one since a database
+  // migration. Rebuild the recoverable installation/repository mirror after
+  // the response; historical factory records remain a separate migration.
+  repositoryRepair?: () => Promise<void>;
   // Local DEV_FAKE_INSTALLATIONS session — no GitHub token to verify repo
   // permissions with, so permission checks pass by construction.
   devFake?: boolean;
 };
+
+export type GitHubStatus =
+  | 'not_connected'
+  | 'reauthorization_required'
+  | 'temporarily_unavailable'
+  | 'app_not_installed'
+  | 'syncing'
+  | 'ready';
 
 // Per-isolate caches. Entries are tiny (a token string / a handful of ids);
 // isolate recycling is the eviction policy.
@@ -52,7 +68,17 @@ const INSTALLATIONS_TTL_MS = 5 * 60_000;
 const INSTALLATIONS_STALE_MAX_MS = 60 * 60_000;
 const tokenCache = new Map<string, { token: string; exp: number }>();
 const installationsCache = new Map<string, { ids: number[]; fetchedAt: number }>();
-const installationRefreshes = new Map<string, Promise<number[] | null>>();
+const repositoryRepairs = new Map<string, Promise<void>>();
+type InstallationRefresh =
+  | { kind: 'success'; ids: number[] }
+  | { kind: 'reauthorization_required' }
+  | { kind: 'temporarily_unavailable' };
+
+const installationRefreshes = new Map<string, Promise<InstallationRefresh>>();
+const githubAccessIssues = new Map<
+  string,
+  'reauthorization_required' | 'temporarily_unavailable'
+>();
 // Synthetic (Artifacts) installation ids were the one uncached PostgreSQL read on
 // every API request — same TTL discipline as the GitHub installation list,
 // with the same bounded staleness on membership revocation.
@@ -89,21 +115,34 @@ async function githubToken(userId: string): Promise<string> {
 }
 
 // GitHub-verified installation ids, cached for 5 minutes and served stale
-// (up to an hour) when GitHub is unreachable. Null only when there is no
-// answer at all — fresh fetch failed and nothing usable is cached.
-async function refreshInstallationIds(userId: string): Promise<number[] | null> {
+// (up to an hour) when GitHub is unreachable. Without a usable snapshot, the
+// result preserves whether the user should retry or re-authorize.
+async function refreshInstallationIds(userId: string): Promise<InstallationRefresh> {
   const running = installationRefreshes.get(userId);
   if (running) return running;
   const refresh = (async () => {
     const ghToken = await githubToken(userId);
-    if (!ghToken) return null;
+    if (!ghToken) {
+      githubAccessIssues.set(userId, 'reauthorization_required');
+      return { kind: 'reauthorization_required' } as const;
+    }
     try {
       const ids = await fetchUserInstallationIds(ghToken);
       await storeInstallationAccessSnapshot(userId, ids);
       installationsCache.set(userId, { ids, fetchedAt: Date.now() });
-      return ids;
-    } catch {
-      return null;
+      githubAccessIssues.delete(userId);
+      return { kind: 'success', ids } as const;
+    } catch (err) {
+      // Never keep retrying a rejected credential from isolate memory. A
+      // successful relink updates PostgreSQL; the next request must read it.
+      tokenCache.delete(userId);
+      if (err instanceof GitHubApiError && err.status === 401) {
+        githubAccessIssues.set(userId, 'reauthorization_required');
+        return { kind: 'reauthorization_required' } as const;
+      }
+      githubAccessIssues.set(userId, 'temporarily_unavailable');
+      console.warn('turbodiff: GitHub installation membership is temporarily unavailable', err);
+      return { kind: 'temporarily_unavailable' } as const;
     }
   })();
   installationRefreshes.set(userId, refresh);
@@ -115,14 +154,51 @@ async function refreshInstallationIds(userId: string): Promise<number[] | null> 
 }
 
 interface InstallationResolution {
+  kind: 'success';
   ids: number[];
   refresh?: () => Promise<void>;
+  repair?: () => Promise<void>;
 }
 
-async function installationIds(userId: string): Promise<InstallationResolution | null> {
+type InstallationResult =
+  | InstallationResolution
+  | { kind: 'reauthorization_required' | 'temporarily_unavailable' };
+
+async function repairRepositoryMirror(userId: string, installationIds: number[]): Promise<void> {
+  const running = repositoryRepairs.get(userId);
+  if (running) return running;
+  const repair = Promise.all(
+    installationIds.map((installationId) =>
+      syncInstallationRepos(installationId)
+        .then(() => ensureBuiltinAgents(installationId))
+        .catch((err) => {
+          console.warn(
+            `turbodiff: installation recovery failed for installation ${installationId}:`,
+            err,
+          );
+        }),
+    ),
+  ).then(() => undefined);
+  repositoryRepairs.set(userId, repair);
+  try {
+    await repair;
+  } finally {
+    if (repositoryRepairs.get(userId) === repair) repositoryRepairs.delete(userId);
+  }
+}
+
+async function installationIds(userId: string): Promise<InstallationResult> {
   const cached = installationsCache.get(userId);
   if (cached && Date.now() - cached.fetchedAt < INSTALLATIONS_TTL_MS) {
-    return { ids: cached.ids };
+    return {
+      kind: 'success',
+      ids: cached.ids,
+      refresh: githubAccessIssues.has(userId)
+        ? async () => {
+            await refreshInstallationIds(userId);
+          }
+        : undefined,
+    };
   }
 
   const durable = await installationAccessSnapshot(userId);
@@ -133,9 +209,20 @@ async function installationIds(userId: string): Promise<InstallationResolution |
       fetchedAt: durable.verifiedAt,
     });
     const age = now - durable.verifiedAt;
-    if (age < INSTALLATIONS_TTL_MS) return { ids: durable.installationIds };
+    if (age < INSTALLATIONS_TTL_MS) {
+      return {
+        kind: 'success',
+        ids: durable.installationIds,
+        refresh: githubAccessIssues.has(userId)
+          ? async () => {
+              await refreshInstallationIds(userId);
+            }
+          : undefined,
+      };
+    }
     if (age < INSTALLATIONS_STALE_MAX_MS) {
       return {
+        kind: 'success',
         ids: durable.installationIds,
         refresh: async () => {
           await refreshInstallationIds(userId);
@@ -145,11 +232,17 @@ async function installationIds(userId: string): Promise<InstallationResolution |
   }
 
   const fresh = await refreshInstallationIds(userId);
-  if (fresh) return { ids: fresh };
-  if (cached && now - cached.fetchedAt < INSTALLATIONS_STALE_MAX_MS) {
-    return { ids: cached.ids };
+  if (fresh.kind === 'success') {
+    return {
+      kind: 'success',
+      ids: fresh.ids,
+      repair: fresh.ids.length > 0 ? () => repairRepositoryMirror(userId, fresh.ids) : undefined,
+    };
   }
-  return null;
+  if (cached && now - cached.fetchedAt < INSTALLATIONS_STALE_MAX_MS) {
+    return { kind: 'success', ids: cached.ids };
+  }
+  return fresh;
 }
 
 export async function githubTokenForUser(user: AuthedUser): Promise<string> {
@@ -231,6 +324,7 @@ export async function requireUser(request: Request): Promise<AuthedUser | null> 
         .map(Number)
         .filter((n) => Number.isInteger(n)),
       githubConnected: true,
+      githubStatus: 'ready',
       name: 'dev',
       devFake: true,
     };
@@ -260,6 +354,7 @@ async function resolveAuthedUser(user: AuthUser): Promise<AuthedUser | null> {
       session: { authUserId: user.id, userId: 0, login: '' },
       installationIds: [],
       githubConnected: false,
+      githubStatus: 'not_connected',
       name: user.name || user.email,
     };
   }
@@ -268,15 +363,34 @@ async function resolveAuthedUser(user: AuthUser): Promise<AuthedUser | null> {
     installationIds(user.id),
     cachedSyntheticInstallationIds(githubId),
   ]);
-  if (resolved === null) return null;
+  if (resolved.kind !== 'success') {
+    return {
+      session: { authUserId: user.id, userId: githubId, login },
+      // A GitHub credential problem must not lock a user out of native
+      // projects whose authorization is already durable in PostgreSQL.
+      installationIds: synthetic,
+      githubConnected: true,
+      githubStatus: resolved.kind,
+      name: login,
+    };
+  }
   // GitHub cannot know about Artifacts-hosted projects, so membership-derived
   // installation ids are unioned in.
+  const accessIssue = githubAccessIssues.get(user.id);
   return {
     session: { authUserId: user.id, userId: githubId, login },
     installationIds: [...new Set([...resolved.ids, ...synthetic])],
     githubConnected: true,
+    githubStatus:
+      accessIssue ??
+      (resolved.ids.length === 0
+        ? 'app_not_installed'
+        : resolved.repair || repositoryRepairs.has(user.id)
+          ? 'syncing'
+          : 'ready'),
     name: login,
     membershipRefresh: resolved.refresh,
+    repositoryRepair: resolved.repair,
   };
 }
 

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -406,6 +406,15 @@ export interface ApiMe {
   login: string | null;
   name: string;
   github_connected: boolean;
+  // Recovery-oriented account state. `github_connected` remains the stable
+  // identity/link flag; this tells the UI which useful next action to show.
+  github_status:
+    | 'not_connected'
+    | 'reauthorization_required'
+    | 'temporarily_unavailable'
+    | 'app_not_installed'
+    | 'syncing'
+    | 'ready';
   github_app_slug: string;
   vapid_public_key: string;
   installation_ids: number[];


### PR DESCRIPTION
## Summary

- distinguish an expired Turbodiff session from recoverable GitHub account states
- guide users to connect GitHub, re-authorize, retry, or install/configure the GitHub App
- rebuild missing GitHub installation, repository, and built-in agent rows in the background
- stop persisting account identity across sessions and bound failed WebSocket reconnects
- prevent the login route from redirecting a forced session renewal back into the dashboard loop

## Root cause

The dashboard shell accepted a valid Better Auth session, while API authentication returned 401 when GitHub installation membership could not be resolved. This could happen when PostgreSQL contained the user/session rows but was missing the migrated GitHub provider account or installation snapshot. The client redirected to the login page, which saw the valid base session and redirected back to the dashboard, creating the reload loop.

The API now keeps the valid application session and reports a typed GitHub recovery state instead. Repository authorization remains fail-closed when no verified GitHub installation IDs are available, while native Turbodiff projects remain accessible.

A successful GitHub membership refresh also repairs the recoverable PostgreSQL mirror data. Historical tasks, reviews, and usage records still require migration from the original database.

## Verification

- vp test: 19 files, 116 tests passed
- PostgreSQL-backed Worker suite: 11 files, 144 tests passed
- Worker, client, and Worker-test TypeScript checks passed
- client production build passed
- formatting and lint completed with zero errors