### PR TITLE
feat(auth): accept-invite landing page and GitHub email adoption

### DIFF
--- a/src/client/lib/queries.ts
+++ b/src/client/lib/queries.ts
@@ -13,6 +13,7 @@ import type {
   ApiFeatureDetail,
   ApiFeatureDiff,
   ApiIntegrations,
+  ApiInvitationPreview,
   ApiMe,
   ApiModels,
   ApiOrgMembers,
@@ -206,6 +207,16 @@ export const orgMembersQuery = (installationId: number) =>
   queryOptions({
     queryKey: ['org-members', installationId],
     queryFn: () => api.get<ApiOrgMembers>(`/api/organizations/${installationId}/members`),
+  });
+
+// Never retried: every failure here (not found, expired, wrong account) is a
+// definitive answer the page turns into a message, not a transient.
+export const invitationQuery = (id: string) =>
+  queryOptions({
+    queryKey: ['invitation', id],
+    queryFn: () => api.get<ApiInvitationPreview>(`/api/invitations/${encodeURIComponent(id)}`),
+    retry: false,
+    staleTime: 0,
   });
 
 export const integrationsQuery = queryOptions({

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -133,6 +133,15 @@ const onboardingRoute = createRoute({
   component: lazyRouteComponent(() => import('./pages/onboarding.tsx'), 'OnboardingPage'),
 });
 
+// Invitation-email landing page — outside the shell like /onboarding: the
+// recipient may have no installation to show a board for yet.
+const acceptInviteRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/accept-invite',
+  validateSearch: (s: JsonObject): { id?: string } => (isString(s.id) ? { id: s.id } : {}),
+  component: lazyRouteComponent(() => import('./pages/accept-invite.tsx'), 'AcceptInvitePage'),
+});
+
 const boardRoute = createRoute({
   getParentRoute: () => shellRoute,
   path: '/',
@@ -292,6 +301,7 @@ const automationRunRoute = createRoute({
 
 const routeTree = rootRoute.addChildren([
   onboardingRoute,
+  acceptInviteRoute,
   shellRoute.addChildren([
     boardRoute,
     taskRoute,

--- a/src/client/pages/accept-invite.tsx
+++ b/src/client/pages/accept-invite.tsx
@@ -1,0 +1,143 @@
+import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useNavigate, useSearch } from '@tanstack/react-router';
+import { Loader2, LogOut, UserPlus } from 'lucide-react';
+import { toast } from 'sonner';
+import type { ApiInvitationAccepted, ApiInvitationPreview } from '../../shared/api-types.ts';
+import { api, ApiError } from '../lib/api.ts';
+import { invitationQuery, meQuery, queryClient } from '../lib/queries.ts';
+import { Button } from '../components/ui/button.tsx';
+import { Card } from '../components/ui/card.tsx';
+import { Pill } from '../components/ui/pill.tsx';
+
+// Landing page for the link in an invitation email (/accept-invite?id=…).
+// Lives outside the AppShell like /onboarding: the recipient may have
+// nothing else to look at yet — an invited password account has no
+// installations until it links GitHub, and a GitHub account only reaches
+// the organization's pages if GitHub lists them on its installation.
+//
+// Every failure the invitation lookup can produce is definitive (unknown or
+// used-up id, expired, sent to a different address), so the page shows the
+// reason instead of a retry — and, for the wrong-account case, the way out
+// is signing out and back in as the invited address.
+
+function failureMessage(err: Error): string {
+  if (err instanceof ApiError && err.status === 403) {
+    return 'This invitation was sent to a different email address.';
+  }
+  return 'This invitation is no longer valid — it may have expired or already been used.';
+}
+
+function SignOutForm() {
+  return (
+    <form method="post" action="/auth/logout" className="mt-4">
+      <Button type="submit" variant="secondary" size="sm">
+        <LogOut className="size-3.5" aria-hidden /> Sign out and switch account
+      </Button>
+    </form>
+  );
+}
+
+function Invitation({ id, invitation }: { id: string; invitation: ApiInvitationPreview }) {
+  const navigate = useNavigate();
+  const { data: me } = useSuspenseQuery(meQuery);
+  const accept = useMutation({
+    mutationFn: () =>
+      api.post<ApiInvitationAccepted>(`/api/invitations/${encodeURIComponent(id)}/accept`),
+    onSuccess: (accepted) => {
+      toast.success(`You joined ${accepted.org_name}`);
+      void queryClient.invalidateQueries({ queryKey: ['me'] });
+      // The members page needs GitHub-side installation access too; land on
+      // the board otherwise (an invited password account gets its connect
+      // prompt there).
+      const installationId = accepted.installation_id;
+      if (installationId !== null && me.installation_ids.includes(installationId)) {
+        void navigate({
+          to: '/settings/members/$installationId',
+          params: { installationId: String(installationId) },
+        });
+      } else {
+        void navigate({ to: '/' });
+      }
+    },
+    onError: (err) => toast.error(err instanceof ApiError ? err.message : 'Request failed'),
+  });
+
+  return (
+    <>
+      <h1 className="text-lg leading-snug font-medium tracking-wide sm:text-xl">
+        Join {invitation.org_name} on Turbodiff
+      </h1>
+      <p className="mt-2 text-[0.85rem] text-mute">
+        You were invited as{' '}
+        <Pill tone={invitation.role === 'member' ? 'neutral' : 'on'}>{invitation.role}</Pill> of the{' '}
+        {invitation.org_name} organization.
+      </p>
+      <Card className="mt-6 p-4">
+        <p className="text-[0.85rem] text-mute">
+          Accepting as <span className="text-ink">{me.name}</span> ({invitation.email}).
+        </p>
+        <Button
+          className="mt-4"
+          onClick={() => accept.mutate()}
+          loading={accept.isPending}
+          disabled={accept.isPending}
+        >
+          <UserPlus className="size-3.5" aria-hidden /> Accept invitation
+        </Button>
+      </Card>
+    </>
+  );
+}
+
+export function AcceptInvitePage() {
+  const { id } = useSearch({ from: '/accept-invite' });
+  const { data: me } = useSuspenseQuery(meQuery);
+  const invitation = useQuery({ ...invitationQuery(id ?? ''), enabled: id !== undefined });
+
+  let body: React.ReactNode;
+  if (id === undefined) {
+    body = (
+      <p className="text-[0.85rem] text-mute">
+        This link is missing its invitation id. Open the link from the invitation email again.
+      </p>
+    );
+  } else if (invitation.isPending) {
+    body = (
+      <p className="flex items-center gap-2 text-[0.85rem] text-mute" role="status">
+        <Loader2 className="size-3.5 animate-spin" aria-hidden /> Checking your invitation…
+      </p>
+    );
+  } else if (invitation.isError) {
+    body = (
+      <>
+        <h1 className="text-lg leading-snug font-medium tracking-wide sm:text-xl">
+          Can&rsquo;t open this invitation
+        </h1>
+        <p className="mt-2 text-[0.85rem] text-mute">{failureMessage(invitation.error)}</p>
+        <p className="mt-2 text-[0.85rem] text-mute">
+          You are signed in as <span className="text-ink">{me.name}</span>.
+        </p>
+        <SignOutForm />
+      </>
+    );
+  } else {
+    body = <Invitation id={id} invitation={invitation.data} />;
+  }
+
+  return (
+    <div className="mx-auto flex min-h-dvh max-w-md flex-col justify-center px-4 py-10">
+      <span className="mb-6 font-mono text-base font-semibold tracking-wide text-ink">
+        turbodiff
+        <span className="animate-cursor text-accent-bright" aria-hidden>
+          _
+        </span>
+      </span>
+      {body}
+      <p className="mt-8 text-[0.8rem] text-mute">
+        <a href="/" className="text-accent-bright hover:underline">
+          Back to the dashboard &rarr;
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/src/client/pages/accept-invite.tsx
+++ b/src/client/pages/accept-invite.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 import type { ApiInvitationAccepted, ApiInvitationPreview } from '../../shared/api-types.ts';
 import { api, ApiError } from '../lib/api.ts';
 import { invitationQuery, meQuery, queryClient } from '../lib/queries.ts';
+import { Stamp } from '../components/identity.tsx';
 import { Button } from '../components/ui/button.tsx';
 import { Card } from '../components/ui/card.tsx';
 import { Pill } from '../components/ui/pill.tsx';
@@ -17,23 +18,48 @@ import { Pill } from '../components/ui/pill.tsx';
 //
 // Every failure the invitation lookup can produce is definitive (unknown or
 // used-up id, expired, sent to a different address), so the page shows the
-// reason instead of a retry — and, for the wrong-account case, the way out
-// is signing out and back in as the invited address.
+// reason instead of a retry. Only the wrong-account case has a way out the
+// recipient can take themselves — signing out and back in as the invited
+// address; a dead invitation needs an owner to send a new one.
+//
+// Layout follows the Paper board "11 Accept invite" (design system file):
+// wordmark, invited sticker, headline, one card with the account row and
+// the action, dashboard link.
 
-function failureMessage(err: Error): string {
-  if (err instanceof ApiError && err.status === 403) {
-    return 'This invitation was sent to a different email address.';
-  }
-  return 'This invitation is no longer valid — it may have expired or already been used.';
+// The 403 from the invitation endpoints is better-auth's recipient check:
+// the session's email is not the invited address.
+function wrongAccount(err: Error): boolean {
+  return err instanceof ApiError && err.status === 403;
 }
 
-function SignOutForm() {
+// Initials for the avatar tile: first letters of the first two words of the
+// display name ("Nico Botha" → NB, "supermemer-ai" → S).
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter((word) => word.length > 0)
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+// Whole days until the invitation expires, floored at zero — better-auth
+// treats a past expiresAt as not found, so a rendered invitation is never
+// negative.
+function daysLeft(expiresAt: string | null): string | null {
+  if (expiresAt === null) return null;
+  const ms = Date.parse(expiresAt) - Date.now();
+  if (Number.isNaN(ms)) return null;
+  const days = Math.max(0, Math.ceil(ms / 86_400_000));
+  if (days === 0) return 'expires today';
+  return days === 1 ? '1 day left' : `${days} days left`;
+}
+
+function Headline({ children }: { children: React.ReactNode }) {
   return (
-    <form method="post" action="/auth/logout" className="mt-4">
-      <Button type="submit" variant="secondary" size="sm">
-        <LogOut className="size-3.5" aria-hidden /> Sign out and switch account
-      </Button>
-    </form>
+    <h1 className="text-xl leading-8 font-medium tracking-tight text-ink sm:text-2xl">
+      {children}
+    </h1>
   );
 }
 
@@ -61,37 +87,88 @@ function Invitation({ id, invitation }: { id: string; invitation: ApiInvitationP
     },
     onError: (err) => toast.error(err instanceof ApiError ? err.message : 'Request failed'),
   });
+  const meta = [invitation.invited_by ? `Invited by ${invitation.invited_by}` : null]
+    .concat(daysLeft(invitation.expires_at))
+    .filter((part) => part !== null)
+    .join(' · ');
 
   return (
     <>
-      <h1 className="text-lg leading-snug font-medium tracking-wide sm:text-xl">
-        Join {invitation.org_name} on Turbodiff
-      </h1>
+      <div className="mb-3.5 pl-0.5">
+        <Stamp>You&rsquo;re invited</Stamp>
+      </div>
+      <Headline>Join {invitation.org_name} on Turbodiff</Headline>
       <p className="mt-2 text-[0.85rem] text-mute">
         You were invited as{' '}
         <Pill tone={invitation.role === 'member' ? 'neutral' : 'on'}>{invitation.role}</Pill> of the{' '}
         {invitation.org_name} organization.
       </p>
-      <Card className="mt-6 p-4">
-        <p className="text-[0.85rem] text-mute">
-          Accepting as <span className="text-ink">{me.name}</span> ({invitation.email}).
-        </p>
-        <Button
-          className="mt-4"
-          onClick={() => accept.mutate()}
-          loading={accept.isPending}
-          disabled={accept.isPending}
-        >
-          <UserPlus className="size-3.5" aria-hidden /> Accept invitation
-        </Button>
+      <Card className="mt-6 flex flex-col gap-3.5 p-4">
+        <div className="flex items-center gap-3">
+          <span
+            className="flex size-8 shrink-0 items-center justify-center rounded-full bg-accent font-mono text-[11px] font-semibold tracking-[0.08em] text-accent-ink"
+            aria-hidden
+          >
+            {initials(me.name)}
+          </span>
+          <div className="min-w-0">
+            <p className="text-[0.85rem] text-mute">
+              Accepting as <span className="text-ink">{me.name}</span>
+            </p>
+            <p className="truncate font-mono text-xs text-mute">{invitation.email}</p>
+          </div>
+        </div>
+        <hr className="border-line" />
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Button
+            onClick={() => accept.mutate()}
+            loading={accept.isPending}
+            disabled={accept.isPending}
+          >
+            <UserPlus className="size-3.5" aria-hidden /> Accept invitation
+          </Button>
+          {meta ? <p className="font-mono text-[11px] tracking-wide text-mute">{meta}</p> : null}
+        </div>
       </Card>
+    </>
+  );
+}
+
+function Failure({ error }: { error: Error }) {
+  const { data: me } = useSuspenseQuery(meQuery);
+  if (wrongAccount(error)) {
+    return (
+      <>
+        <Headline>Can&rsquo;t open this invitation</Headline>
+        <p className="mt-2 text-[0.85rem] text-mute">
+          This invitation was sent to a different email address.
+        </p>
+        <p className="mt-2 text-[0.85rem] text-mute">
+          You are signed in as <span className="text-ink">{me.name}</span>.
+        </p>
+        <form method="post" action="/auth/logout" className="mt-4">
+          <Button type="submit" variant="secondary" size="sm">
+            <LogOut className="size-3.5" aria-hidden /> Sign out and switch account
+          </Button>
+        </form>
+      </>
+    );
+  }
+  return (
+    <>
+      <Headline>Can&rsquo;t open this invitation</Headline>
+      <p className="mt-2 text-[0.85rem] text-mute">
+        This invitation is no longer valid — it may have expired or already been used.
+      </p>
+      <p className="mt-2 text-[0.85rem] text-mute">
+        Ask an owner of the organization to send a new one.
+      </p>
     </>
   );
 }
 
 export function AcceptInvitePage() {
   const { id } = useSearch({ from: '/accept-invite' });
-  const { data: me } = useSuspenseQuery(meQuery);
   const invitation = useQuery({ ...invitationQuery(id ?? ''), enabled: id !== undefined });
 
   let body: React.ReactNode;
@@ -108,25 +185,14 @@ export function AcceptInvitePage() {
       </p>
     );
   } else if (invitation.isError) {
-    body = (
-      <>
-        <h1 className="text-lg leading-snug font-medium tracking-wide sm:text-xl">
-          Can&rsquo;t open this invitation
-        </h1>
-        <p className="mt-2 text-[0.85rem] text-mute">{failureMessage(invitation.error)}</p>
-        <p className="mt-2 text-[0.85rem] text-mute">
-          You are signed in as <span className="text-ink">{me.name}</span>.
-        </p>
-        <SignOutForm />
-      </>
-    );
+    body = <Failure error={invitation.error} />;
   } else {
     body = <Invitation id={id} invitation={invitation.data} />;
   }
 
   return (
     <div className="mx-auto flex min-h-dvh max-w-md flex-col justify-center px-4 py-10">
-      <span className="mb-6 font-mono text-base font-semibold tracking-wide text-ink">
+      <span className="mb-7 font-mono text-base font-semibold tracking-wide text-ink">
         turbodiff
         <span className="animate-cursor text-accent-bright" aria-hidden>
           _

--- a/src/domain/attribution.ts
+++ b/src/domain/attribution.ts
@@ -15,6 +15,13 @@ export function noreplyEmail(user: GitIdentity): string {
   return `${user.id}+${user.login}@users.noreply.github.com`;
 }
 
+// The placeholder better-auth stores for a GitHub sign-in that carried no
+// email (see mapProfileToUser in better-auth.ts). Nobody can receive mail
+// there, so an invitation addressed to a real inbox never matches it.
+export function isNoreplyEmail(email: string): boolean {
+  return email.toLowerCase().endsWith('@users.noreply.github.com');
+}
+
 // Env vars for `git commit`. Empty when no human instructed the run — git
 // then falls back to the repo-config bot identity for the author too.
 export function gitAuthorEnv(user: GitIdentity | null | undefined) {

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -130,7 +130,7 @@ import {
 import { APIError } from 'better-auth';
 import { withAuth } from '../integrations/auth/better-auth.ts';
 import { certificateUrl } from '../services/certificates.ts';
-import { memberRole } from '../services/access-control.ts';
+import { memberRole, organizationSummary } from '../services/access-control.ts';
 import {
   CR_BOT_AUTHOR,
   getCrDiffPatch,
@@ -201,6 +201,8 @@ import type {
   ApiFeatureDiff,
   ApiIntegrations,
   ApiInvitation,
+  ApiInvitationAccepted,
+  ApiInvitationPreview,
   ApiMe,
   ApiMember,
   ApiModels,
@@ -2953,6 +2955,11 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
   // src/services/access-control.ts for why the 'member'/'invitation' resources keep
   // better-auth's own action vocabulary instead of app-specific verbs.
 
+  // better-auth stores roles as free text; the API vocabulary is closed.
+  function apiRole(role: string): ApiRole {
+    return role === 'owner' || role === 'admin' ? role : 'member';
+  }
+
   function orgApiErrorResponse<T>(c: Context<ApiEnv>, err: T): Response {
     if (!(err instanceof APIError)) throw err;
     const body = err.body;
@@ -2982,8 +2989,6 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
       listPendingInvitations(resolved.orgId),
       memberRole(resolved.orgId, c.get('user').session.userId),
     ]);
-    const asRole = (role: string): ApiRole =>
-      role === 'owner' || role === 'admin' ? role : 'member';
     return c.json<ApiOrgMembers>({
       org_id: resolved.orgId,
       members: members.map(
@@ -2991,7 +2996,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
           id: m.id,
           login: m.login,
           email: m.email,
-          role: asRole(m.role),
+          role: apiRole(m.role),
           joined_at: m.created_at,
         }),
       ),
@@ -2999,7 +3004,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         (i): ApiInvitation => ({
           id: i.id,
           email: i.email,
-          role: asRole(i.role),
+          role: apiRole(i.role),
           status: i.status,
           expires_at: i.expires_at,
         }),
@@ -3037,6 +3042,52 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         role: invitation.role as ApiRole,
         status: invitation.status,
         expires_at: invitation.expiresAt ? new Date(invitation.expiresAt).toISOString() : null,
+      });
+    } catch (err) {
+      return orgApiErrorResponse(c, err);
+    }
+  });
+
+  // Invitation-email landing (/accept-invite): the recipient reads the
+  // invitation they were sent, then accepts it. Both run better-auth's own
+  // endpoints on the caller's real session, so its recipient check
+  // (invitation email = session email), expiry, and membership limit apply
+  // unchanged — no installation gate here, because the recipient has no
+  // installation access yet; the email match is the whole authorization.
+  app.get('/invitations/:id', async (c) => {
+    try {
+      const invitation = await withAuth((instance) =>
+        instance.api.getInvitation({
+          headers: c.req.raw.headers,
+          query: { id: c.req.param('id') },
+        }),
+      );
+      const org = await organizationSummary(invitation.organizationId);
+      return c.json<ApiInvitationPreview>({
+        id: invitation.id,
+        email: invitation.email,
+        role: apiRole(invitation.role),
+        org_name: org?.name ?? invitation.organizationName,
+        installation_id: org?.installationId ?? null,
+        expires_at: invitation.expiresAt ? new Date(invitation.expiresAt).toISOString() : null,
+      });
+    } catch (err) {
+      return orgApiErrorResponse(c, err);
+    }
+  });
+
+  app.post('/invitations/:id/accept', async (c) => {
+    try {
+      const accepted = await withAuth((instance) =>
+        instance.api.acceptInvitation({
+          headers: c.req.raw.headers,
+          body: { invitationId: c.req.param('id') },
+        }),
+      );
+      const org = await organizationSummary(accepted.invitation.organizationId);
+      return c.json<ApiInvitationAccepted>({
+        org_name: org?.name ?? '',
+        installation_id: org?.installationId ?? null,
       });
     } catch (err) {
       return orgApiErrorResponse(c, err);

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -130,7 +130,7 @@ import {
 import { APIError } from 'better-auth';
 import { withAuth } from '../integrations/auth/better-auth.ts';
 import { certificateUrl } from '../services/certificates.ts';
-import { memberRole, organizationSummary } from '../services/access-control.ts';
+import { inviterLabel, memberRole, organizationSummary } from '../services/access-control.ts';
 import {
   CR_BOT_AUTHOR,
   getCrDiffPatch,
@@ -3062,13 +3062,17 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
           query: { id: c.req.param('id') },
         }),
       );
-      const org = await organizationSummary(invitation.organizationId);
+      const [org, invitedBy] = await Promise.all([
+        organizationSummary(invitation.organizationId),
+        inviterLabel(invitation.inviterId),
+      ]);
       return c.json<ApiInvitationPreview>({
         id: invitation.id,
         email: invitation.email,
         role: apiRole(invitation.role),
         org_name: org?.name ?? invitation.organizationName,
         installation_id: org?.installationId ?? null,
+        invited_by: invitedBy,
         expires_at: invitation.expiresAt ? new Date(invitation.expiresAt).toISOString() : null,
       });
     } catch (err) {

--- a/src/http/api.worker.test.ts
+++ b/src/http/api.worker.test.ts
@@ -740,6 +740,7 @@ describe('organization member management', () => {
       role: 'admin',
       org_name: 'acme',
       installation_id: 1001,
+      invited_by: '@octocat',
     });
 
     const accept = await app.request('https://turbodiff.test/api/invitations/inv1/accept', {

--- a/src/http/api.worker.test.ts
+++ b/src/http/api.worker.test.ts
@@ -11,6 +11,7 @@ import type { ApiBoard, ApiModels, ApiUsage } from '../shared/api-types.ts';
 import { isJsonObject, isString, parseJson } from '../shared/json.ts';
 import { RUNNER_MODELS } from '../shared/runner-models.ts';
 import { createApiRoutes, type ApiRouteDependencies } from './api.ts';
+import { handleEmailSignUp } from './auth-email.ts';
 import {
   ensureBuiltinAgents,
   getFactoryRun,
@@ -695,6 +696,102 @@ describe('organization member management', () => {
       .prepare('SELECT id FROM "organization" WHERE "installationId" = 1001')
       .first();
     expect(orgRow).toBeNull();
+  });
+
+  // The invitation endpoints resolve the recipient from a real better-auth
+  // session (cookie), not from the `authenticate` stub — so the invitee is
+  // signed up through the same handler production uses.
+  async function inviteeCookie(email: string): Promise<string> {
+    const app = new Hono();
+    app.post('/api/auth/sign-up/email', handleEmailSignUp);
+    const response = await app.request('https://turbodiff.test/api/auth/sign-up/email', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Invitee', email, password: 'a-long-password' }),
+    });
+    expect(response.status).toBe(200);
+    return response.headers.get('set-cookie')?.split(';', 1)[0] ?? '';
+  }
+
+  async function seedInvitation(email: string): Promise<void> {
+    await testDatabase()
+      .prepare(
+        `INSERT INTO "invitation" (id, "organizationId", email, role, status, "expiresAt", "createdAt", "inviterId")
+				 VALUES ('inv1', 'org1', ?1, 'admin', 'pending', '2999-01-01T00:00:00.000Z',
+				         '2026-01-01T00:00:00.000Z', 'u1')`,
+      )
+      .bind(email)
+      .run();
+  }
+
+  it('lets the invited address read and accept its invitation, recording the member row', async () => {
+    await seedOrg('owner');
+    await seedInvitation('invitee@example.test');
+    const cookie = await inviteeCookie('invitee@example.test');
+    const app = authenticatedApi();
+
+    const preview = await app.request('https://turbodiff.test/api/invitations/inv1', {
+      headers: { cookie },
+    });
+    expect(preview.status).toBe(200);
+    expect(await preview.json()).toMatchObject({
+      id: 'inv1',
+      email: 'invitee@example.test',
+      role: 'admin',
+      org_name: 'acme',
+      installation_id: 1001,
+    });
+
+    const accept = await app.request('https://turbodiff.test/api/invitations/inv1/accept', {
+      method: 'POST',
+      headers: { cookie },
+    });
+    expect(accept.status).toBe(200);
+    expect(await accept.json()).toEqual({ org_name: 'acme', installation_id: 1001 });
+
+    const member = await testDatabase()
+      .prepare(
+        `SELECT m.role FROM "member" m JOIN "user" u ON u.id = m."userId"
+				 WHERE m."organizationId" = 'org1' AND u.email = 'invitee@example.test'`,
+      )
+      .first<{ role: string }>();
+    expect(member).toEqual({ role: 'admin' });
+    const invitation = await testDatabase()
+      .prepare(`SELECT status FROM "invitation" WHERE id = 'inv1'`)
+      .first<{ status: string }>();
+    expect(invitation).toEqual({ status: 'accepted' });
+  });
+
+  it('refuses the invitation to a session whose email does not match', async () => {
+    await seedOrg('owner');
+    await seedInvitation('invitee@example.test');
+    const cookie = await inviteeCookie('someone-else@example.test');
+    const app = authenticatedApi();
+
+    const preview = await app.request('https://turbodiff.test/api/invitations/inv1', {
+      headers: { cookie },
+    });
+    expect(preview.status).toBe(403);
+    const accept = await app.request('https://turbodiff.test/api/invitations/inv1/accept', {
+      method: 'POST',
+      headers: { cookie },
+    });
+    expect(accept.status).toBe(403);
+    const members = await testDatabase()
+      .prepare(`SELECT COUNT(*) AS n FROM "member" WHERE "organizationId" = 'org1'`)
+      .first<{ n: number }>();
+    expect(members).toEqual({ n: 1 });
+  });
+
+  it('reports an unknown invitation id as not found rather than a server error', async () => {
+    await seedOrg('owner');
+    const cookie = await inviteeCookie('invitee@example.test');
+    const preview = await authenticatedApi().request(
+      'https://turbodiff.test/api/invitations/nope',
+      { headers: { cookie } },
+    );
+    expect(preview.status).toBe(400);
+    expect(await preview.json()).toEqual({ error: 'Invitation not found!' });
   });
 
   it('rejects invite, remove, and role-change requests from a member-role caller', async () => {

--- a/src/http/ui.ts
+++ b/src/http/ui.ts
@@ -210,13 +210,21 @@ export function createUiRoutes() {
     const query = new URL(c.req.url).searchParams;
     const oauthAuthorize = query.has('client_id') && query.has('redirect_uri');
     const renewSession = query.get('expired') === '1';
-    const next = oauthAuthorize ? `/api/auth/mcp/authorize?${query.toString()}` : '/';
+    // Plain in-app continuation (the /accept-invite link from an invitation
+    // email): path-only so the redirect can't leave the app, same idiom as
+    // /auth/login/github.
+    const requested = query.get('next') ?? '';
+    const requestedNext =
+      requested.startsWith('/') && !requested.startsWith('//') ? requested : null;
+    const next = oauthAuthorize
+      ? `/api/auth/mcp/authorize?${query.toString()}`
+      : (requestedNext ?? '/');
     // An API 401 can arrive while a cookie-cached shell session still exists.
     // Do not redirect that recovery request back to the dashboard.
     if (!renewSession && (await hasSession(c))) return c.redirect(next);
     return c.html(
       renderAuthPage(
-        oauthAuthorize ? next : undefined,
+        oauthAuthorize || requestedNext ? next : undefined,
         renewSession
           ? 'Your Turbodiff session needs to be renewed. Sign in to continue.'
           : undefined,
@@ -307,6 +315,17 @@ export function createUiRoutes() {
   app.get('/', async (c) => {
     if (!(await hasSession(c))) return c.html(renderLanding());
     return c.html(await shellForPath(c, '/'));
+  });
+
+  // Invitation-email landing page. The recipient usually arrives signed out
+  // (or signed in as the wrong account), so sign-in must come back here with
+  // the invitation id intact rather than landing on the dashboard.
+  app.get('/accept-invite', async (c) => {
+    const url = new URL(c.req.url);
+    if (!(await hasSession(c))) {
+      return c.redirect(`/auth/login?next=${encodeURIComponent(url.pathname + url.search)}`);
+    }
+    return c.html(await shellForPath(c, url.pathname));
   });
 
   // Public long-form pages (src/http/blog.tsx). Posts are code, so an unknown

--- a/src/integrations/auth/better-auth.ts
+++ b/src/integrations/auth/better-auth.ts
@@ -3,7 +3,10 @@ import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { mcp } from 'better-auth/plugins';
 import { organization } from 'better-auth/plugins/organization';
+import { eq, or, sql } from 'drizzle-orm';
 import { withDatabase, type Database } from '../../data/database.ts';
+import { isNoreplyEmail } from '../../domain/attribution.ts';
+import { isNumber, isString } from '../../shared/json.ts';
 import {
   account,
   invitation,
@@ -50,9 +53,14 @@ import { orgAc, orgRoles } from './organization-access.ts';
 //     that carries githubId — that combination only occurs on the
 //     overrideUserInfoOnSignIn profile sync, which would otherwise rewrite a
 //     linked user's email to the GitHub address on every GitHub sign-in and
-//     silently change their password-login identifier. (Trade-off: GitHub
-//     email changes no longer propagate to GitHub-only users either;
-//     nothing keys on email, so that drift is cosmetic.)
+//     silently change their password-login identifier. One exception: a row
+//     still holding the noreply placeholder (a GitHub sign-in from before
+//     the App had the Email addresses permission) adopts the real address
+//     the sync now carries — organization invitations match on email
+//     (better-auth's accept-invitation compares invitation.email to the
+//     session user's), so the placeholder would keep every invite
+//     unacceptable. A placeholder can only belong to a GitHub sign-in, never
+//     a password identifier, so nothing a user typed is rewritten.
 //   - The github "account" row is the single store for the user's OAuth
 //     access/refresh token pair, encrypted at rest (encryptOAuthTokens).
 //     auth.api.getAccessToken refreshes it near expiry and persists the
@@ -92,6 +100,26 @@ const SESSION_DAYS = 30;
 // Inference must own the instance type: betterAuth is deeply generic over its
 // options, and annotating with ReturnType<typeof betterAuth> collapses that
 // to Auth<BetterAuthOptions>, which the concrete instance doesn't satisfy.
+// Whether a GitHub profile sync may replace the stored email: the row still
+// holds the noreply placeholder, the sync carries a real address, and no
+// other user owns that address already (email is unique — adopting a taken
+// one would fail the whole sign-in instead of just the sync).
+async function adoptsSyncedEmail(
+  database: Database,
+  data: { githubId?: unknown; email?: unknown },
+): Promise<boolean> {
+  if (!isNumber(data.githubId) || !isString(data.email) || isNoreplyEmail(data.email)) return false;
+  const rows = await database
+    .select({ githubId: user.githubId, email: user.email })
+    .from(user)
+    .where(
+      or(eq(user.githubId, data.githubId), eq(sql`lower(${user.email})`, data.email.toLowerCase())),
+    );
+  const own = rows.find((row) => row.githubId === data.githubId);
+  const taken = rows.some((row) => row.githubId !== data.githubId);
+  return own !== undefined && isNoreplyEmail(own.email) && !taken;
+}
+
 function createAuth(database: Database) {
   return betterAuth({
     baseURL: env.PUBLIC_BASE_URL,
@@ -141,12 +169,15 @@ function createAuth(database: Database) {
         update: {
           // See design notes: a provider-profile sync (the only update that
           // carries githubId) must never rewrite the email a password user
-          // signs in with. Merging undefined removes the fields — the
-          // adapter drops undefined columns from the UPDATE.
-          before: async (user) =>
-            'githubId' in user
-              ? { data: { ...user, email: undefined, emailVerified: undefined } }
-              : { data: user },
+          // signs in with — unless the row still holds the noreply
+          // placeholder, which the real GitHub address replaces. Merging
+          // undefined removes the fields — the adapter drops undefined
+          // columns from the UPDATE.
+          before: async (data) => {
+            if (!('githubId' in data)) return { data };
+            if (await adoptsSyncedEmail(database, data)) return { data };
+            return { data: { ...data, email: undefined, emailVerified: undefined } };
+          },
         },
       },
     },

--- a/src/integrations/auth/better-auth.worker.test.ts
+++ b/src/integrations/auth/better-auth.worker.test.ts
@@ -1,0 +1,99 @@
+/* oxlint-disable typescript/triple-slash-reference -- generated Worker bindings */
+/// <reference path="../../../worker-configuration.d.ts" />
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+
+import { testDatabase } from '../../test/database-fixture.ts';
+// The user.update.before hook: what a GitHub profile sync may rewrite.
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { withAuth } from './better-auth.ts';
+
+// overrideUserInfoOnSignIn reaches the user row through better-auth's
+// internal adapter, which is where database hooks run — so drive that
+// adapter with the same shape the GitHub sign-in produces rather than a
+// full OAuth round-trip.
+async function syncGithubProfile(
+  userId: string,
+  profile: { githubId: number; login: string; email: string },
+): Promise<void> {
+  await withAuth(async (instance) => {
+    const context = await instance.$context;
+    await context.internalAdapter.updateUser(userId, {
+      name: profile.login,
+      login: profile.login,
+      githubId: profile.githubId,
+      email: profile.email,
+      emailVerified: true,
+    });
+  });
+}
+
+async function seedUser(id: string, email: string, githubId: number | null): Promise<void> {
+  await testDatabase()
+    .prepare(
+      `INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt", login, "githubId")
+       VALUES (?1, ?1, ?2, false, '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z',
+               ?1, ?3)`,
+    )
+    .bind(id, email, githubId)
+    .run();
+}
+
+async function storedEmail(id: string): Promise<{ email: string; emailVerified: boolean } | null> {
+  return testDatabase()
+    .prepare('SELECT email, "emailVerified" FROM "user" WHERE id = ?1')
+    .bind(id)
+    .first<{ email: string; emailVerified: boolean }>();
+}
+
+describe('GitHub profile sync and the stored email', () => {
+  beforeEach(async () => {
+    for (const table of ['session', 'account', 'user']) {
+      await testDatabase().prepare(`DELETE FROM "${table}"`).run();
+    }
+  });
+
+  it('replaces the noreply placeholder with the address GitHub now reports', async () => {
+    await seedUser('u1', '583231+octocat@users.noreply.github.com', 583231);
+    await syncGithubProfile('u1', {
+      githubId: 583231,
+      login: 'octocat',
+      email: 'Octocat@Example.test',
+    });
+    expect(await storedEmail('u1')).toEqual({ email: 'octocat@example.test', emailVerified: true });
+  });
+
+  it('keeps a real stored email when the sync carries a different one', async () => {
+    // A password account that linked GitHub signs in with the address it
+    // typed — the GitHub address must never replace it.
+    await seedUser('u1', 'pat@example.test', 583231);
+    await syncGithubProfile('u1', { githubId: 583231, login: 'pat', email: 'pat@github.test' });
+    expect(await storedEmail('u1')).toEqual({ email: 'pat@example.test', emailVerified: false });
+  });
+
+  it('keeps the placeholder when another account already owns the synced address', async () => {
+    await seedUser('u1', '583231+octocat@users.noreply.github.com', 583231);
+    await seedUser('u2', 'octocat@example.test', null);
+    await syncGithubProfile('u1', {
+      githubId: 583231,
+      login: 'octocat',
+      email: 'octocat@example.test',
+    });
+    expect(await storedEmail('u1')).toEqual({
+      email: '583231+octocat@users.noreply.github.com',
+      emailVerified: false,
+    });
+  });
+
+  it('keeps the placeholder when GitHub still reports none', async () => {
+    await seedUser('u1', '583231+octocat@users.noreply.github.com', 583231);
+    await syncGithubProfile('u1', {
+      githubId: 583231,
+      login: 'octocat',
+      email: '583231+octocat@users.noreply.github.com',
+    });
+    expect(await storedEmail('u1')).toEqual({
+      email: '583231+octocat@users.noreply.github.com',
+      emailVerified: false,
+    });
+  });
+});

--- a/src/services/access-control.ts
+++ b/src/services/access-control.ts
@@ -282,3 +282,14 @@ export async function organizationSummary(
     SELECT name, "installationId" FROM auth."organization" WHERE id = ${organizationId}
   `);
 }
+
+// Who sent an invitation, for the accept-invite page's "Invited by" line —
+// the GitHub login when the inviter has one, their display name otherwise
+// (password accounts). Null when the inviter's user row is gone.
+export async function inviterLabel(userId: string): Promise<string | null> {
+  const row = await queryOne<{ login: string | null; name: string }>(sql`
+    SELECT login, name FROM auth."user" WHERE id = ${userId}
+  `);
+  if (!row) return null;
+  return row.login ? `@${row.login}` : row.name;
+}

--- a/src/services/access-control.ts
+++ b/src/services/access-control.ts
@@ -271,3 +271,14 @@ export async function capabilityDenied(
   if (orgRoles[role].authorize(request).success) return null;
   return `'${action}' capability required for this organization`;
 }
+
+// The organization an invitation belongs to, as the accept-invite page
+// reports it: its display name and the GitHub installation behind it (where
+// the recipient is sent next). Null for an unknown organization id.
+export async function organizationSummary(
+  organizationId: string,
+): Promise<{ name: string; installationId: number } | null> {
+  return queryOne<{ name: string; installationId: number }>(sql`
+    SELECT name, "installationId" FROM auth."organization" WHERE id = ${organizationId}
+  `);
+}

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -472,6 +472,9 @@ export interface ApiInvitationPreview {
   // The GitHub installation behind the organization — the members page the
   // recipient lands on after accepting, if GitHub also lists them on it.
   installation_id: number | null;
+  // "@login" for a GitHub inviter, their display name for a password
+  // account, null when the inviter's account no longer exists.
+  invited_by: string | null;
   expires_at: string | null;
 }
 

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -462,6 +462,24 @@ export interface ApiOrgMembers {
   my_role: ApiRole;
 }
 
+// A pending invitation as seen by its recipient on /accept-invite. Only the
+// signed-in user whose email matches the invitation can read it.
+export interface ApiInvitationPreview {
+  id: string;
+  email: string;
+  role: ApiRole;
+  org_name: string;
+  // The GitHub installation behind the organization — the members page the
+  // recipient lands on after accepting, if GitHub also lists them on it.
+  installation_id: number | null;
+  expires_at: string | null;
+}
+
+export interface ApiInvitationAccepted {
+  org_name: string;
+  installation_id: number | null;
+}
+
 export interface ApiError {
   error: string;
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -60,7 +60,7 @@
     "GITHUB_APP_SLUG": "turbodiff",
     // "From" address for organization invite emails, sent via Resend
     // (RESEND_API_KEY secret) — must be on a domain verified with Resend.
-    "RESEND_FROM_ADDRESS": "Turbodiff <noreply@turbodiff.dev>",
+    "RESEND_FROM_ADDRESS": "Turbodiff <noreply@mail.turbodiff.dev>",
     // Max auto-triggered reviews per installation per rolling 24h.
     "REVIEW_DAILY_LIMIT": "50",
     // Optional gateway model id used instead of each agent's configured


### PR DESCRIPTION
## Why

Organization invitations could never be accepted:

- The invitation email linked to `/accept-invite`, which nothing served (no client route, no server route).
- GitHub sign-ins stored the `<id>+<login>@users.noreply.github.com` placeholder (the App had no Email addresses permission), and better-auth's `accept-invitation` refuses unless the invitation email equals the session user's email. A real inbox could never match a placeholder.

The GitHub App now has **Email addresses: Read-only** (account permission, no org approval needed). This PR does the two code halves.

## What changed

**Accept-invite flow**
- `GET /api/invitations/:id` and `POST /api/invitations/:id/accept` wrap better-auth's `getInvitation` / `acceptInvitation` on the caller's real session, so its recipient check, expiry, and membership-limit rules apply unchanged. No installation gate — the recipient has no installation access yet; the email match is the whole authorization. The response carries the org name and the installation behind it.
- `/accept-invite` is served as a shell page. A signed-out hit redirects to `/auth/login?next=/accept-invite?id=…` (path-only, same idiom as `/auth/login/github`) and comes back with the id intact. `/auth/login` now honours a plain `next` for both the GitHub button and the password form.
- `src/client/pages/accept-invite.tsx` lives outside the AppShell like `/onboarding`. It shows org + role, an Accept button, definitive failure messages (expired/used vs. sent to a different address), and a sign-out button for the wrong-account case. After accepting it lands on the members page only if GitHub also lists that installation for the user, otherwise on the board.

**Email adoption on GitHub sign-in**
- The `user.update.before` hook still strips `email`/`emailVerified` from the profile sync, with one exception: a row holding the noreply placeholder adopts the real address the sync now carries. It never rewrites a typed password identifier (a placeholder can only come from a GitHub sign-in), and refuses if another account already owns the address (email is unique — adopting would fail the whole sign-in rather than just the sync).

**Small reuse**
- `apiRole()` replaces the members route's local `asRole` so the three invitation/member routes share one role mapper.
- `isNoreplyEmail()` next to `noreplyEmail()` in `src/domain/attribution.ts`.

## Tests

- `src/http/api.worker.test.ts`: invitee signs up through the real sign-up handler (the endpoints resolve the recipient from the cookie, not the `authenticate` stub), then reads + accepts → member row and `accepted` status; wrong email → 403 on both; unknown id → 400.
- `src/integrations/auth/better-auth.worker.test.ts`: drives `internalAdapter.updateUser` (where the hook runs) for the four cases — placeholder replaced, real email kept, taken address refused, placeholder kept when GitHub still reports none.

Verified locally: `vp check` 0 errors; unit suite 22/22 files; worker suite 12/12 files (against a fresh local Postgres — the shared local `turbodiff` db is stale relative to main); client build emits the new chunk.

## Reviewer notes

- Not visually verified in a browser (vite dev hangs on this machine); the page typechecks and bundles.
- Existing users keep the placeholder until their next GitHub sign-in after this deploys; the sync replaces it then.
- `requireEmailVerificationOnInvitation` is left at better-auth's default (off with opaque invitation ids). Password sign-ups are still unverified, so an unverified password account with the invited address can accept — same trust level as today's sign-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
