### PR TITLE
fix: baseline the check command on the base branch; record review failures and let a human retry a parked stage

### DIFF
--- a/src/ai/runtime/check-command.test.ts
+++ b/src/ai/runtime/check-command.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vite-plus/test';
 import type { ExecOptions, ExecResult } from '@cloudflare/sandbox';
-import { type CheckSandbox, checkCommandUnrunnable, runCheckCommand } from './check-command.ts';
+import {
+  type CheckSandbox,
+  checkBaselineNote,
+  checkCommandUnrunnable,
+  runCheckCommand,
+} from './check-command.ts';
 
 // Minimal fake sandbox: records the exec invocation and returns a canned
 // result, enough to exercise runCheckCommand without a real container. Only
@@ -82,5 +87,17 @@ describe('checkCommandUnrunnable', () => {
     const err = checkCommandUnrunnable('vp check', 'vp: command not found');
     expect(err.message).toContain('`vp check`');
     expect(err.message).toContain('command not found');
+  });
+});
+
+describe('checkBaselineNote', () => {
+  it('names the command and base, and carries the tail of the baseline output', () => {
+    const note = checkBaselineNote('vp lint', 'main', `${'x'.repeat(2_000)}\nFound 103 errors`);
+
+    expect(note.markdown).toContain('<code>vp lint</code> fails on <code>main</code>');
+    expect(note.markdown).toContain('Found 103 errors');
+    expect(note.markdown).not.toContain('x'.repeat(1_500));
+    expect(note.plain).toMatch(/^\*\*Check command not applied\.\*\*/);
+    expect(note.plain).toContain('Found 103 errors');
   });
 });

--- a/src/ai/runtime/check-command.ts
+++ b/src/ai/runtime/check-command.ts
@@ -73,3 +73,31 @@ export function checkCommandUnrunnable(command: string, output: string): Error {
       `check that it is installed and correctly configured: ${output.slice(-300)}`,
   );
 }
+
+// The note a run attaches to its pull request (or native change request)
+// when the check command already failed on the base branch and therefore did
+// not gate the change: what was skipped, why, and the tail of the baseline
+// run so the repo owner can fix the command (or the base) for future runs.
+export interface CheckBaselineNote {
+  markdown: string; // GitHub PR body (collapsible)
+  plain: string; // native change-request summary
+}
+
+export function checkBaselineNote(
+  command: string,
+  base: string,
+  output: string,
+): CheckBaselineNote {
+  const tail = output.trim().slice(-1_200);
+  const why =
+    `\`${command}\` already fails in a clean checkout of \`${base}\`, so this change ` +
+    'could not be gated on it — CI is the arbiter here. Fix the check command ' +
+    '(or the base branch) so future runs are checked.';
+  return {
+    markdown:
+      `<details><summary>Check command not applied: <code>${command}</code> fails on ` +
+      `<code>${base}</code></summary>\n\n${why}\n\nLast lines of that run:\n\n` +
+      `\`\`\`\n${tail}\n\`\`\`\n\n</details>`,
+    plain: `**Check command not applied.** ${why}\n\n\`\`\`\n${tail}\n\`\`\``,
+  };
+}

--- a/src/ai/workflows/generation.ts
+++ b/src/ai/workflows/generation.ts
@@ -43,7 +43,11 @@ import {
 } from '../../integrations/github/app.ts';
 import { UNTRUSTED_CONTENT_RULES } from '../../domain/prompt-security.ts';
 import { installDependencies, NPM_CACHE_ENV } from '../runtime/sandbox-deps.ts';
-import { checkCommandUnrunnable, runCheckCommand } from '../runtime/check-command.ts';
+import {
+  checkBaselineNote,
+  checkCommandUnrunnable,
+  runCheckCommand,
+} from '../runtime/check-command.ts';
 import { mintUserToken } from '../../services/user-tokens.ts';
 import { openNativeChangeRequest } from '../../services/change-requests.ts';
 import { notifyFeatureLive } from '../../services/live-updates.ts';
