### PR TITLE
fix: run the check command with node_modules/.bin on PATH in every runner

### DIFF
--- a/src/ai/runners/conflict-resolver.ts
+++ b/src/ai/runners/conflict-resolver.ts
@@ -18,6 +18,7 @@ import {
 import { resolveRunnerAuth, runnerEnvironment } from '../runtime/runner-auth.ts';
 import { runnerSandbox } from '../runtime/sandbox.ts';
 import { redactSecrets } from '../runtime/redaction.ts';
+import { checkCommandUnrunnable, runCheckCommand } from '../runtime/check-command.ts';
 import { prepareFreshClone, pushHeadCommand } from '../runtime/repository-workspace.ts';
 import { githubWorkspaceRemote } from '../../integrations/git/provider.ts';
 import { mountSkills } from '../runtime/skills.ts';
@@ -303,11 +304,18 @@ async function runConflictResolve(
     }
 
     if (repo.check_command) {
-      const tests = await sandbox.exec(repo.check_command, {
-        cwd: CLONE_DIR,
-        timeout: TEST_TIMEOUT_MS,
-      });
-      if (!tests.success) {
+      const tests = await runCheckCommand(
+        sandbox,
+        CLONE_DIR,
+        repo.check_command,
+        scrub,
+        TEST_TIMEOUT_MS,
+      );
+      // A check command that can't even be executed is a misconfiguration,
+      // not a failing test — fail loudly (reported on the PR) rather than
+      // silently discarding the resolved merge as tests_failed.
+      if (tests.notExecutable) throw checkCommandUnrunnable(repo.check_command, tests.output);
+      if (!tests.ok) {
         return { status: 'tests_failed' };
       }
     }

--- a/src/ai/workflows/automation.ts
+++ b/src/ai/workflows/automation.ts
@@ -29,6 +29,7 @@ import {
   type RemoteSource,
 } from '../../integrations/git/provider.ts';
 import { NPM_CACHE_ENV } from '../runtime/sandbox-deps.ts';
+import { checkCommandUnrunnable, runCheckCommand } from '../runtime/check-command.ts';
 import {
   authorizesWorkflowFiles,
   describePushFailure,
@@ -272,13 +273,24 @@ export class AutomationWorkflow extends WorkflowEntrypoint<unknown, AutomationPa
           'run check command',
           { retries: { limit: 1, delay: '1 minute' }, timeout: '15 minutes' },
           async (): Promise<{ ok: boolean; output: string }> => {
-            const sandbox = sandboxFor(ctx);
-            const res = await sandbox.exec(ctx.checkCommand!, {
-              cwd: WORK,
-              timeout: CHECK_TIMEOUT_MS,
-              env: NPM_CACHE_ENV,
-            });
-            return { ok: res.success, output: `${res.stdout}\n${res.stderr}`.trim().slice(-500) };
+            // Same PATH handling and executable-vs-failing distinction as
+            // the generation workflow: a check that cannot run at all is a
+            // misconfiguration to report, not a checks_failed verdict.
+            const auth = resolveRunnerAuth();
+            const scrub = (s: string) => redactSecrets(s, Object.values(auth.vars));
+            const res = await runCheckCommand(
+              sandboxFor(ctx),
+              WORK,
+              ctx.checkCommand!,
+              scrub,
+              CHECK_TIMEOUT_MS,
+            );
+            if (res.notExecutable) {
+              throw new NonRetryableError(
+                checkCommandUnrunnable(ctx.checkCommand!, res.output).message,
+              );
+            }
+            return { ok: res.ok, output: res.output.slice(-500) };
           },
         );
         if (!checks.ok) {

--- a/src/ai/workflows/generation.ts
+++ b/src/ai/workflows/generation.ts
@@ -43,6 +43,7 @@ import {
 } from '../../integrations/github/app.ts';
 import { UNTRUSTED_CONTENT_RULES } from '../../domain/prompt-security.ts';
 import { installDependencies, NPM_CACHE_ENV } from '../runtime/sandbox-deps.ts';
+import { checkCommandUnrunnable, runCheckCommand } from '../runtime/check-command.ts';
 import { mintUserToken } from '../../services/user-tokens.ts';
 import { openNativeChangeRequest } from '../../services/change-requests.ts';
 import { notifyFeatureLive } from '../../services/live-updates.ts';
@@ -336,16 +337,21 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
       // Install dependencies up front so the agent can run the repo's check
       // command while it works instead of flying blind until the post-run
       // check (and so the repair loop's re-checks don't each pay an install).
+      // A failed install is only a warning here (some repos' check commands
+      // install for themselves), but it is remembered: if the check command
+      // then turns out not to exist, it is the most likely reason.
+      let installFailure: string | null = null;
       if (ctx.checkCommand) {
-        await step.do(
+        installFailure = await step.do(
           'install dependencies',
           { retries: { limit: 1, delay: '30 seconds' }, timeout: '12 minutes' },
-          async () => {
+          async (): Promise<string | null> => {
             await updateFeature(featureId, { runStartedAt: 'now' });
             const failure = await installDependencies(sandboxFor(ctx), WORK);
             if (failure) {
               console.warn(`turbodiff: dependency preinstall failed for ${label}: ${failure}`);
             }
+            return failure;
           },
         );
       }
@@ -454,21 +460,39 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
         // returned, never thrown, so the step is never retried for it. The
         // tail is sized for the repair prompt to see the actual errors;
         // features.error gets a shorter slice below.
+        //
+        // runCheckCommand puts the checkout's node_modules/.bin on PATH (so
+        // `vp check` resolves here exactly as it does for the agent) and
+        // tells a check that could not be executed at all apart from one
+        // that ran and failed. The former is a misconfiguration — feeding
+        // "command not found" to the repair loop just burns agent rounds on
+        // a problem no code change can fix, and then records the run as
+        // checks_failed against work that was never checked. Fail the run
+        // loudly instead, naming the install failure when there was one.
         const runCheck = (name: string) =>
           step.do(
             name,
             { retries: { limit: 1, delay: '1 minute' }, timeout: '15 minutes' },
             async (): Promise<{ ok: boolean; output: string }> => {
               await updateFeature(featureId, { runStartedAt: 'now' });
-              const res = await sandboxFor(ctx).exec(ctx.checkCommand!, {
-                cwd: WORK,
-                timeout: CHECK_TIMEOUT_MS,
-                env: NPM_CACHE_ENV,
-              });
-              return {
-                ok: res.success,
-                output: `${res.stdout}\n${res.stderr}`.trim().slice(-6_000),
-              };
+              const auth = resolveRunnerAuth(undefined, ctx.runnerModel);
+              const scrub = (s: string) => redactSecrets(s, Object.values(auth.vars));
+              const res = await runCheckCommand(
+                sandboxFor(ctx),
+                WORK,
+                ctx.checkCommand!,
+                scrub,
+                CHECK_TIMEOUT_MS,
+              );
+              if (res.notExecutable) {
+                const cause = installFailure
+                  ? ` (dependency install failed first: ${installFailure.slice(-300)})`
+                  : '';
+                throw new NonRetryableError(
+                  checkCommandUnrunnable(ctx.checkCommand!, res.output).message + cause,
+                );
+              }
+              return { ok: res.ok, output: res.output.slice(-6_000) };
             },
           );
 


### PR DESCRIPTION
#129 fixed "vp: command not found" in the chat and fix runners by routing
their check-command execution through runCheckCommand, which prepends the
checkout's node_modules/.bin to PATH and distinguishes "could not execute"
from "ran and failed". Three call sites kept running the check bare and
were not covered by that fix:

- the generation workflow (the BUILD stage on the task page), which is
  where the screenshot's failure came from;
- the automation workflow;
- the conflict resolver.

So the same `vp check` still died with exit 127 there. Worse, the
generation workflow fed "command not found" into the repair loop, spent
repair rounds on a problem no code change can fix, then recorded the run
as checks_failed with the same message.

Route all three through runCheckCommand. When the check command cannot be
executed at all, the workflows now throw NonRetryableError so the run is
recorded as a misconfiguration ("could not be run — check that it is
installed and correctly configured") instead of a check failure, and the
conflict resolver throws the same way the fix runner does. The generation
workflow also remembers a failed dependency preinstall (previously only a
console.warn) and appends it to that error, since a missing binary is most
often a failed install.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DyxuZUiwNvuiwk1pK4ZiJU