### PR TITLE
fix: record why a review failed, and let a human retry a parked lifecycle stage

### DIFF
--- a/db/migrations/0008_review-error.sql
+++ b/db/migrations/0008_review-error.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "app"."reviews" ADD COLUMN "error" text;

--- a/db/migrations/meta/0008_snapshot.json
+++ b/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,7224 @@
+{
+  "id": "f3802328-53f1-4de0-b419-ec6a6a1f3cf4",
+  "prevId": "4fcdb08c-d2a0-4006-b965-795601ebdafa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app.acceptance_contracts": {
+      "name": "acceptance_contracts",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "acceptance_contracts_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria": {
+          "name": "criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "acceptance_contracts_work_item_idx": {
+          "name": "acceptance_contracts_work_item_idx",
+          "columns": [
+            {
+              "expression": "work_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acceptance_contracts_change_idx": {
+          "name": "acceptance_contracts_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acceptance_contracts_work_item_id_fkey": {
+          "name": "acceptance_contracts_work_item_id_fkey",
+          "tableFrom": "acceptance_contracts",
+          "tableTo": "work_items",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "work_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acceptance_contracts_change_id_fkey": {
+          "name": "acceptance_contracts_change_id_fkey",
+          "tableFrom": "acceptance_contracts",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acceptance_contracts_version_check": {
+          "name": "acceptance_contracts_version_check",
+          "value": "version > 0"
+        },
+        "acceptance_contracts_owner_check": {
+          "name": "acceptance_contracts_owner_check",
+          "value": "(work_item_id IS NOT NULL) OR (change_id IS NOT NULL)"
+        },
+        "acceptance_contracts_criteria_array_check": {
+          "name": "acceptance_contracts_criteria_array_check",
+          "value": "jsonb_typeof(criteria) = 'array'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.account": {
+      "name": "account",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_fkey": {
+          "name": "account_userId_fkey",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_provider_identity_unique": {
+          "name": "account_provider_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "accountId",
+            "providerId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.agent_runs": {
+      "name": "agent_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "agent_runs_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fix_attempt_id": {
+          "name": "fix_attempt_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_run_id": {
+          "name": "automation_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_key": {
+          "name": "log_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "agent_runs_automation_idx": {
+          "name": "agent_runs_automation_idx",
+          "columns": [
+            {
+              "expression": "automation_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(automation_run_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_feature_idx": {
+          "name": "agent_runs_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(feature_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_fix_attempt_idx": {
+          "name": "agent_runs_fix_attempt_idx",
+          "columns": [
+            {
+              "expression": "fix_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(fix_attempt_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_plan_idx": {
+          "name": "agent_runs_plan_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(plan_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_plan_id_fkey": {
+          "name": "agent_runs_plan_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_feature_id_fkey": {
+          "name": "agent_runs_feature_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_fix_attempt_id_fkey": {
+          "name": "agent_runs_fix_attempt_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "fix_attempts",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "fix_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_automation_run_id_fkey": {
+          "name": "agent_runs_automation_run_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "automation_runs",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "automation_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_runs_kind_check": {
+          "name": "agent_runs_kind_check",
+          "value": "kind = ANY (ARRAY['plan_analyze'::text, 'plan_refine'::text, 'generate'::text, 'verify'::text, 'fix'::text, 'automation'::text, 'chat'::text, 'resolve_conflict'::text])"
+        },
+        "agent_runs_owner": {
+          "name": "agent_runs_owner",
+          "value": "num_nonnulls(plan_id, feature_id, fix_attempt_id, automation_run_id) >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.agents": {
+      "name": "agents",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "agents_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare/anthropic/claude-sonnet-5'"
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_installation_id_fkey": {
+          "name": "agents_installation_id_fkey",
+          "tableFrom": "agents",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_id_installation_unique": {
+          "name": "agents_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "installation_id"
+          ]
+        },
+        "agents_installation_slug_unique": {
+          "name": "agents_installation_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "installation_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agents_slug_format": {
+          "name": "agents_slug_format",
+          "value": "slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.automation_runs": {
+      "name": "automation_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "automation_runs_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "automation_runs_automation_idx": {
+          "name": "automation_runs_automation_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_one_running_idx": {
+          "name": "automation_runs_one_running_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_id_fkey": {
+          "name": "automation_runs_automation_id_fkey",
+          "tableFrom": "automation_runs",
+          "tableTo": "automations",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "automation_runs_status_check": {
+          "name": "automation_runs_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'pr_opened'::text, 'no_changes'::text, 'checks_failed'::text, 'failed'::text])"
+        },
+        "automation_runs_pr_number_check": {
+          "name": "automation_runs_pr_number_check",
+          "value": "(pr_number IS NULL) OR (pr_number > 0)"
+        },
+        "automation_runs_input_tokens_check": {
+          "name": "automation_runs_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "automation_runs_output_tokens_check": {
+          "name": "automation_runs_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "automation_runs_cache_read_tokens_check": {
+          "name": "automation_runs_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "automation_runs_cache_write_tokens_check": {
+          "name": "automation_runs_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "automation_runs_cost_usd_check": {
+          "name": "automation_runs_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.automations": {
+      "name": "automations",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "automations_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_kind": {
+          "name": "schedule_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_of_day": {
+          "name": "time_of_day",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "automations_due_idx": {
+          "name": "automations_due_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automations_repository_idx": {
+          "name": "automations_repository_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automations_repository_id_fkey": {
+          "name": "automations_repository_id_fkey",
+          "tableFrom": "automations",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "automations_schedule_kind_check": {
+          "name": "automations_schedule_kind_check",
+          "value": "schedule_kind = ANY (ARRAY['hourly'::text, 'daily'::text, 'weekly'::text])"
+        },
+        "automations_day_of_week_check": {
+          "name": "automations_day_of_week_check",
+          "value": "(day_of_week >= 0) AND (day_of_week <= 6)"
+        },
+        "automations_schedule_shape": {
+          "name": "automations_schedule_shape",
+          "value": "((schedule_kind = 'hourly'::text) AND (time_of_day IS NULL) AND (day_of_week IS NULL)) OR ((schedule_kind = 'daily'::text) AND (time_of_day IS NOT NULL) AND (day_of_week IS NULL)) OR ((schedule_kind = 'weekly'::text) AND (time_of_day IS NOT NULL) AND (day_of_week IS NOT NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.change_request_counters": {
+      "name": "change_request_counters",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_number": {
+          "name": "last_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "change_request_counters_repository_id_fkey": {
+          "name": "change_request_counters_repository_id_fkey",
+          "tableFrom": "change_request_counters",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "change_request_counters_last_number_check": {
+          "name": "change_request_counters_last_number_check",
+          "value": "last_number > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.change_requests": {
+      "name": "change_requests",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "change_requests_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_branch": {
+          "name": "source_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "source_head": {
+          "name": "source_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_head": {
+          "name": "target_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_base": {
+          "name": "merge_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mergeable": {
+          "name": "mergeable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_files": {
+          "name": "conflict_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff_key": {
+          "name": "diff_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patch_truncated": {
+          "name": "patch_truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_head": {
+          "name": "merged_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_by": {
+          "name": "opened_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'factory'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "change_requests_feature_idx": {
+          "name": "change_requests_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(feature_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_requests_change_unique": {
+          "name": "change_requests_change_unique",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_requests_open_branches_unique": {
+          "name": "change_requests_open_branches_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'open'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_requests_repo_status_idx": {
+          "name": "change_requests_repo_status_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_requests_feature_id_features_id_fk": {
+          "name": "change_requests_feature_id_features_id_fk",
+          "tableFrom": "change_requests",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "change_requests_change_id_changes_id_fk": {
+          "name": "change_requests_change_id_changes_id_fk",
+          "tableFrom": "change_requests",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_requests_repository_id_fkey": {
+          "name": "change_requests_repository_id_fkey",
+          "tableFrom": "change_requests",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "change_requests_repo_number_unique": {
+          "name": "change_requests_repo_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "change_requests_number_check": {
+          "name": "change_requests_number_check",
+          "value": "number > 0"
+        },
+        "change_requests_status_check": {
+          "name": "change_requests_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'merged'::text, 'closed'::text])"
+        },
+        "change_requests_review_status_check": {
+          "name": "change_requests_review_status_check",
+          "value": "(review_status IS NULL) OR (review_status = ANY (ARRAY['approved'::text, 'changes_requested'::text]))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.changes": {
+      "name": "changes",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "changes_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_key": {
+          "name": "provider_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_branch": {
+          "name": "source_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "source_head": {
+          "name": "source_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_head": {
+          "name": "target_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "changes_repo_status_idx": {
+          "name": "changes_repo_status_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "changes_repository_id_fkey": {
+          "name": "changes_repository_id_fkey",
+          "tableFrom": "changes",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "changes_repo_provider_key_unique": {
+          "name": "changes_repo_provider_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id",
+            "provider_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "changes_number_check": {
+          "name": "changes_number_check",
+          "value": "number > 0"
+        },
+        "changes_origin_check": {
+          "name": "changes_origin_check",
+          "value": "origin = ANY (ARRAY['human'::text, 'factory'::text, 'automation'::text, 'imported'::text])"
+        },
+        "changes_status_check": {
+          "name": "changes_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'merged'::text, 'closed'::text])"
+        },
+        "changes_capabilities_array_check": {
+          "name": "changes_capabilities_array_check",
+          "value": "jsonb_typeof(capabilities) = 'array'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.chat_messages": {
+      "name": "chat_messages",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "chat_messages_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'done'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "chat_messages_feature_idx": {
+          "name": "chat_messages_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_one_pending_user_idx": {
+          "name": "chat_messages_one_pending_user_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((role = 'user'::text) AND (status = ANY (ARRAY['queued'::text, 'running'::text])))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_feature_id_fkey": {
+          "name": "chat_messages_feature_id_fkey",
+          "tableFrom": "chat_messages",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_messages_role_check": {
+          "name": "chat_messages_role_check",
+          "value": "role = ANY (ARRAY['user'::text, 'assistant'::text])"
+        },
+        "chat_messages_status_check": {
+          "name": "chat_messages_status_check",
+          "value": "status = ANY (ARRAY['queued'::text, 'running'::text, 'done'::text, 'failed'::text])"
+        },
+        "chat_messages_outcome_check": {
+          "name": "chat_messages_outcome_check",
+          "value": "(outcome IS NULL) OR (outcome = ANY (ARRAY['changed'::text, 'no_changes'::text, 'tests_failed'::text]))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.cockpit_comments": {
+      "name": "cockpit_comments",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cockpit_comments_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'additions'"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "fix_attempt_id": {
+          "name": "fix_attempt_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "cockpit_comments_feature_idx": {
+          "name": "cockpit_comments_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cockpit_comments_fix_attempt_idx": {
+          "name": "cockpit_comments_fix_attempt_idx",
+          "columns": [
+            {
+              "expression": "fix_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(fix_attempt_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cockpit_comments_feature_id_fkey": {
+          "name": "cockpit_comments_feature_id_fkey",
+          "tableFrom": "cockpit_comments",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cockpit_comments_fix_attempt_id_fkey": {
+          "name": "cockpit_comments_fix_attempt_id_fkey",
+          "tableFrom": "cockpit_comments",
+          "tableTo": "fix_attempts",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "fix_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cockpit_comments_line_check": {
+          "name": "cockpit_comments_line_check",
+          "value": "line > 0"
+        },
+        "cockpit_comments_side_check": {
+          "name": "cockpit_comments_side_check",
+          "value": "side = ANY (ARRAY['additions'::text, 'deletions'::text])"
+        },
+        "cockpit_comments_status_check": {
+          "name": "cockpit_comments_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'dispatched'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.connections": {
+      "name": "connections",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "connections_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mcp'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_allowlist": {
+          "name": "tool_allowlist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_ciphertext": {
+          "name": "auth_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optional": {
+          "name": "optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "auth_config_ciphertext": {
+          "name": "auth_config_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_expires_at": {
+          "name": "oauth_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_needs_reauth": {
+          "name": "oauth_needs_reauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "oauth_has_refresh_token": {
+          "name": "oauth_has_refresh_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connections_installation_id_fkey": {
+          "name": "connections_installation_id_fkey",
+          "tableFrom": "connections",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_id_installation_unique": {
+          "name": "connections_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "installation_id"
+          ]
+        },
+        "connections_installation_name_unique": {
+          "name": "connections_installation_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "installation_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connections_kind_check": {
+          "name": "connections_kind_check",
+          "value": "kind = ANY (ARRAY['mcp'::text, 'api'::text])"
+        },
+        "connections_auth_type_check": {
+          "name": "connections_auth_type_check",
+          "value": "auth_type = ANY (ARRAY['none'::text, 'bearer'::text, 'api_key'::text, 'client_credentials'::text, 'oauth'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.cr_checks": {
+      "name": "cr_checks",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cr_checks_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cr_checks_change_request_id_fkey": {
+          "name": "cr_checks_change_request_id_fkey",
+          "tableFrom": "cr_checks",
+          "tableTo": "change_requests",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "change_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cr_checks_name_unique": {
+          "name": "cr_checks_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "change_request_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cr_checks_status_check": {
+          "name": "cr_checks_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'passed'::text, 'failed'::text, 'error'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.cr_comments": {
+      "name": "cr_comments",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cr_comments_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'comment'"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "cr_comments_change_request_idx": {
+          "name": "cr_comments_change_request_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cr_comments_change_request_id_fkey": {
+          "name": "cr_comments_change_request_id_fkey",
+          "tableFrom": "cr_comments",
+          "tableTo": "change_requests",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "change_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cr_comments_line_check": {
+          "name": "cr_comments_line_check",
+          "value": "(line IS NULL) OR (line > 0)"
+        },
+        "cr_comments_kind_check": {
+          "name": "cr_comments_kind_check",
+          "value": "kind = ANY (ARRAY['comment'::text, 'finding'::text, 'summary'::text])"
+        },
+        "cr_comments_severity_check": {
+          "name": "cr_comments_severity_check",
+          "value": "(severity IS NULL) OR (severity = ANY (ARRAY['P1'::text, 'P2'::text, 'P3'::text]))"
+        },
+        "cr_comments_location": {
+          "name": "cr_comments_location",
+          "value": "((file IS NULL) AND (line IS NULL)) OR (file IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.factory_runs": {
+      "name": "factory_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "factory_runs_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_key": {
+          "name": "profile_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_stage": {
+          "name": "start_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stop_after_stage": {
+          "name": "stop_after_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_snapshot": {
+          "name": "policy_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "handoff_reason": {
+          "name": "handoff_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "factory_runs_repo_created_idx": {
+          "name": "factory_runs_repo_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "factory_runs_change_idx": {
+          "name": "factory_runs_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "factory_runs_work_item_idx": {
+          "name": "factory_runs_work_item_idx",
+          "columns": [
+            {
+              "expression": "work_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(work_item_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "factory_runs_repository_id_fkey": {
+          "name": "factory_runs_repository_id_fkey",
+          "tableFrom": "factory_runs",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "factory_runs_work_item_id_fkey": {
+          "name": "factory_runs_work_item_id_fkey",
+          "tableFrom": "factory_runs",
+          "tableTo": "work_items",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "work_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "factory_runs_change_id_fkey": {
+          "name": "factory_runs_change_id_fkey",
+          "tableFrom": "factory_runs",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "factory_runs_idempotency_key_unique": {
+          "name": "factory_runs_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "factory_runs_status_check": {
+          "name": "factory_runs_status_check",
+          "value": "status = ANY (ARRAY['active'::text, 'awaiting_human'::text, 'handed_off'::text, 'completed'::text, 'failed'::text, 'cancelled'::text])"
+        },
+        "factory_runs_profile_check": {
+          "name": "factory_runs_profile_check",
+          "value": "profile_key = ANY (ARRAY['review_on_demand'::text, 'automatic_review'::text, 'review_and_repair'::text, 'idea_to_pr'::text, 'assisted_delivery'::text, 'full_delivery'::text, 'native_turnkey'::text, 'legacy_factory'::text])"
+        },
+        "factory_runs_stage_check": {
+          "name": "factory_runs_stage_check",
+          "value": "start_stage = ANY (ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text]) AND stop_after_stage = ANY (ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text])"
+        },
+        "factory_runs_stage_order_check": {
+          "name": "factory_runs_stage_order_check",
+          "value": "array_position(ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text], start_stage) <= array_position(ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text], stop_after_stage)"
+        },
+        "factory_runs_policy_object_check": {
+          "name": "factory_runs_policy_object_check",
+          "value": "jsonb_typeof(policy_snapshot) = 'object'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.factory_version": {
+      "name": "factory_version",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "factory_version_singleton_check": {
+          "name": "factory_version_singleton_check",
+          "value": "id = 1"
+        },
+        "factory_version_positive_check": {
+          "name": "factory_version_positive_check",
+          "value": "version > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.features": {
+      "name": "features",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "features_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptance": {
+          "name": "acceptance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_login": {
+          "name": "coauthor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_id": {
+          "name": "coauthor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_started_at": {
+          "name": "run_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_model": {
+          "name": "runner_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criteria_conflict": {
+          "name": "criteria_conflict",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "acceptance_updated_at": {
+          "name": "acceptance_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_acceptance": {
+          "name": "proposed_acceptance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_session_id": {
+          "name": "chat_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "features_change_request_idx": {
+          "name": "features_change_request_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_request_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_change_idx": {
+          "name": "features_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_generating_created_idx": {
+          "name": "features_generating_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(status = 'generating'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_open_pr_idx": {
+          "name": "features_open_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((status = 'pr_opened'::text) AND (pr_number IS NOT NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_plan_idx": {
+          "name": "features_plan_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(plan_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_repository_created_idx": {
+          "name": "features_repository_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_repository_pr_idx": {
+          "name": "features_repository_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(pr_number IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "features_plan_id_plans_id_fk": {
+          "name": "features_plan_id_plans_id_fk",
+          "tableFrom": "features",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "features_change_request_id_change_requests_id_fk": {
+          "name": "features_change_request_id_change_requests_id_fk",
+          "tableFrom": "features",
+          "tableTo": "change_requests",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "change_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "features_change_id_changes_id_fk": {
+          "name": "features_change_id_changes_id_fk",
+          "tableFrom": "features",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "features_repository_id_fkey": {
+          "name": "features_repository_id_fkey",
+          "tableFrom": "features",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "features_plan_repository_unique": {
+          "name": "features_plan_repository_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plan_id",
+            "repository_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "features_pr_number_check": {
+          "name": "features_pr_number_check",
+          "value": "pr_number > 0"
+        },
+        "features_status_check": {
+          "name": "features_status_check",
+          "value": "status = ANY (ARRAY['queued'::text, 'generating'::text, 'pr_opened'::text, 'no_changes'::text, 'checks_failed'::text, 'failed'::text, 'merged'::text, 'pr_closed'::text, 'abandoned'::text])"
+        },
+        "features_input_tokens_check": {
+          "name": "features_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "features_output_tokens_check": {
+          "name": "features_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "features_cache_read_tokens_check": {
+          "name": "features_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "features_cache_write_tokens_check": {
+          "name": "features_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "features_cost_usd_check": {
+          "name": "features_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.fix_attempts": {
+      "name": "fix_attempts",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "fix_attempts_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage_run_id": {
+          "name": "stage_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "fix_attempts_one_running_idx": {
+          "name": "fix_attempts_one_running_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fix_attempts_pr_idx": {
+          "name": "fix_attempts_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fix_attempts_stage_run_idx": {
+          "name": "fix_attempts_stage_run_idx",
+          "columns": [
+            {
+              "expression": "stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(stage_run_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fix_attempts_stage_run_id_stage_runs_id_fk": {
+          "name": "fix_attempts_stage_run_id_stage_runs_id_fk",
+          "tableFrom": "fix_attempts",
+          "tableTo": "stage_runs",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fix_attempts_repository_id_fkey": {
+          "name": "fix_attempts_repository_id_fkey",
+          "tableFrom": "fix_attempts",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "fix_attempts_pr_number_check": {
+          "name": "fix_attempts_pr_number_check",
+          "value": "pr_number > 0"
+        },
+        "fix_attempts_status_check": {
+          "name": "fix_attempts_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'fixed'::text, 'no_changes'::text, 'tests_failed'::text, 'failed'::text])"
+        },
+        "fix_attempts_input_tokens_check": {
+          "name": "fix_attempts_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "fix_attempts_output_tokens_check": {
+          "name": "fix_attempts_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "fix_attempts_cache_read_tokens_check": {
+          "name": "fix_attempts_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "fix_attempts_cache_write_tokens_check": {
+          "name": "fix_attempts_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "fix_attempts_cost_usd_check": {
+          "name": "fix_attempts_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.installation_repo_sync": {
+      "name": "installation_repo_sync",
+      "schema": "app",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncing_until": {
+          "name": "syncing_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "installation_repo_sync_installation_id_fkey": {
+          "name": "installation_repo_sync_installation_id_fkey",
+          "tableFrom": "installation_repo_sync",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.installations": {
+      "name": "installations",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval('app.native_entity_id_seq'::regclass)"
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended": {
+          "name": "suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "installer_github_id": {
+          "name": "installer_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "installations_installer_idx": {
+          "name": "installations_installer_idx",
+          "columns": [
+            {
+              "expression": "installer_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(installer_github_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "installations_id_provider_unique": {
+          "name": "installations_id_provider_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "provider"
+          ]
+        },
+        "installations_provider_login_unique": {
+          "name": "installations_provider_login_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "account_login"
+          ]
+        },
+        "installations_provider_account_unique": {
+          "name": "installations_provider_account_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "installations_account_type_check": {
+          "name": "installations_account_type_check",
+          "value": "account_type = ANY (ARRAY['Organization'::text, 'User'::text])"
+        },
+        "installations_provider_check": {
+          "name": "installations_provider_check",
+          "value": "provider = ANY (ARRAY['github'::text, 'artifacts'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.invitation": {
+      "name": "invitation",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviterId": {
+          "name": "inviterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_email_status_idx": {
+          "name": "invitation_email_status_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_idx": {
+          "name": "invitation_inviter_idx",
+          "columns": [
+            {
+              "expression": "inviterId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_organization_idx": {
+          "name": "invitation_organization_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_pending_email_unique": {
+          "name": "invitation_pending_email_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'pending'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organizationId_fkey": {
+          "name": "invitation_organizationId_fkey",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviterId_fkey": {
+          "name": "invitation_inviterId_fkey",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "inviterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "role = ANY (ARRAY['owner'::text, 'admin'::text, 'member'::text])"
+        },
+        "invitation_status_check": {
+          "name": "invitation_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'accepted'::text, 'rejected'::text, 'canceled'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.lifecycle_events": {
+      "name": "lifecycle_events",
+      "schema": "app",
+      "columns": {
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "factory_run_id": {
+          "name": "factory_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "lifecycle_events_factory_run_idx": {
+          "name": "lifecycle_events_factory_run_idx",
+          "columns": [
+            {
+              "expression": "factory_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lifecycle_events_change_idx": {
+          "name": "lifecycle_events_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lifecycle_events_factory_run_id_fkey": {
+          "name": "lifecycle_events_factory_run_id_fkey",
+          "tableFrom": "lifecycle_events",
+          "tableTo": "factory_runs",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "factory_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lifecycle_events_change_id_fkey": {
+          "name": "lifecycle_events_change_id_fkey",
+          "tableFrom": "lifecycle_events",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lifecycle_events_kind_check": {
+          "name": "lifecycle_events_kind_check",
+          "value": "kind = ANY (ARRAY['work.requested'::text, 'plan.ready'::text, 'human.approved'::text, 'change.opened'::text, 'change.updated'::text, 'change.closed'::text, 'stage.completed'::text, 'stage.failed'::text, 'external.checks_updated'::text, 'human.resume_requested'::text, 'human.handoff_requested'::text, 'run.cancelled'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.member": {
+      "name": "member",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organizationId_fkey": {
+          "name": "member_organizationId_fkey",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_userId_fkey": {
+          "name": "member_userId_fkey",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member_organization_user_unique": {
+          "name": "member_organization_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organizationId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "role = ANY (ARRAY['owner'::text, 'admin'::text, 'member'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.oauthAccessToken": {
+      "name": "oauthAccessToken",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_expiry_idx": {
+          "name": "oauth_access_token_expiry_idx",
+          "columns": [
+            {
+              "expression": "accessTokenExpiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauthAccessToken_clientId_fkey": {
+          "name": "oauthAccessToken_clientId_fkey",
+          "tableFrom": "oauthAccessToken",
+          "tableTo": "oauthApplication",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauthAccessToken_userId_fkey": {
+          "name": "oauthAccessToken_userId_fkey",
+          "tableFrom": "oauthAccessToken",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthAccessToken_accessToken_key": {
+          "name": "oauthAccessToken_accessToken_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "accessToken"
+          ]
+        },
+        "oauthAccessToken_refreshToken_key": {
+          "name": "oauthAccessToken_refreshToken_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refreshToken"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.oauthApplication": {
+      "name": "oauthApplication",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientSecret": {
+          "name": "clientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectUrls": {
+          "name": "redirectUrls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauthApplication_userId_fkey": {
+          "name": "oauthApplication_userId_fkey",
+          "tableFrom": "oauthApplication",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthApplication_clientId_key": {
+          "name": "oauthApplication_clientId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.oauthConsent": {
+      "name": "oauthConsent",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentGiven": {
+          "name": "consentGiven",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauthConsent_clientId_fkey": {
+          "name": "oauthConsent_clientId_fkey",
+          "tableFrom": "oauthConsent",
+          "tableTo": "oauthApplication",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauthConsent_userId_fkey": {
+          "name": "oauthConsent_userId_fkey",
+          "tableFrom": "oauthConsent",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_consent_client_user_unique": {
+          "name": "oauth_consent_client_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.organization": {
+      "name": "organization",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installationId": {
+          "name": "installationId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_installationId_fkey": {
+          "name": "organization_installationId_fkey",
+          "tableFrom": "organization",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "installationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_key": {
+          "name": "organization_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_installationId_key": {
+          "name": "organization_installationId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "installationId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.plan_repositories": {
+      "name": "plan_repositories",
+      "schema": "app",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "plan_repositories_repository_idx": {
+          "name": "plan_repositories_repository_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plan_repositories_plan_id_fkey": {
+          "name": "plan_repositories_plan_id_fkey",
+          "tableFrom": "plan_repositories",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_repositories_repository_id_fkey": {
+          "name": "plan_repositories_repository_id_fkey",
+          "tableFrom": "plan_repositories",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "plan_repositories_pkey": {
+          "name": "plan_repositories_pkey",
+          "columns": [
+            "plan_id",
+            "repository_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "plan_repositories_position_unique": {
+          "name": "plan_repositories_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plan_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plan_repositories_position_check": {
+          "name": "plan_repositories_position_check",
+          "value": "(\"position\" >= 0) AND (\"position\" <= 2)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.plans": {
+      "name": "plans",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "plans_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "todo_id": {
+          "name": "todo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptance": {
+          "name": "acceptance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'analyzing'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_login": {
+          "name": "created_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_model": {
+          "name": "runner_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "plans_active_idx": {
+          "name": "plans_active_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(NOT archived)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plans_feature_idx": {
+          "name": "plans_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(feature_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plans_repository_created_idx": {
+          "name": "plans_repository_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plans_todo_id_todos_id_fk": {
+          "name": "plans_todo_id_todos_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "todos",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "todo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plans_feature_id_features_id_fk": {
+          "name": "plans_feature_id_features_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plans_repository_id_fkey": {
+          "name": "plans_repository_id_fkey",
+          "tableFrom": "plans",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plans_todo_unique": {
+          "name": "plans_todo_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "todo_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plans_status_check": {
+          "name": "plans_status_check",
+          "value": "status = ANY (ARRAY['analyzing'::text, 'awaiting_answers'::text, 'refining'::text, 'plan_ready'::text, 'approving'::text, 'approved'::text, 'failed'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "push_subscriptions_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_github_id": {
+          "name": "user_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_idx": {
+          "name": "push_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_github_id_fkey": {
+          "name": "push_subscriptions_user_github_id_fkey",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "user_github_id"
+          ],
+          "columnsTo": [
+            "githubId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_key": {
+          "name": "push_subscriptions_endpoint_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repo_agents": {
+      "name": "repo_agents",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_agents_agent_tenant_idx": {
+          "name": "repo_agents_agent_tenant_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_agents_repository_tenant_idx": {
+          "name": "repo_agents_repository_tenant_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_agents_repository_tenant_fk": {
+          "name": "repo_agents_repository_tenant_fk",
+          "tableFrom": "repo_agents",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id",
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "installation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_agents_agent_tenant_fk": {
+          "name": "repo_agents_agent_tenant_fk",
+          "tableFrom": "repo_agents",
+          "tableTo": "agents",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "agent_id",
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "installation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repo_agents_pkey": {
+          "name": "repo_agents_pkey",
+          "columns": [
+            "repository_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repo_connections": {
+      "name": "repo_connections",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviews": {
+          "name": "reviews",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "automations": {
+          "name": "automations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_connections_connection_tenant_idx": {
+          "name": "repo_connections_connection_tenant_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_connections_repository_tenant_idx": {
+          "name": "repo_connections_repository_tenant_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_connections_repository_tenant_fk": {
+          "name": "repo_connections_repository_tenant_fk",
+          "tableFrom": "repo_connections",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id",
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "installation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_connections_connection_tenant_fk": {
+          "name": "repo_connections_connection_tenant_fk",
+          "tableFrom": "repo_connections",
+          "tableTo": "connections",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "connection_id",
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "installation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repo_connections_pkey": {
+          "name": "repo_connections_pkey",
+          "columns": [
+            "repository_id",
+            "connection_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repo_skills": {
+      "name": "repo_skills",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_skills_repository_tenant_idx": {
+          "name": "repo_skills_repository_tenant_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_skills_skill_tenant_idx": {
+          "name": "repo_skills_skill_tenant_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_skills_repository_tenant_fk": {
+          "name": "repo_skills_repository_tenant_fk",
+          "tableFrom": "repo_skills",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id",
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "installation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_skills_skill_tenant_fk": {
+          "name": "repo_skills_skill_tenant_fk",
+          "tableFrom": "repo_skills",
+          "tableTo": "skills",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "skill_id",
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "installation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repo_skills_pkey": {
+          "name": "repo_skills_pkey",
+          "columns": [
+            "repository_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repositories": {
+      "name": "repositories",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval('app.native_entity_id_seq'::regclass)"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "artifacts_repo": {
+          "name": "artifacts_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_push_at": {
+          "name": "last_push_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_on_push": {
+          "name": "review_on_push",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_intake": {
+          "name": "review_intake",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'factory_only'"
+        },
+        "process_profile": {
+          "name": "process_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy_factory'"
+        },
+        "blocking_reviews": {
+          "name": "blocking_reviews",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_fix": {
+          "name": "auto_fix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "check_command": {
+          "name": "check_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_command": {
+          "name": "run_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_port": {
+          "name": "app_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_merge": {
+          "name": "auto_merge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "demo_videos": {
+          "name": "demo_videos",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "launchable": {
+          "name": "launchable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_resolve_conflicts": {
+          "name": "auto_resolve_conflicts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "repositories_artifacts_repo_unique": {
+          "name": "repositories_artifacts_repo_unique",
+          "columns": [
+            {
+              "expression": "artifacts_repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(artifacts_repo IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_enabled_idx": {
+          "name": "repositories_enabled_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_installation_idx": {
+          "name": "repositories_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_installation_provider_fk": {
+          "name": "repositories_installation_provider_fk",
+          "tableFrom": "repositories",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "installation_id",
+            "provider"
+          ],
+          "columnsTo": [
+            "id",
+            "provider"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repositories_id_installation_unique": {
+          "name": "repositories_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "installation_id"
+          ]
+        },
+        "repositories_owner_name_unique": {
+          "name": "repositories_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "repositories_provider_check": {
+          "name": "repositories_provider_check",
+          "value": "provider = ANY (ARRAY['github'::text, 'artifacts'::text])"
+        },
+        "repositories_app_port_check": {
+          "name": "repositories_app_port_check",
+          "value": "(app_port >= 1) AND (app_port <= 65535)"
+        },
+        "repositories_review_intake_check": {
+          "name": "repositories_review_intake_check",
+          "value": "review_intake = ANY (ARRAY['factory_only'::text, 'on_demand'::text, 'all_changes'::text])"
+        },
+        "repositories_process_profile_check": {
+          "name": "repositories_process_profile_check",
+          "value": "process_profile = ANY (ARRAY['review_on_demand'::text, 'automatic_review'::text, 'review_and_repair'::text, 'idea_to_pr'::text, 'assisted_delivery'::text, 'full_delivery'::text, 'native_turnkey'::text, 'legacy_factory'::text])"
+        },
+        "repositories_artifacts_shape": {
+          "name": "repositories_artifacts_shape",
+          "value": "((provider = 'artifacts'::text) AND (artifacts_repo IS NOT NULL) AND (default_branch IS NOT NULL)) OR ((provider = 'github'::text) AND (artifacts_repo IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.repository_refs": {
+      "name": "repository_refs",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pushed_at": {
+          "name": "pushed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "repository_refs_head_idx": {
+          "name": "repository_refs_head_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repository_refs_repository_id_fkey": {
+          "name": "repository_refs_repository_id_fkey",
+          "tableFrom": "repository_refs",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repository_refs_pkey": {
+          "name": "repository_refs_pkey",
+          "columns": [
+            "repository_id",
+            "ref"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.reviews": {
+      "name": "reviews",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "reviews_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event": {
+          "name": "trigger_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_url": {
+          "name": "review_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_instance_id": {
+          "name": "agent_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_tier": {
+          "name": "risk_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_count": {
+          "name": "findings_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage_run_id": {
+          "name": "stage_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "reviews_agent_instance_idx": {
+          "name": "reviews_agent_instance_idx",
+          "columns": [
+            {
+              "expression": "agent_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_installation_time_idx": {
+          "name": "reviews_installation_time_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_one_running_instance_idx": {
+          "name": "reviews_one_running_instance_idx",
+          "columns": [
+            {
+              "expression": "agent_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((status = 'running'::text) AND (agent_instance_id IS NOT NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_repo_pr_idx": {
+          "name": "reviews_repo_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_repository_installation_idx": {
+          "name": "reviews_repository_installation_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_running_installation_idx": {
+          "name": "reviews_running_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_stage_run_idx": {
+          "name": "reviews_stage_run_idx",
+          "columns": [
+            {
+              "expression": "stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(stage_run_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_stage_run_id_stage_runs_id_fk": {
+          "name": "reviews_stage_run_id_stage_runs_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "stage_runs",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reviews_repository_tenant_fk": {
+          "name": "reviews_repository_tenant_fk",
+          "tableFrom": "reviews",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id",
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "installation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reviews_output_tokens_check": {
+          "name": "reviews_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "reviews_cache_read_tokens_check": {
+          "name": "reviews_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "reviews_cache_write_tokens_check": {
+          "name": "reviews_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "reviews_pr_number_check": {
+          "name": "reviews_pr_number_check",
+          "value": "pr_number > 0"
+        },
+        "reviews_status_check": {
+          "name": "reviews_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'completed'::text, 'failed'::text])"
+        },
+        "reviews_input_tokens_check": {
+          "name": "reviews_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "reviews_cost_usd_check": {
+          "name": "reviews_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        },
+        "reviews_risk_tier_check": {
+          "name": "reviews_risk_tier_check",
+          "value": "(risk_tier IS NULL) OR (risk_tier = ANY (ARRAY['trivial'::text, 'lite'::text, 'full'::text]))"
+        },
+        "reviews_findings_count_check": {
+          "name": "reviews_findings_count_check",
+          "value": "(findings_count IS NULL) OR (findings_count >= 0)"
+        },
+        "reviews_verdict_check": {
+          "name": "reviews_verdict_check",
+          "value": "(verdict IS NULL) OR (verdict = ANY (ARRAY['approve'::text, 'comment'::text, 'request_changes'::text]))"
+        },
+        "reviews_completion_shape": {
+          "name": "reviews_completion_shape",
+          "value": "((status = 'running'::text) AND (completed_at IS NULL)) OR (status <> 'running'::text)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.session": {
+      "name": "session",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeOrganizationId": {
+          "name": "activeOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_active_organization_idx": {
+          "name": "session_active_organization_idx",
+          "columns": [
+            {
+              "expression": "activeOrganizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"activeOrganizationId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_expires_at_idx": {
+          "name": "session_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_fkey": {
+          "name": "session_userId_fkey",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_fk": {
+          "name": "session_active_organization_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "activeOrganizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_key": {
+          "name": "session_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.skills": {
+      "name": "skills",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "skills_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skills_installation_id_fkey": {
+          "name": "skills_installation_id_fkey",
+          "tableFrom": "skills",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_id_installation_unique": {
+          "name": "skills_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "installation_id"
+          ]
+        },
+        "skills_installation_slug_unique": {
+          "name": "skills_installation_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "installation_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "skills_slug_format": {
+          "name": "skills_slug_format",
+          "value": "slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.stage_runs": {
+      "name": "stage_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "stage_runs_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "factory_run_id": {
+          "name": "factory_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_instance": {
+          "name": "workflow_instance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "stage_runs_factory_run_idx": {
+          "name": "stage_runs_factory_run_idx",
+          "columns": [
+            {
+              "expression": "factory_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stage_runs_change_idx": {
+          "name": "stage_runs_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stage_runs_factory_run_id_fkey": {
+          "name": "stage_runs_factory_run_id_fkey",
+          "tableFrom": "stage_runs",
+          "tableTo": "factory_runs",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "factory_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stage_runs_change_id_fkey": {
+          "name": "stage_runs_change_id_fkey",
+          "tableFrom": "stage_runs",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stage_runs_idempotency_key_unique": {
+          "name": "stage_runs_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        },
+        "stage_runs_attempt_unique": {
+          "name": "stage_runs_attempt_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "factory_run_id",
+            "stage",
+            "attempt"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "stage_runs_attempt_check": {
+          "name": "stage_runs_attempt_check",
+          "value": "attempt > 0"
+        },
+        "stage_runs_status_check": {
+          "name": "stage_runs_status_check",
+          "value": "status = ANY (ARRAY['queued'::text, 'running'::text, 'completed'::text, 'failed'::text, 'cancelled'::text])"
+        },
+        "stage_runs_stage_check": {
+          "name": "stage_runs_stage_check",
+          "value": "stage = ANY (ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.todo_repositories": {
+      "name": "todo_repositories",
+      "schema": "app",
+      "columns": {
+        "todo_id": {
+          "name": "todo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "todo_repositories_repository_idx": {
+          "name": "todo_repositories_repository_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "todo_repositories_todo_id_fkey": {
+          "name": "todo_repositories_todo_id_fkey",
+          "tableFrom": "todo_repositories",
+          "tableTo": "todos",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "todo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "todo_repositories_repository_id_fkey": {
+          "name": "todo_repositories_repository_id_fkey",
+          "tableFrom": "todo_repositories",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "todo_repositories_pkey": {
+          "name": "todo_repositories_pkey",
+          "columns": [
+            "todo_id",
+            "repository_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "todo_repositories_position_unique": {
+          "name": "todo_repositories_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "todo_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "todo_repositories_position_check": {
+          "name": "todo_repositories_position_check",
+          "value": "(\"position\" >= 0) AND (\"position\" <= 2)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.todos": {
+      "name": "todos",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "todos_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_login": {
+          "name": "created_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "todos_installation_unplanned_idx": {
+          "name": "todos_installation_unplanned_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(plan_id IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "todos_plan_unique": {
+          "name": "todos_plan_unique",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(plan_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "todos_plan_id_plans_id_fk": {
+          "name": "todos_plan_id_plans_id_fk",
+          "tableFrom": "todos",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "todos_installation_id_fkey": {
+          "name": "todos_installation_id_fkey",
+          "tableFrom": "todos",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.user": {
+      "name": "user",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubId": {
+          "name": "githubId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_github_id_unique": {
+          "name": "user_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "githubId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user_installation_access": {
+      "name": "user_installation_access",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_ids": {
+          "name": "installation_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_installation_access_user_id_fkey": {
+          "name": "user_installation_access_user_id_fkey",
+          "tableFrom": "user_installation_access",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_installation_access_no_null_ids": {
+          "name": "user_installation_access_no_null_ids",
+          "value": "array_position(installation_ids, NULL::bigint) IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.user_tokens": {
+      "name": "user_tokens",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_ciphertext": {
+          "name": "refresh_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.verification": {
+      "name": "verification",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_expires_at_idx": {
+          "name": "verification_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.verifications": {
+      "name": "verifications",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "verifications_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo": {
+          "name": "demo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "verifications_feature_idx": {
+          "name": "verifications_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verifications_one_running_idx": {
+          "name": "verifications_one_running_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verifications_running_created_idx": {
+          "name": "verifications_running_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verifications_feature_id_fkey": {
+          "name": "verifications_feature_id_fkey",
+          "tableFrom": "verifications",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verifications_status_check": {
+          "name": "verifications_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'passed'::text, 'failed'::text, 'error'::text, 'skipped'::text])"
+        },
+        "verifications_input_tokens_check": {
+          "name": "verifications_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "verifications_output_tokens_check": {
+          "name": "verifications_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "verifications_cache_read_tokens_check": {
+          "name": "verifications_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "verifications_cache_write_tokens_check": {
+          "name": "verifications_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "verifications_cost_usd_check": {
+          "name": "verifications_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.work_items": {
+      "name": "work_items",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "work_items_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "work_items_repo_created_idx": {
+          "name": "work_items_repo_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_items_repository_id_fkey": {
+          "name": "work_items_repository_id_fkey",
+          "tableFrom": "work_items",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "work_items_origin_check": {
+          "name": "work_items_origin_check",
+          "value": "origin = ANY (ARRAY['idea'::text, 'issue'::text, 'external_change'::text, 'automation'::text, 'api'::text])"
+        },
+        "work_items_status_check": {
+          "name": "work_items_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'closed'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "app": "app",
+    "auth": "auth"
+  },
+  "sequences": {
+    "app.native_entity_id_seq": {
+      "name": "native_entity_id_seq",
+      "schema": "app",
+      "increment": "1",
+      "startWith": "4000000000000000",
+      "minValue": "1",
+      "maxValue": "9007199254740991",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1788108555286,
       "tag": "0007_lifecycle-repair",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1788344402439,
+      "tag": "0008_review-error",
+      "breakpoints": true
     }
   ]
 }

--- a/src/ai/review/dispatch.ts
+++ b/src/ai/review/dispatch.ts
@@ -82,7 +82,10 @@ export async function dispatchReviewAgent(
       `turbodiff: dispatch failed for ${instanceId} (${agent.slug} on ${repo.owner}/${repo.name}#${prNumber}):`,
       error,
     );
-    await markReviewFailed(instanceId);
+    await markReviewFailed(
+      instanceId,
+      `dispatch failed: ${error instanceof Error ? error.message : String(error)}`.slice(0, 1_000),
+    );
     return false;
   }
   return true;

--- a/src/ai/review/metering.ts
+++ b/src/ai/review/metering.ts
@@ -11,6 +11,19 @@ import { failLifecycleReview } from '../../services/lifecycle.ts';
 // isolate; this subscriber registers in every isolate and sees only that
 // isolate's turns — exactly the per-review attribution we want.
 
+// The settlement's error is the only record of why a review died — the
+// review row keeps it so the failure is diagnosable from the product.
+export function settlementReason(event: {
+  outcome: 'completed' | 'failed' | 'aborted';
+  error?: { name?: string; message: string; type?: string; details?: string };
+}): string {
+  if (event.outcome === 'completed') return 'agent run ended without posting a review';
+  const error = event.error;
+  if (!error) return `agent run ${event.outcome}`;
+  const head = [error.type ?? error.name, error.message].filter(Boolean).join(': ');
+  return `${event.outcome}: ${head}${error.details ? ` — ${error.details}` : ''}`.slice(0, 1_000);
+}
+
 export function registerReviewMetering(): void {
   observe((event) => {
     if (event.instanceId === undefined) return;
@@ -18,7 +31,7 @@ export function registerReviewMetering(): void {
     // (agent error, abort, or a run that ended without posting), flip it to
     // failed so it doesn't sit "running" until the stall cutoff.
     if (event.type === 'submission_settled') {
-      void failLifecycleReview(event.instanceId).catch((err) =>
+      void failLifecycleReview(event.instanceId, settlementReason(event)).catch((err) =>
         console.error('turbodiff: marking review failed errored', err),
       );
       return;

--- a/src/client/lib/queries.ts
+++ b/src/client/lib/queries.ts
@@ -51,6 +51,14 @@ const RUNNING_PLAN_STATUSES = new Set(['analyzing', 'refining']);
 // user retries.
 export const GENERATION_STOPPED = new Set(['failed', 'checks_failed', 'no_changes']);
 
+// A stopped feature whose retry is already on the queue: the retry routes
+// stamp features.error with this before the workflow flips the status to
+// 'generating', so the stopped state is momentary — keep polling it, and
+// don't offer (or colour as an error) another retry.
+export function retryQueued(error: string | null | undefined): boolean {
+  return error === 'retry queued' || /^retry scheduled in /.test(error ?? '');
+}
+
 export function taskIsLive(p: ApiPlan): boolean {
   if (RUNNING_PLAN_STATUSES.has(p.status)) return true;
   if (p.repos.some((r) => r.verification?.status === 'running')) return true;
@@ -58,7 +66,11 @@ export function taskIsLive(p: ApiPlan): boolean {
   // flight unless it stopped.
   return (
     p.status === 'approved' &&
-    p.repos.some((r) => !r.pr_number && !GENERATION_STOPPED.has(r.feature_status ?? ''))
+    p.repos.some(
+      (r) =>
+        !r.pr_number &&
+        (!GENERATION_STOPPED.has(r.feature_status ?? '') || retryQueued(r.feature_error)),
+    )
   );
 }
 
@@ -109,7 +121,9 @@ export const featureQuery = (id: number) =>
       if (!d) return false;
       // Poll while generation is in flight (no PR yet, not stopped) or a
       // verification run is live.
-      if (!d.pr && !GENERATION_STOPPED.has(d.feature.status)) return LIVE_POLL_MS;
+      if (!d.pr && (!GENERATION_STOPPED.has(d.feature.status) || retryQueued(d.feature.error))) {
+        return LIVE_POLL_MS;
+      }
       if (d.verification?.status === 'running') return LIVE_POLL_MS;
       // Poll while a comment batch's fix run hasn't resolved yet.
       const fixInFlight = d.comments.some(

--- a/src/client/pages/feature.tsx
+++ b/src/client/pages/feature.tsx
@@ -20,6 +20,7 @@ import {
   featureQuery,
   FIX_TERMINAL,
   GENERATION_STOPPED,
+  retryQueued,
 } from '../lib/queries.ts';
 import { cn } from '../lib/utils.ts';
 import { AgentRunLog } from '../components/agent-run-log.tsx';
@@ -831,10 +832,21 @@ export default function FeaturePage() {
               <Muted>Generation stopped without a pull request.</Muted>
             </p>
             {data.feature.error ? (
-              <p className="mt-2 text-[0.85rem] text-danger">{data.feature.error}</p>
+              <p
+                className={cn(
+                  'mt-2 text-[0.85rem]',
+                  retryQueued(data.feature.error) ? 'text-mute' : 'text-danger',
+                )}
+              >
+                {data.feature.error}
+              </p>
             ) : null}
             <div className="mt-4">
-              <Button onClick={() => retryGeneration.mutate()} loading={retryGeneration.isPending}>
+              <Button
+                onClick={() => retryGeneration.mutate()}
+                loading={retryGeneration.isPending}
+                disabled={retryQueued(data.feature.error)}
+              >
                 Retry generation
               </Button>
             </div>

--- a/src/client/pages/feature.tsx
+++ b/src/client/pages/feature.tsx
@@ -119,10 +119,18 @@ function stationsFor(data: ApiFeatureDetail): Station[] {
   const merged = data.pr?.state === 'merged';
   const conflict = data.pr?.mergeable_state === 'dirty';
 
+  // No GitHub review yet is "polling" only while the lifecycle's review
+  // stage is still live — a failed stage is a failure, not a wait.
+  const lastReviewStage = data.lifecycle_runs
+    .at(-1)
+    ?.stages.filter((stage) => stage.stage === 'review')
+    .at(-1);
   const build: Station = { label: 'Build', verdict: 'GO', tone: 'go' };
   const review: Station =
     data.reviews.length === 0
-      ? { label: 'Review', verdict: 'POLLING', tone: 'hold', pulse: true }
+      ? lastReviewStage?.status === 'failed'
+        ? { label: 'Review', verdict: 'FAILED', tone: 'abort' }
+        : { label: 'Review', verdict: 'POLLING', tone: 'hold', pulse: true }
       : blocking
         ? { label: 'Review', verdict: 'NO-GO', tone: 'abort' }
         : { label: 'Review', verdict: 'GO', tone: 'go' };
@@ -247,7 +255,16 @@ function GoNoGoBoard({ data }: { data: ApiFeatureDetail }) {
   );
 }
 
-function LifecycleHistory({ runs }: { runs: ApiFeatureDetail['lifecycle_runs'] }) {
+function LifecycleHistory({
+  runs,
+  onResume,
+  resuming,
+}: {
+  runs: ApiFeatureDetail['lifecycle_runs'];
+  // Re-run the failed stage of a run parked on a human decision.
+  onResume: (runId: number) => void;
+  resuming: boolean;
+}) {
   if (runs.length === 0) return null;
   return (
     <>
@@ -296,6 +313,18 @@ function LifecycleHistory({ runs }: { runs: ApiFeatureDetail['lifecycle_runs'] }
                   </li>
                 ))}
               </ol>
+              {run.status === 'awaiting_human' && run.stages.at(-1)?.status === 'failed' ? (
+                <div className="mt-3">
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => onResume(run.id)}
+                    loading={resuming}
+                  >
+                    Retry {sentence(run.stages.at(-1)?.stage ?? 'stage')}
+                  </Button>
+                </div>
+              ) : null}
               {run.handoff_reason ? (
                 <p className="mt-3 text-xs text-mute">Handoff: {run.handoff_reason}</p>
               ) : null}
@@ -729,6 +758,15 @@ export default function FeaturePage() {
     },
     onError: onApiError,
   });
+  const resumeStage = useMutation({
+    mutationFn: (runId: number) =>
+      api.post(`/api/factory/features/${id}/lifecycle/${runId}/resume`),
+    onSuccess: () => {
+      toast.success('Stage retried — it runs again on the same delivery');
+      refresh();
+    },
+    onError: onApiError,
+  });
   const rereview = useMutation({
     mutationFn: () => api.post(`/api/factory/features/${id}/review`),
     onSuccess: () => {
@@ -1091,7 +1129,11 @@ export default function FeaturePage() {
         </div>
       ) : null}
 
-      <LifecycleHistory runs={data.lifecycle_runs} />
+      <LifecycleHistory
+        runs={data.lifecycle_runs}
+        onResume={(runId) => resumeStage.mutate(runId)}
+        resuming={resumeStage.isPending}
+      />
       <AgentRunLog runs={data.runs} />
 
       {/* Review workspace: an always-visible file tree beside the diff, so the

--- a/src/client/pages/task.tsx
+++ b/src/client/pages/task.tsx
@@ -18,7 +18,7 @@ import { useDictation } from '../lib/dictation.ts';
 import { ago } from '../lib/format.ts';
 import { applyOptimistic } from '../lib/optimistic.ts';
 import { pushSupported, subscribeToPush } from '../lib/push.ts';
-import { GENERATION_STOPPED, meQuery, taskQuery } from '../lib/queries.ts';
+import { GENERATION_STOPPED, meQuery, retryQueued, taskQuery } from '../lib/queries.ts';
 import { taskColumn, taskStages, taskState } from '../lib/task-state.ts';
 import { cn } from '../lib/utils.ts';
 import { AgentRunLog } from '../components/agent-run-log.tsx';
@@ -440,7 +440,14 @@ export function TaskPage() {
                         <Pill tone={tone}>{label}</Pill>
                       </div>
                       {stopped && r.feature_error ? (
-                        <p className="mt-2 text-[0.85rem] text-danger">{r.feature_error}</p>
+                        <p
+                          className={cn(
+                            'mt-2 text-[0.85rem]',
+                            retryQueued(r.feature_error) ? 'text-mute' : 'text-danger',
+                          )}
+                        >
+                          {r.feature_error}
+                        </p>
                       ) : null}
                       <div className="mt-3 flex flex-col gap-2 sm:flex-row">
                         {stopped && featureId !== null ? (
@@ -448,6 +455,7 @@ export function TaskPage() {
                             size="sm"
                             onClick={() => retry.mutate(featureId)}
                             loading={retry.isPending && retry.variables === r.feature_id}
+                            disabled={retryQueued(r.feature_error)}
                           >
                             Retry generation
                           </Button>

--- a/src/data/db.worker.test.ts
+++ b/src/data/db.worker.test.ts
@@ -38,6 +38,7 @@ import {
   setChatSessionId,
   tryRecordAutomationRun,
   tryRecordFixAttempt,
+  markReviewFailed,
   tryRecordReview,
   updatePlan,
   upsertInstallation,
@@ -324,6 +325,18 @@ describe('cockpit chat messages', () => {
 });
 
 describe('review dispatch invariants', () => {
+  it('records why a review failed', async () => {
+    const id = await tryRecordReview(101, 1001, 12, 'opened', 'review', 'review--acme--api--12');
+    await expect(
+      markReviewFailed('review--acme--api--12', 'dispatch failed: boom'),
+    ).resolves.toMatchObject({ stage_run_id: null });
+    const row = await testDatabase()
+      .prepare(`SELECT status, error FROM reviews WHERE id = ?1`)
+      .bind(id)
+      .first<{ status: string; error: string | null }>();
+    expect(row).toEqual({ status: 'failed', error: 'dispatch failed: boom' });
+  });
+
   it('admits exactly one concurrent claim for the same agent instance', async () => {
     const results = await Promise.all(
       Array.from({ length: 8 }, () =>

--- a/src/data/factory.ts
+++ b/src/data/factory.ts
@@ -1060,7 +1060,8 @@ export async function tryRecordReview(
 ): Promise<number | null> {
   return withTransaction(async (transaction) => {
     await transaction.execute(sql`
-        UPDATE app.reviews SET status = 'failed', completed_at = CURRENT_TIMESTAMP
+        UPDATE app.reviews SET status = 'failed', completed_at = CURRENT_TIMESTAMP,
+          error = COALESCE(error, 'stalled: no completion before a replacement was admitted')
         WHERE agent_instance_id = ${agentInstanceId} AND status = 'running'
           AND created_at < ${minutesAgo(STALL_AFTER_MINUTES)}
       `);

--- a/src/data/reviews.ts
+++ b/src/data/reviews.ts
@@ -48,6 +48,7 @@ export interface ReviewActivityRow {
   findings_count: number | null; // null until post_review completes the row
   stage_run_id: number | null;
   verdict: string | null;
+  error: string | null; // why a failed row failed
   repo_owner: string | null; // null if the repo was since removed
   repo_name: string | null;
 }
@@ -193,9 +194,15 @@ export async function dashboardStats(installationIds: number[]): Promise<Dashboa
 // that never posted). No-op when the row is already completed.
 export async function markReviewFailed(
   agentInstanceId: string,
+  // Why: the dispatch error or the agent's settlement error. Persisted so a
+  // failed review is diagnosable from its row (live finding: every review
+  // had died within seconds with zero tokens and nothing on record to say
+  // why — the reason only ever reached the Worker log).
+  error: string | null = null,
 ): Promise<{ stage_run_id: number | null } | null> {
   return queryOne<{ stage_run_id: number | null }>(sql`
-    UPDATE app.reviews SET status = 'failed', completed_at = CURRENT_TIMESTAMP
+    UPDATE app.reviews SET status = 'failed', completed_at = CURRENT_TIMESTAMP,
+      error = COALESCE(${error}::text, error)
     WHERE id = (
       SELECT id FROM app.reviews
       WHERE agent_instance_id = ${agentInstanceId} AND status = 'running'
@@ -210,6 +217,8 @@ export interface ReviewStageProgress {
   completed: number;
   failed: number;
   blocking: boolean;
+  // Recorded reasons of the failed reviews, oldest first.
+  errors: string[];
 }
 
 export async function reviewStageProgress(stageRunId: number): Promise<ReviewStageProgress> {
@@ -218,10 +227,14 @@ export async function reviewStageProgress(stageRunId: number): Promise<ReviewSta
       COUNT(*) FILTER (WHERE status = 'running') AS running,
       COUNT(*) FILTER (WHERE status = 'completed') AS completed,
       COUNT(*) FILTER (WHERE status = 'failed') AS failed,
-      COALESCE(BOOL_OR(verdict = 'request_changes'), FALSE) AS blocking
+      COALESCE(BOOL_OR(verdict = 'request_changes'), FALSE) AS blocking,
+      COALESCE(
+        ARRAY_REMOVE(ARRAY_AGG(error ORDER BY id) FILTER (WHERE status = 'failed'), NULL),
+        '{}'
+      ) AS errors
     FROM app.reviews WHERE stage_run_id = ${stageRunId}
   `);
-  return row ?? { running: 0, completed: 0, failed: 0, blocking: false };
+  return row ?? { running: 0, completed: 0, failed: 0, blocking: false, errors: [] };
 }
 
 // True when this agent's review of this PR is running and young enough to

--- a/src/data/schema.ts
+++ b/src/data/schema.ts
@@ -651,6 +651,9 @@ export const reviews = appSchema.table(
       { onDelete: 'set null' },
     ),
     verdict: text(),
+    // Why a failed row failed: the dispatch error or the agent's settlement
+    // error. Null on completed rows.
+    error: text(),
     createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),

--- a/src/http/api-support.ts
+++ b/src/http/api-support.ts
@@ -72,6 +72,7 @@ export function serializeReview(r: ReviewActivityRow): ApiReview {
     risk_tier: r.risk_tier,
     findings_count: r.findings_count,
     state: reviewState(r),
+    error: r.error,
     review_url: r.review_url,
     total_tokens: totalTokens(r),
     cost_usd: r.cost_usd,

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -172,7 +172,7 @@ import { checkMergeability, dispatchConflictResolution } from '../services/merge
 import { mergePullRequest } from '../services/auto-merge.ts';
 import { enqueueFactoryMessage, enqueueFactoryMessages } from '../services/factory-queue.ts';
 import { DEFAULT_MODEL } from '../domain/personas.ts';
-import { scheduleChangeReview } from '../services/lifecycle.ts';
+import { resumeFailedStage, scheduleChangeReview } from '../services/lifecycle.ts';
 import type { LifecycleDecision } from '../domain/lifecycle-contract.ts';
 import {
   ADOPTABLE_PROCESS_PROFILE_KEYS,
@@ -1735,6 +1735,28 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
     await updateFeature(feature.id, { error: 'retry queued' });
     await enqueueFactoryMessage({ kind: 'generate', featureId: feature.id });
     return c.json({ ok: true });
+  });
+
+  // A delivery run parked by a stage failure waits on a human — this is the
+  // human: re-run the failed stage as a fresh attempt on the same run.
+  app.post('/factory/features/:id/lifecycle/:runId/resume', async (c) => {
+    const id = Number(c.req.param('id'));
+    const runId = Number(c.req.param('runId'));
+    const feature = Number.isInteger(id) ? await getFeature(id) : null;
+    const repo = feature ? await getRepoById(feature.repository_id) : null;
+    if (!feature || !repo || !c.get('user').installationIds.includes(repo.installation_id)) {
+      return c.json({ error: 'unknown feature' }, 404);
+    }
+    const run = (await listFactoryRunsForFeature(feature.id)).find((r) => r.id === runId);
+    if (!run) return c.json({ error: 'unknown run' }, 404);
+    const result = await resumeFailedStage(run.id, c.get('user').session.login, enqueueFactory);
+    if (result.kind === 'rejected') return c.json({ error: result.reason }, 409);
+    return c.json({
+      ok: true,
+      stage: result.stage,
+      attempt: result.attempt,
+      stage_run_id: result.stageRunId,
+    });
   });
 
   // Context-file upload for planning (pdf/images). Stored in the ARTIFACTS

--- a/src/http/webhooks.worker.test.ts
+++ b/src/http/webhooks.worker.test.ts
@@ -32,6 +32,8 @@ import type { ReviewDispatcher } from '../services/change-review.ts';
 import {
   completeLifecycleReview,
   completeLifecycleStage,
+  failLifecycleReview,
+  resumeFailedStage,
   runLifecycleStage,
   scheduleFeatureDelivery,
 } from '../services/lifecycle.ts';
@@ -480,6 +482,106 @@ describe('composable feature delivery', () => {
       { attempt: 2, status: 'failed', error: 'generation run was killed — retry' },
       { attempt: 3, status: 'queued' },
     ]);
+  });
+
+  it('surfaces why a review stage failed and lets a human retry it on the same run', async () => {
+    await seedRepo();
+    await ensureBuiltinAgents(1001);
+    const featureId = await createFeature(101, 'Reviewed delivery', 'Ship it', ['It works']);
+    const change = await upsertChange({
+      repositoryId: 101,
+      providerKey: 'github:43',
+      number: 43,
+      origin: 'factory',
+      title: 'Reviewed delivery',
+      externalUrl: 'https://github.com/acme/api/pull/43',
+      sourceBranch: 'turbodiff/feature-43',
+      targetBranch: 'main',
+      status: 'open',
+      sourceHead: 'e'.repeat(40),
+      targetHead: 'f'.repeat(40),
+      draft: false,
+      capabilities: ['read_change', 'publish_review', 'write_head', 'publish_check', 'merge'],
+    });
+    await updateFeature(featureId, { status: 'pr_opened', prNumber: 43, changeId: change.id });
+    const created = await createFactoryRunWithStage({
+      repositoryId: 101,
+      changeId: change.id,
+      profileKey: 'full_delivery',
+      startStage: 'review',
+      stopAfterStage: 'merge',
+      policySnapshot: { key: 'full_delivery' },
+      trigger: 'test',
+      eventKind: 'human.resume_requested',
+      decision: { kind: 'schedule', stage: 'review' },
+      idempotencyKey: `review-delivery:${featureId}`,
+      stageInput: { featureId },
+    });
+    const queued: FactoryMessage[] = [];
+    const enqueue = async (message: FactoryMessage) => void queued.push(message);
+    const dispatch: ReviewDispatcher = async (agent, repo, prNumber, _url, trigger, options) => {
+      await tryRecordReview(
+        repo.id,
+        repo.installation_id,
+        prNumber,
+        trigger,
+        agent.slug,
+        `${agent.slug}--${repo.owner}--${repo.name}--${prNumber}`,
+        options?.riskTier ?? null,
+        options?.stageRunId ?? null,
+      );
+      return true;
+    };
+    const command: RunStageCommand = {
+      kind: 'run_stage',
+      factoryRunId: created.run.id,
+      stageRunId: created.stageRun!.id,
+      stage: 'review',
+      idempotencyKey: created.stageRun!.idempotency_key,
+      changeId: change.id,
+    };
+    await runLifecycleStage(command, dispatch, { computeRisk: async () => 'full', enqueue });
+
+    // The agent dies before posting: the settlement reason lands on the
+    // review row and on the stage the lifecycle panel shows.
+    await failLifecycleReview('review--acme--api--43', 'failed: AiError: model not found', enqueue);
+    await expect(getStageRun(created.stageRun!.id)).resolves.toMatchObject({
+      status: 'failed',
+      error: 'all review dispatches failed: failed: AiError: model not found',
+      output: { completed: 0, failed: 1, errors: ['failed: AiError: model not found'] },
+    });
+    await expect(getFactoryRun(created.run.id)).resolves.toMatchObject({
+      status: 'awaiting_human',
+    });
+
+    // A human retries the stage: a fresh attempt on the same run, so verify
+    // and merge still follow it.
+    queued.length = 0;
+    await expect(resumeFailedStage(created.run.id, 'nico', enqueue)).resolves.toMatchObject({
+      kind: 'scheduled',
+      stage: 'review',
+      attempt: 2,
+    });
+    await expect(getFactoryRun(created.run.id)).resolves.toMatchObject({
+      status: 'active',
+      handoff_reason: null,
+    });
+    expect(stageCommands(queued)).toMatchObject([
+      {
+        stage: 'review',
+        factoryRunId: created.run.id,
+        idempotencyKey: `${created.run.id}:review:2`,
+        changeId: change.id,
+      },
+    ]);
+    await expect(listStageRuns(created.run.id)).resolves.toMatchObject([
+      { stage: 'review', attempt: 1, status: 'failed' },
+      { stage: 'review', attempt: 2, status: 'queued', input: { featureId } },
+    ]);
+    // Only a parked run can be retried.
+    await expect(resumeFailedStage(created.run.id, 'nico', enqueue)).resolves.toMatchObject({
+      kind: 'rejected',
+    });
   });
 
   it('hands verified delivery to the merge executor and completes the run', async () => {

--- a/src/services/lifecycle.ts
+++ b/src/services/lifecycle.ts
@@ -390,6 +390,16 @@ async function coordinateStageOutcome(
   }
 }
 
+// What a settled review stage records: the dispatch tallies, plus the failed
+// reviews' reasons when there were any.
+type ReviewStageOutput = {
+  running: number;
+  completed: number;
+  failed: number;
+  blocking: boolean;
+  errors?: string[];
+};
+
 async function settleReviewStage(
   stageRunId: number,
   enqueue: typeof enqueueFactoryMessage,
@@ -398,12 +408,13 @@ async function settleReviewStage(
   if (!stageRun || stageRun.stage !== 'review' || stageRun.status !== 'running') return;
   const progress = await reviewStageProgress(stageRunId);
   if (progress.running > 0) return;
-  const output: JsonValue = {
+  const output: ReviewStageOutput = {
     running: progress.running,
     completed: progress.completed,
     failed: progress.failed,
     blocking: progress.blocking,
   };
+  if (progress.errors.length > 0) output.errors = progress.errors;
   const command: RunStageCommand = {
     kind: 'run_stage',
     factoryRunId: stageRun.factory_run_id,
@@ -413,7 +424,10 @@ async function settleReviewStage(
   };
   if (stageRun.change_id !== null) command.changeId = stageRun.change_id;
   if (progress.completed === 0) {
-    await finishStageRun(stageRun.id, 'failed', output, 'all review dispatches failed');
+    // The first recorded reason rides on the stage error — that's what the
+    // lifecycle panel shows.
+    const why = progress.errors[0] ? `: ${progress.errors[0]}` : '';
+    await finishStageRun(stageRun.id, 'failed', output, `all review dispatches failed${why}`);
     await coordinateStageOutcome(command, false, enqueue);
     return;
   }
@@ -436,10 +450,84 @@ export async function completeLifecycleReview(
 
 export async function failLifecycleReview(
   agentInstanceId: string,
+  reason: string | null = null,
   enqueue: typeof enqueueFactoryMessage = enqueueFactoryMessage,
 ): Promise<void> {
-  const failed = await markReviewFailed(agentInstanceId);
+  const failed = await markReviewFailed(agentInstanceId, reason);
   if (failed?.stage_run_id) await settleReviewStage(failed.stage_run_id, enqueue);
+}
+
+export type ResumeStageResult =
+  | { kind: 'scheduled'; stageRunId: number; stage: LifecycleStage; attempt: number }
+  | { kind: 'rejected'; reason: string };
+
+// A run parked by a stage failure ("stage failure requires retry policy
+// evaluation") has no automatic retry policy yet — a human is the policy.
+// Re-run the failed stage as a fresh attempt on the same run, so the rest of
+// the delivery (verify, merge) continues from there once it passes.
+export async function resumeFailedStage(
+  runId: number,
+  actor: string | null,
+  enqueue: typeof enqueueFactoryMessage = enqueueFactoryMessage,
+): Promise<ResumeStageResult> {
+  const run = await getFactoryRun(runId);
+  if (!run) return { kind: 'rejected', reason: 'unknown run' };
+  if (run.status !== 'awaiting_human') {
+    return {
+      kind: 'rejected',
+      reason: `run is ${run.status.replaceAll('_', ' ')}, not waiting on a human`,
+    };
+  }
+  const latest = (await listStageRuns(run.id)).at(-1);
+  if (!latest || latest.status !== 'failed') {
+    return { kind: 'rejected', reason: 'the latest stage did not fail' };
+  }
+  const repo = await getRepoById(run.repository_id);
+  if (!repo) return { kind: 'rejected', reason: 'repository missing' };
+  const changeId = latest.change_id ?? run.change_id;
+  const change = changeId ? await getChange(changeId) : null;
+  const featureId = featureIdFromInput(latest.input);
+  const feature = featureId ? await getFeature(featureId) : null;
+  const acceptanceContract = change ? await latestAcceptanceContractForChange(change.id) : null;
+  const decision = decideLifecycle(run.profile_key, {
+    event: 'human.resume_requested',
+    origin: change?.origin ?? (feature ? 'factory' : 'imported'),
+    startStage: latest.stage,
+    stopAfterStage: run.stop_after_stage,
+    capabilities: change?.capabilities,
+    facts: {
+      repositoryEnabled: repo.enabled,
+      runStatus: run.status,
+      acceptanceContractPresent: acceptanceContract !== null || feature?.acceptance != null,
+    },
+  });
+  if (decision.kind !== 'schedule') {
+    return {
+      kind: 'rejected',
+      reason: decision.kind === 'complete' ? 'run is complete' : decision.reason,
+    };
+  }
+  const next = await recordLifecycleDecision(
+    run.id,
+    changeId ?? null,
+    'human.resume_requested',
+    { stageRunId: latest.id, actor },
+    decision,
+    `resume:${run.id}:${latest.id}`,
+    latest.input ?? undefined,
+  );
+  if (!next) return { kind: 'rejected', reason: 'this stage was already retried' };
+  await resumeFactoryRun(run.id);
+  await enqueue(
+    commandFor(
+      run.id,
+      next.id,
+      next.stage,
+      next.change_id ?? changeId ?? null,
+      next.idempotency_key,
+    ),
+  );
+  return { kind: 'scheduled', stageRunId: next.id, stage: next.stage, attempt: next.attempt };
 }
 
 export async function completeLifecycleRepair(

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -26,6 +26,7 @@ export interface ApiReview {
   risk_tier: string | null;
   findings_count: number | null;
   state: ReviewState;
+  error: string | null; // why a failed review failed
   review_url: string | null;
   total_tokens: number;
   cost_usd: number;


### PR DESCRIPTION
## Why

Every review ever recorded in production (8 of 8, PRs 127–135) failed within 2–4 s of dispatch with zero tokens, and nothing said why: the reviewer's settlement error only reached the Worker log, the row just flipped to `failed`, the stage said "all review dispatches failed", and the pipeline card kept showing the review as *polling*. Root cause turned out to be exhausted AI Gateway credits — the reviewer is the only component that runs through the `env.AI` binding (everything else runs the CLI in the sandbox with its own key). With this change that would have shown up as a billing error on the first failed review.

A run parked on "stage failure requires retry policy evaluation" also had no way forward: no retry policy exists, so a `full_delivery` run whose review failed could never reach verify or merge.

## Change

- `app.reviews.error` (migration `0008_review-error`): recorded by the dispatch catch, by the metering subscriber from the settlement's outcome/error, and by the stale-claim sweep. The review stage's error now carries the first recorded reason, which the lifecycle panel displays. `/api/reviews` exposes `error`.
- `resumeFailedStage` + `POST /api/factory/features/:id/lifecycle/:runId/resume`: records `human.resume_requested` on the same run, schedules the failed stage as a fresh attempt, and reactivates the run. The lifecycle panel gets a **Retry \<stage\>** button.
- Pipeline card: a failed review stage shows **FAILED** rather than POLLING.

Verified: typecheck, lint (incl. anti-slop), `db:check`, schema test, worker suite (147) and unit suite (126) pass. New tests cover the recorded reason, the stage error, the resume path, and its idempotency.

## After deploy

Top up the gateway credits (or store an Anthropic BYOK key under the `default` alias), then open TD-0002, expand the lifecycle panel, press **Retry review**. Verify and merge follow on the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcL9hLMj2MVeEthj3QdnYr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcL9hLMj2MVeEthj3QdnYr)_