### PR TITLE
fix: size the sandbox so a repo's own lint tooling can run (standard-3)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -83,9 +83,9 @@
     {
       "class_name": "Sandbox",
       "image": "./Dockerfile",
-      // "standard-1" over "lite": fix runs clone repos, run the agent CLI,
-      // and execute test suites — they need the memory/CPU headroom.
-      "instance_type": "standard-1",
+      // 8 GiB: oxlint with JS plugins (`vp lint`) reserves a ~6 GiB arena per
+      // thread, which Linux refuses on a 4 GiB VM before linting anything.
+      "instance_type": "standard-3",
       // Every sandbox id (per-repo gen--, plan--, fix--, provision--, ...)
       // holds one instance for its whole sleepAfter keep-warm window, so the
       // cap must cover concurrent runs PLUS warm idlers. 5 deadlocked in


### PR DESCRIPTION
## Why

Generation check runs of `vp lint` died inside the sandbox with an oxc_allocator panic (`fixed_size.rs`: called `Result::unwrap()` on an `Err` value), before linting a single file.

With JS plugins configured (every Vite+ repo has `vite-plus/oxlint-plugin`), oxlint uses a fixed-size arena per thread for raw AST transfer: a ~4 GiB block with 2 GiB alignment, which glibc serves as one ~6 GiB virtual mapping. Linux's default overcommit heuristic refuses any single mapping larger than the VM's RAM, so on the 4 GiB `standard-1` instance the reservation fails and oxlint panics. Only address space is reserved; actual memory use stays small. No `--threads` setting changes this, and upstream's allocator revamp (oxc-project/oxc#20513) is unmerged.

## Change

- `wrangler.jsonc`: sandbox `instance_type` `standard-1` → `standard-3` (2 vCPU, 8 GiB).

CPU is billed on utilisation, so the second vCPU is free while warm containers idle; provisioned memory per instance doubles.

The follow-up (baseline check on the base branch) is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcL9hLMj2MVeEthj3QdnYr