### PR TITLE
fix: wrap the "agent is working" status pill so it can't stretch the chat rail on mobile

### DIFF
--- a/src/client/components/chat-panel.tsx
+++ b/src/client/components/chat-panel.tsx
@@ -39,7 +39,7 @@ function ChatMessage({ message }: { message: ApiChatMessage }) {
   if (message.role === 'user') {
     return (
       <div className="ml-auto min-w-0 max-w-[85%] rounded-md border border-line-2 border-r-2 border-r-accent bg-surface px-3 py-2 text-[0.82rem]">
-        <div className="mb-1 flex items-center gap-1.5 text-xs text-mute">
+        <div className="mb-1 flex flex-wrap items-center gap-1.5 text-xs text-mute">
           <strong>@{message.author}</strong>
           <span>{ago(message.created_at)}</span>
           {message.status === 'failed' ? <Pill tone="red">Failed</Pill> : null}
@@ -53,7 +53,7 @@ function ChatMessage({ message }: { message: ApiChatMessage }) {
   }
   return (
     <div className="min-w-0 max-w-[85%] rounded-md border border-line-2 border-l-2 border-l-accent bg-surface px-3 py-2 text-[0.82rem]">
-      <div className="mb-1 flex items-center gap-1.5 text-xs text-mute">
+      <div className="mb-1 flex flex-wrap items-center gap-1.5 text-xs text-mute">
         <strong>Agent</strong>
         <span>{ago(message.created_at)}</span>
         <OutcomePill message={message} />
@@ -149,8 +149,10 @@ export function ChatPanel({ featureId, canWrite }: { featureId: number; canWrite
           </div>
         )}
         {pending ? (
+          // A full sentence, not a short status chip — let it wrap (the Pill
+          // is nowrap by default) so it never stretches the rail on mobile.
           <p className="mt-3">
-            <Pill tone="running">
+            <Pill tone="running" className="max-w-full items-start whitespace-normal">
               Agent is working — replies land here, usually within a few minutes
             </Pill>
           </p>


### PR DESCRIPTION
## Summary

Follow-up to #129 (merged). A third source of mobile horizontal overflow in the cockpit chat: the "Agent is working…" indicator.

The running-status indicator puts a full sentence — *"Agent is working — replies land here, usually within a few minutes"* — inside a `Pill`, whose base style is `whitespace-nowrap`. That default is correct for short status chips (`Pushed abc1234`, `MERGED`), but a non-wrapping full sentence is wider than a phone viewport, so it stretched the whole layout.

## Changes (`src/client/components/chat-panel.tsx`)
- Let **this one** pill instance wrap: `whitespace-normal` + `max-w-full`, with the pulsing dot top-aligned (`items-start`). Every other pill keeps its `nowrap` chip behavior — the shared `Pill` component is unchanged.
- Add `flex-wrap` to both message-header rows so a long outcome pill (e.g. `Checks failed — not pushed`) drops to a new line instead of overflowing its bubble on a very narrow screen — the same class of bug, pre-empted.

Purely additive Tailwind utility classes — no TypeScript, imports, or logic touched.

## Verification
- `vp lint` — 0 errors.
- `vp run check:types` — clean across all three tsconfig programs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015vru25DkzBJpF6sr6gkk4o)_