### PR TITLE
fix: mobile chat overflow and discarded work when the check binary isn't on PATH

### DIFF
--- a/src/ai/runners/chat.ts
+++ b/src/ai/runners/chat.ts
@@ -30,6 +30,7 @@ import {
 } from '../../integrations/github/app.ts';
 import { UNTRUSTED_CONTENT_RULES } from '../../domain/prompt-security.ts';
 import { installDependencies, NPM_CACHE_ENV } from '../runtime/sandbox-deps.ts';
+import { checkCommandUnrunnable, runCheckCommand } from '../runtime/check-command.ts';
 import {
   CHAT_BUSY_DELAY_SECONDS,
   CHAT_BUSY_RETRIES,
@@ -313,15 +314,13 @@ export async function runChatTurn(params: ChatTurnParams): Promise<ChatTurnResul
     }
 
     if (params.testCommand) {
-      const runTests = async () => {
-        const tests = await sandbox.exec(params.testCommand!, {
-          cwd: CLONE_DIR,
-          timeout: TEST_TIMEOUT_MS,
-          env: NPM_CACHE_ENV,
-        });
-        return { ok: tests.success, output: scrub(`${tests.stdout}\n${tests.stderr}`.trim()) };
-      };
+      const runTests = () =>
+        runCheckCommand(sandbox, CLONE_DIR, params.testCommand!, scrub, TEST_TIMEOUT_MS);
       let tests = await runTests();
+      // A check command that can't even be executed is a misconfiguration,
+      // not a failing test — fail loudly rather than silently discarding the
+      // committed work as `tests_failed`.
+      if (tests.notExecutable) throw checkCommandUnrunnable(params.testCommand, tests.output);
       for (let round = 1; !tests.ok && round <= REPAIR_ROUNDS; round++) {
         // Drop test-command working-tree mutations before the agent looks.
         await sandbox.exec(`git -C ${CLONE_DIR} checkout -- . && git -C ${CLONE_DIR} clean -fd`);

--- a/src/ai/runners/fixer.ts
+++ b/src/ai/runners/fixer.ts
@@ -29,6 +29,7 @@ import {
 } from '../../integrations/github/app.ts';
 import { UNTRUSTED_CONTENT_RULES } from '../../domain/prompt-security.ts';
 import { installDependencies, NPM_CACHE_ENV } from '../runtime/sandbox-deps.ts';
+import { checkCommandUnrunnable, runCheckCommand } from '../runtime/check-command.ts';
 import { FIX_MAX_ATTEMPTS, type FixQueueMessage } from '../../shared/factory-messages.ts';
 import { enqueueFactoryMessage } from '../../services/factory-queue.ts';
 import { completeLifecycleRepair } from '../../services/lifecycle.ts';
@@ -411,15 +412,13 @@ export async function runFix(params: FixParams): Promise<FixOutcome> {
 
     let testOutput: string | undefined;
     if (params.testCommand) {
-      const runTests = async () => {
-        const tests = await sandbox.exec(params.testCommand!, {
-          cwd: CLONE_DIR,
-          timeout: TEST_TIMEOUT_MS,
-          env: NPM_CACHE_ENV,
-        });
-        return { ok: tests.success, output: scrub(`${tests.stdout}\n${tests.stderr}`.trim()) };
-      };
+      const runTests = () =>
+        runCheckCommand(sandbox, CLONE_DIR, params.testCommand!, scrub, TEST_TIMEOUT_MS);
       let tests = await runTests();
+      // A check command that can't even be executed is a misconfiguration,
+      // not a failing test — fail loudly rather than recording tests_failed
+      // and discarding the committed fix.
+      if (tests.notExecutable) throw checkCommandUnrunnable(params.testCommand, tests.output);
       let sessionId = claudeCliSessionId(agent.stdout);
       for (let round = 1; !tests.ok && round <= REPAIR_ROUNDS; round++) {
         // Drop test-command working-tree mutations before the agent looks:

--- a/src/ai/runtime/check-command.test.ts
+++ b/src/ai/runtime/check-command.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vite-plus/test';
+import type { ExecOptions, ExecResult } from '@cloudflare/sandbox';
+import { type CheckSandbox, checkCommandUnrunnable, runCheckCommand } from './check-command.ts';
+
+// Minimal fake sandbox: records the exec invocation and returns a canned
+// result, enough to exercise runCheckCommand without a real container. Only
+// the fields runCheckCommand reads need real values.
+function fakeSandbox(result: Pick<ExecResult, 'success' | 'exitCode' | 'stdout' | 'stderr'>) {
+  const calls: { command: string; options?: ExecOptions }[] = [];
+  const sandbox: CheckSandbox = {
+    exec: async (command, options) => {
+      calls.push({ command, options });
+      return { ...result, command, duration: 0, timestamp: '1970-01-01T00:00:00Z' };
+    },
+  };
+  return { sandbox, calls };
+}
+
+const scrub = (s: string) => s;
+const TIMEOUT = 60_000;
+
+describe('runCheckCommand', () => {
+  it('prepends the checkout bin dir to PATH so bare binaries resolve', async () => {
+    const { sandbox, calls } = fakeSandbox({
+      success: true,
+      exitCode: 0,
+      stdout: 'ok',
+      stderr: '',
+    });
+
+    const res = await runCheckCommand(sandbox, '/workspace/repo', 'vp check', scrub, TIMEOUT);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.command).toBe(
+      'export PATH="/workspace/repo/node_modules/.bin:$PATH"; vp check',
+    );
+    expect(res).toMatchObject({ ok: true, notExecutable: false });
+  });
+
+  it('treats a running check that reports failures as a real test failure', async () => {
+    const { sandbox } = fakeSandbox({
+      success: false,
+      exitCode: 1,
+      stdout: '2 tests failed',
+      stderr: '',
+    });
+
+    const res = await runCheckCommand(sandbox, '/workspace/repo', 'vp test', scrub, TIMEOUT);
+
+    expect(res).toMatchObject({ ok: false, notExecutable: false });
+  });
+
+  it('flags a missing binary (exit 127 + "command not found") as not executable', async () => {
+    const { sandbox } = fakeSandbox({
+      success: false,
+      exitCode: 127,
+      stdout: '',
+      stderr: 'bash: line 1: vp: command not found',
+    });
+
+    const res = await runCheckCommand(sandbox, '/workspace/repo', 'vp check', scrub, TIMEOUT);
+
+    expect(res.notExecutable).toBe(true);
+  });
+
+  it('does not mistake a test that merely exits 127 for a missing binary', async () => {
+    const { sandbox } = fakeSandbox({
+      success: false,
+      exitCode: 127,
+      stdout: '127 assertions failed',
+      stderr: '',
+    });
+
+    const res = await runCheckCommand(sandbox, '/workspace/repo', 'vp test', scrub, TIMEOUT);
+
+    expect(res.notExecutable).toBe(false);
+  });
+});
+
+describe('checkCommandUnrunnable', () => {
+  it('names the command and includes the tail of the output', () => {
+    const err = checkCommandUnrunnable('vp check', 'vp: command not found');
+    expect(err.message).toContain('`vp check`');
+    expect(err.message).toContain('command not found');
+  });
+});

--- a/src/ai/runtime/check-command.ts
+++ b/src/ai/runtime/check-command.ts
@@ -1,0 +1,75 @@
+import type { ExecOptions, ExecResult } from '@cloudflare/sandbox';
+import { NPM_CACHE_ENV } from './sandbox-deps.ts';
+
+// The sliver of the sandbox this module drives. Narrowing to it (a real
+// Sandbox is assignable) keeps the dependency surface honest and lets tests
+// supply a lightweight fake without casting.
+export interface CheckSandbox {
+  exec(command: string, options?: ExecOptions): Promise<ExecResult>;
+}
+
+// Running a repository's check command (the sandbox verification gate before
+// factory pushes) has two hazards this helper handles for every runner:
+//
+//  1. PATH. The agent runs the check through pnpm/npm scripts, which put the
+//     checkout's `node_modules/.bin` on PATH — so a check like `vp check` or
+//     `eslint .` resolves. The harness's own post-run check ran the command
+//     bare, without that bin dir, so those same commands died with
+//     "command not found" and legitimate work was discarded as a test
+//     failure. Prepend `node_modules/.bin` so the harness resolves binaries
+//     the same way the package scripts do.
+//
+//  2. Executable vs. failing. A command that cannot be executed at all
+//     (missing binary, not executable) is an environment/config error, not a
+//     failing test — treating it as `tests_failed` silently throws away the
+//     agent's changes and tells the user their code failed checks when it did
+//     not. Surface it distinctly so the caller can fail loudly instead.
+
+export interface CheckResult {
+  ok: boolean;
+  output: string;
+  // The check command itself could not be run (binary missing from PATH, or
+  // not executable) — distinct from the command running and reporting
+  // failures. Callers should treat this as a hard error, not `tests_failed`.
+  notExecutable: boolean;
+}
+
+// Shell exit codes for "could not execute the command": 127 = not found,
+// 126 = found but not executable.
+const NOT_FOUND = 127;
+const NOT_EXECUTABLE = 126;
+
+export async function runCheckCommand(
+  sandbox: CheckSandbox,
+  dir: string,
+  command: string,
+  scrub: (s: string) => string,
+  timeoutMs: number,
+): Promise<CheckResult> {
+  // Prepend the checkout's bin dir via the shell so `$PATH` still expands to
+  // the container's PATH (setting env.PATH directly would clobber it, since
+  // exec merges env over the container and PATH is a single value).
+  const res = await sandbox.exec(`export PATH="${dir}/node_modules/.bin:$PATH"; ${command}`, {
+    cwd: dir,
+    env: NPM_CACHE_ENV,
+    timeout: timeoutMs,
+  });
+  const output = scrub(`${res.stdout}\n${res.stderr}`.trim());
+  // Only treat as "could not run" when the shell's not-found/not-executable
+  // exit code is corroborated by the matching message — a test that happens
+  // to exit 127 on its own still counts as a real failure.
+  const notExecutable =
+    !res.success &&
+    (res.exitCode === NOT_FOUND || res.exitCode === NOT_EXECUTABLE) &&
+    /command not found|not found|no such file|not executable|permission denied/i.test(output);
+  return { ok: res.success, output, notExecutable };
+}
+
+// The error thrown when the check command cannot be executed. Kept as one
+// message so both runners report the misconfiguration identically.
+export function checkCommandUnrunnable(command: string, output: string): Error {
+  return new Error(
+    `the repository check command (\`${command}\`) could not be run — ` +
+      `check that it is installed and correctly configured: ${output.slice(-300)}`,
+  );
+}

--- a/src/client/components/chat-panel.tsx
+++ b/src/client/components/chat-panel.tsx
@@ -38,13 +38,13 @@ function OutcomePill({ message }: { message: ApiChatMessage }) {
 function ChatMessage({ message }: { message: ApiChatMessage }) {
   if (message.role === 'user') {
     return (
-      <div className="ml-auto max-w-[85%] rounded-md border border-line-2 border-r-2 border-r-accent bg-surface px-3 py-2 text-[0.82rem]">
+      <div className="ml-auto min-w-0 max-w-[85%] rounded-md border border-line-2 border-r-2 border-r-accent bg-surface px-3 py-2 text-[0.82rem]">
         <div className="mb-1 flex items-center gap-1.5 text-xs text-mute">
           <strong>@{message.author}</strong>
           <span>{ago(message.created_at)}</span>
           {message.status === 'failed' ? <Pill tone="red">Failed</Pill> : null}
         </div>
-        <p className="whitespace-pre-wrap">{message.body}</p>
+        <p className="break-words whitespace-pre-wrap">{message.body}</p>
         {message.status === 'failed' && message.error ? (
           <p className="mt-1 text-xs text-danger">{message.error}</p>
         ) : null}
@@ -52,7 +52,7 @@ function ChatMessage({ message }: { message: ApiChatMessage }) {
     );
   }
   return (
-    <div className="max-w-[85%] rounded-md border border-line-2 border-l-2 border-l-accent bg-surface px-3 py-2 text-[0.82rem]">
+    <div className="min-w-0 max-w-[85%] rounded-md border border-line-2 border-l-2 border-l-accent bg-surface px-3 py-2 text-[0.82rem]">
       <div className="mb-1 flex items-center gap-1.5 text-xs text-mute">
         <strong>Agent</strong>
         <span>{ago(message.created_at)}</span>
@@ -125,10 +125,10 @@ export function ChatPanel({ featureId, canWrite }: { featureId: number; canWrite
   if (!canWrite && messages.length === 0) return null;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       <BlockLabel className="mb-3 shrink-0">Agent chat</BlockLabel>
       {/* Transcript scrolls inside the rail so the composer stays pinned. */}
-      <div className="min-h-0 flex-1 lg:overflow-y-auto">
+      <div className="min-h-0 min-w-0 flex-1 lg:overflow-y-auto">
         {chatLoading ? (
           // History-shaped placeholder — the "ask the agent" empty-state copy
           // must not flash while the real history is still loading.

--- a/src/client/pages/feature.tsx
+++ b/src/client/pages/feature.tsx
@@ -906,7 +906,7 @@ export default function FeaturePage() {
           chat — two matched-height panels that use the full width. Merge is the
           primary CTA, a guarded control that reads as armed only when green. */}
       <div className={cn('grid gap-4', showChat && 'lg:grid-cols-2 lg:items-stretch')}>
-        <Panel className="flex flex-col">
+        <Panel className="flex min-w-0 flex-col">
           <BlockLabel className="mb-3">Pipeline</BlockLabel>
           <GoNoGoBoard data={data} />
           {prState === 'open' || pendingCount > 0 || batchRunning ? (
@@ -970,7 +970,7 @@ export default function FeaturePage() {
         </Panel>
 
         {showChat ? (
-          <Panel className="flex flex-col lg:max-h-[26rem] lg:min-h-0">
+          <Panel className="flex min-w-0 flex-col lg:max-h-[26rem] lg:min-h-0">
             <ChatPanel featureId={data.feature.id} canWrite={prState === 'open'} />
           </Panel>
         ) : null}


### PR DESCRIPTION
## Summary

Fixes two issues in the cockpit reported from the mobile app:

1. **Mobile agent chat stretches the screen.** Code blocks in chat messages render as non-wrapping `<pre>` elements with a large intrinsic min-content width. The grid/flex items containing the chat defaulted to `min-width: auto`, so that width propagated up the layout tree and forced the whole page wider than the viewport — instead of letting the `<pre>`'s existing `overflow-x: auto` scroll the block internally.

2. **The chat says it addressed a comment, but nothing lands in GitHub.** The factory's post-run verification gate ran a repository's configured check command *bare*, without the checkout's `node_modules/.bin` on `PATH`. The agent runs the same check through pnpm/npm scripts (which *do* add that bin dir), so a check like `vp check` passed for the agent but died with `vp: command not found` in the harness — and that environment failure was recorded as `tests_failed`, silently discarding the committed work and telling the user their code failed checks when it had not.

## Changes

### Issue 1 — mobile layout (`630e8dc`)
- Add `min-w-0` to the two cockpit control-row panels (Pipeline + Agent chat) — the key change that stops the blow-out — and down the chat panel's container chain (root, transcript, both message bubbles), so long code now scrolls within its bubble instead of stretching the page.
- Add `break-words` to user message text for long unbroken tokens.
- Also protects the desktop 2-column layout, which had the same latent overflow.

Purely additive Tailwind utility classes — no TypeScript, imports, or logic touched.

### Issue 2 — discarded work on a missing check binary (`fb232d6`)
- Extract a shared `runCheckCommand` helper used by **both** the chat and fix runners that:
  - prepends the checkout's `node_modules/.bin` to `PATH` via the shell, so the harness resolves binaries the same way the package scripts do;
  - distinguishes "the check command could not be executed" (exit 127/126 corroborated by a not-found message) from a genuine test failure, and fails the turn **loudly** with an actionable message instead of throwing the work away as `tests_failed`.
- Add unit tests for the PATH prefix and the executable-vs-failing distinction.

## Verification
- `vp run check:types` — clean across all three tsconfig programs.
- `vp lint` — 0 errors (only pre-existing warnings in unrelated files).
- `vp test` — 121 existing smoke tests pass + 5 new `check-command` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015vru25DkzBJpF6sr6gkk4o)_