@@ -116,17 +120,24 @@ function branchName(feature: FeatureRow): string {
   return `turbodiff/feat-${feature.id}-${slug}`;
 }
 
-function generationPrompt(ctx: RunContext): string {
+// `checkGated`: the repo check command passed on the base, so it will gate
+// this run. When it already fails there, the agent is told not to chase those
+// failures — nothing it does can turn a red baseline green.
+function generationPrompt(ctx: RunContext, checkGated: boolean): string {
   const trivial = ctx.tier === 'trivial';
   // Trivial runs keep the tight no-checks budget; standard runs with a check
   // command are told to verify their own work — the harness re-runs the check
   // afterwards either way, and the repair loop catches what slips through.
   const checkRule =
-    !trivial && ctx.checkCommand
-      ? `- Dependencies are already installed. Before finishing, run \`${ctx.checkCommand}\`
+    ctx.checkCommand && !checkGated
+      ? `- The repository check command (\`${ctx.checkCommand}\`) already fails on the base
+  branch, so it does not gate this change. Do NOT try to fix those pre-existing
+  failures; implement the feature and verify your own changes by reading them.`
+      : !trivial && ctx.checkCommand
+        ? `- Dependencies are already installed. Before finishing, run \`${ctx.checkCommand}\`
   and fix any failures your changes caused. Failures that clearly pre-date this
   feature are not yours to fix — note them in Implementation notes instead.`
-      : `- Do NOT run dependency installs, builds, or test suites unless the change itself
+        : `- Do NOT run dependency installs, builds, or test suites unless the change itself
   requires it — the harness runs the repository's check command after you finish,
   and a separate verification phase checks the acceptance criteria empirically.`;
   return `You are an automated implementation agent working in a fresh checkout of ${ctx.owner}/${ctx.name}.
@@ -356,6 +367,70 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
         );
       }
 
+      // A failing check command is a business outcome, not an infra error —
+      // returned, never thrown, so the step is never retried for it. The
+      // tail is sized for the repair prompt to see the actual errors;
+      // features.error gets a shorter slice below.
+      //
+      // runCheckCommand puts the checkout's node_modules/.bin on PATH (so
+      // `vp check` resolves here exactly as it does for the agent) and
+      // tells a check that could not be executed at all apart from one
+      // that ran and failed. The former is a misconfiguration — feeding
+      // "command not found" to the repair loop just burns agent rounds on
+      // a problem no code change can fix, and then records the run as
+      // checks_failed against work that was never checked. Fail the run
+      // loudly instead, naming the install failure when there was one.
+      const runCheck = (name: string) =>
+        step.do(
+          name,
+          { retries: { limit: 1, delay: '1 minute' }, timeout: '15 minutes' },
+          async (): Promise<{ ok: boolean; output: string }> => {
+            await updateFeature(featureId, { runStartedAt: 'now' });
+            const auth = resolveRunnerAuth(undefined, ctx.runnerModel);
+            const scrub = (s: string) => redactSecrets(s, Object.values(auth.vars));
+            const res = await runCheckCommand(
+              sandboxFor(ctx),
+              WORK,
+              ctx.checkCommand!,
+              scrub,
+              CHECK_TIMEOUT_MS,
+            );
+            if (res.notExecutable) {
+              const cause = installFailure
+                ? ` (dependency install failed first: ${installFailure.slice(-300)})`
+                : '';
+              throw new NonRetryableError(
+                checkCommandUnrunnable(ctx.checkCommand!, res.output).message + cause,
+              );
+            }
+            return { ok: res.ok, output: res.output.slice(-6_000) };
+          },
+        );
+
+      // Baseline: run the check on the untouched checkout before the agent
+      // spends anything. A check that is already red on the base branch can't
+      // gate this change (live finding: a lint that only passes after a
+      // gitignored types file is generated reported 103 errors on a clean
+      // clone, every one blamed on the agent — repair rounds burned and the
+      // work was discarded). Known-red baseline → the agent is told, the
+      // post-run check and repair loop are skipped, and the PR carries the
+      // baseline output so the repo owner can fix the command.
+      let baselineFailure: string | null = null;
+      if (ctx.checkCommand) {
+        const baseline = await runCheck('baseline check command');
+        if (!baseline.ok) {
+          baselineFailure = baseline.output.slice(-2_000);
+          console.warn(
+            `turbodiff: check command already fails on ${ctx.base} for ${label} — not gating`,
+          );
+        }
+        // Drop whatever the check wrote (build output, caches) so the agent
+        // starts from the pristine checkout; ignored paths like node_modules stay.
+        await step.do('reset working copy after baseline', QUICK, async () => {
+          await sandboxFor(ctx).exec(`git -C ${WORK} checkout -- . && git -C ${WORK} clean -fd`);
+        });
+      }
+
       // THE paid step. retries.limit 1 = at most two agent runs per
       // instance, ever. Memoization means success is never re-bought.
       const agentRan = await step.do(
@@ -373,7 +448,10 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
           const scrub = (s: string) => redactSecrets(s, Object.values(auth.vars));
           const sandbox = sandboxFor(ctx);
           await mountSkills(sandbox, WORK, ctx.skills);
-          await sandbox.writeFile(specFile(featureId), generationPrompt(ctx));
+          await sandbox.writeFile(
+            specFile(featureId),
+            generationPrompt(ctx, baselineFailure === null),
+          );
           // stream-json (requires --verbose headless) captures every turn,
           // not just the final result — persisted below so a sandbox run can
           // be compared against a local session turn by turn.
@@ -455,47 +533,7 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
 
       let totalUsage = agentRan.usage;
 
-      if (ctx.checkCommand) {
-        // A failing check command is a business outcome, not an infra error —
-        // returned, never thrown, so the step is never retried for it. The
-        // tail is sized for the repair prompt to see the actual errors;
-        // features.error gets a shorter slice below.
-        //
-        // runCheckCommand puts the checkout's node_modules/.bin on PATH (so
-        // `vp check` resolves here exactly as it does for the agent) and
-        // tells a check that could not be executed at all apart from one
-        // that ran and failed. The former is a misconfiguration — feeding
-        // "command not found" to the repair loop just burns agent rounds on
-        // a problem no code change can fix, and then records the run as
-        // checks_failed against work that was never checked. Fail the run
-        // loudly instead, naming the install failure when there was one.
-        const runCheck = (name: string) =>
-          step.do(
-            name,
-            { retries: { limit: 1, delay: '1 minute' }, timeout: '15 minutes' },
-            async (): Promise<{ ok: boolean; output: string }> => {
-              await updateFeature(featureId, { runStartedAt: 'now' });
-              const auth = resolveRunnerAuth(undefined, ctx.runnerModel);
-              const scrub = (s: string) => redactSecrets(s, Object.values(auth.vars));
-              const res = await runCheckCommand(
-                sandboxFor(ctx),
-                WORK,
-                ctx.checkCommand!,
-                scrub,
-                CHECK_TIMEOUT_MS,
-              );
-              if (res.notExecutable) {
-                const cause = installFailure
-                  ? ` (dependency install failed first: ${installFailure.slice(-300)})`
-                  : '';
-                throw new NonRetryableError(
-                  checkCommandUnrunnable(ctx.checkCommand!, res.output).message + cause,
-                );
-              }
-              return { ok: res.ok, output: res.output.slice(-6_000) };
-            },
-          );
-
+      if (ctx.checkCommand && !baselineFailure) {
         let checks = await runCheck('run check command');
         let sessionId = agentRan.sessionId;
         for (let round = 1; !checks.ok && round <= REPAIR_ROUNDS; round++) {
@@ -619,6 +657,10 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
           .readFile(specFile(featureId))
           .then((f) => f.content.split('## Implementation notes')[1]?.trim())
           .catch(() => undefined);
+        const checkNote =
+          baselineFailure !== null && ctx.checkCommand
+            ? checkBaselineNote(ctx.checkCommand, ctx.base, baselineFailure)
+            : null;
         if (ctx.remoteSource.provider === 'artifacts') {
           // Native change request instead of a GitHub PR
           // (docs/artifacts-provider.md): the CR service computes the diff,
@@ -635,8 +677,10 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
             openedBy: 'factory',
             summary:
               (summary ?? `${ctx.title} — generated change; see the diff.`) +
-              (notes ? `\n\n**Implementation notes**\n\n${notes}` : ''),
-            checkOutcome: ctx.checkCommand ? 'passed' : undefined,
+              (notes ? `\n\n**Implementation notes**\n\n${notes}` : '') +
+              (checkNote ? `\n\n${checkNote.plain}` : ''),
+            // A baseline-red check was not applied, so it records no verdict.
+            checkOutcome: ctx.checkCommand && !checkNote ? 'passed' : undefined,
           });
           await updateFeature(featureId, {
             status: 'pr_opened',
@@ -667,6 +711,7 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
                   (notes
                     ? `\n\n<details><summary>Implementation notes</summary>\n\n${notes}\n\n</details>`
                     : '') +
+                  (checkNote ? `\n\n${checkNote.markdown}` : '') +
                   `\n\n---\n_turbodiff factory · feature #${featureId}_`,
               }),
             })
@@ -738,7 +783,13 @@ export class GenerationWorkflow extends WorkflowEntrypoint<unknown, GenerationPa
       );
 
       console.log(`turbodiff: generation pr_opened for ${label} (PR #${prNumber})`);
-      await settleLifecycle(true, 'change_published');
+      await settleLifecycle(
+        true,
+        'change_published',
+        baselineFailure !== null
+          ? 'check command not applied: fails on the base branch'
+          : undefined,
+      );
       return 'pr_opened';
     } catch (err) {
       // Terminal failure (a step exhausted its retries, or a


### PR DESCRIPTION
Two commits, both needed to get TD-0002 through the factory.

## 1. Don't gate a generation on a check command that already fails on the base

After #133 the check command ran and reported 103 lint errors; the generation spent its repair rounds on them, recorded `checks_failed`, and discarded the work. All 103 exist on a clean checkout of `main`: `vp lint` is only green after `wrangler types` writes the gitignored `worker-configuration.d.ts`, which CI does first and the sandbox never did.

The generation now runs the check on the untouched checkout before the agent starts. Baseline green → unchanged (post-run check, repair loop). Baseline red → the agent is told not to chase pre-existing failures, the gate and repair loop are skipped, and the PR carries the baseline output in a collapsible note. Check cannot run at all → fails loudly before any agent spend.

## 2. Record why a review failed; let a human retry a parked lifecycle stage

Every review ever recorded in production (8 of 8, PRs 127–135) failed within 2–4 s of dispatch with zero tokens, and nothing said why: the reviewer's settlement error only reached the Worker log, the row just flipped to `failed`, the stage said "all review dispatches failed", and the pipeline card kept showing the review as *polling*.

- `app.reviews.error` (migration `0008_review-error`): recorded by the dispatch catch, by the metering subscriber from the settlement's outcome/error, and by the stale-claim sweep. The review stage's error now carries the first recorded reason, which the lifecycle panel displays. `/api/reviews` exposes `error`.
- `resumeFailedStage` + `POST /api/factory/features/:id/lifecycle/:runId/resume`: a run parked on "stage failure requires retry policy evaluation" had no way forward (no retry policy exists), so a `full_delivery` run whose review failed could never reach verify or merge. The resume records `human.resume_requested` on the same run, schedules the failed stage as a fresh attempt, and reactivates the run. The lifecycle panel gets a **Retry \<stage\>** button; the pipeline card shows a failed review stage as **FAILED** rather than POLLING.

Verified: typecheck, lint (incl. anti-slop), `db:check`, schema test, worker suite (147) and unit suite (126) pass. New tests cover the recorded reason, the stage error, the resume path, and its idempotency.

## After deploy

Open TD-0002, expand the lifecycle panel, press **Retry review**. The review runs again; if it fails, the stage error now shows the actual reason from the AI Gateway path (the reviewer is the only component that runs through the `env.AI` binding and the `default` gateway; everything else runs the CLI in the sandbox and works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcL9hLMj2MVeEthj3QdnYr