### PR TITLE
fix(api): gate agent/skill edits on any capable installation

### DIFF
--- a/src/http/api-support.ts
+++ b/src/http/api-support.ts
@@ -534,6 +534,20 @@ export async function capableInstallationIds(
   return checked.filter((id): id is number => id !== null);
 }
 
+// The per-slug lists (agents, skills) show one copy per slug and the edit
+// page mutates through that copy's id. Stable-partition the rows so copies
+// from capable installations come first: the dedupe then picks an editable
+// copy whenever one exists, and the post-save refetch reads the updated row.
+export function preferCapableCopies<Row extends { installation_id: number }>(
+  rows: Row[],
+  capable: ReadonlySet<number>,
+): Row[] {
+  return [
+    ...rows.filter((row) => capable.has(row.installation_id)),
+    ...rows.filter((row) => !capable.has(row.installation_id)),
+  ];
+}
+
 // HTTP mapping for the capability gate: null means allowed, a ready-to-return
 // 403 otherwise — the same null-means-allowed contract as requireRepoPush.
 export async function requireCapability(

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -298,6 +298,7 @@ import {
   authorizedRepo,
   authorizedSkill,
   capableInstallationIds,
+  preferCapableCopies,
   requireCapability,
   currentMonth,
   groupByRepoPr,
@@ -2189,10 +2190,16 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         ),
       ).then(() => undefined),
     );
+    // One entry per slug. The copy chosen stands in for the edit page, whose
+    // PUT/DELETE then fan out through the caller's capable installations — so
+    // prefer a copy from one of those, or an owner of org A editing a shared
+    // agent lands on org B's copy (where they are a plain member) and reads
+    // stale data back after a save that skipped it.
+    const capable = new Set(await capableInstallationIds(c, installationIds, orgAdmin));
     const seen = new Set<string>();
     return c.json<ApiAgentsList>({
       github_app_slug: env.GITHUB_APP_SLUG,
-      agents: agents
+      agents: preferCapableCopies(agents, capable)
         .filter((a) => (seen.has(a.slug) ? false : (seen.add(a.slug), true)))
         .map((a) => ({
           id: a.id,
@@ -2254,13 +2261,16 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
   app.put('/agents/:id', async (c) => {
     const agent = await authorizedAgent(c);
     if (!agent) return c.json({ error: 'unknown agent' }, 404);
-    const deniedCapability = await requireCapability(
-      c,
-      agent.installation_id,
-      'settings',
-      orgAdmin,
-    );
-    if (deniedCapability) return deniedCapability;
+    // Agents are generic across installations, so the gate is the same as on
+    // create: the edit lands wherever the caller holds 'settings', and only a
+    // caller who holds it nowhere is refused. Gating on the clicked copy's
+    // installation alone denied owners of one org for being plain members of
+    // another (the list picks an arbitrary copy per slug).
+    const { installationIds } = c.get('user');
+    const capableIds = await capableInstallationIds(c, installationIds, orgAdmin);
+    if (capableIds.length === 0) {
+      return c.json({ error: "'settings' capability required for this action" }, 403);
+    }
     const body = await c.req.json<JsonObject>().catch(() => null);
     if (!body) return c.json({ error: 'invalid JSON body' }, 400);
     const catalog = await getModelCatalog();
@@ -2272,15 +2282,14 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
       agent.model,
     );
     if (error) return c.json({ error }, 400);
-    // Fan out by slug so the edit applies everywhere; custom agents that
+    // Fan out by slug across the capable installations; custom agents that
     // predate the generic model gain their missing per-installation copies.
-    const { installationIds } = c.get('user');
-    const siblings = (await listAgents(installationIds)).filter((a) => a.slug === agent.slug);
+    const siblings = (await listAgents(capableIds)).filter((a) => a.slug === agent.slug);
     await Promise.all(siblings.map((s) => updateAgent(s.id, values)));
     if (!agent.is_builtin) {
       const covered = new Set(siblings.map((s) => s.installation_id));
       await Promise.all(
-        installationIds.filter((id) => !covered.has(id)).map((id) => createAgent(id, values)),
+        capableIds.filter((id) => !covered.has(id)).map((id) => createAgent(id, values)),
       );
     }
     return c.json({ ok: true });
@@ -2289,16 +2298,15 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
   app.delete('/agents/:id', async (c) => {
     const agent = await authorizedAgent(c);
     if (!agent) return c.json({ error: 'unknown agent' }, 404);
-    const deniedCapability = await requireCapability(
-      c,
-      agent.installation_id,
-      'settings',
-      orgAdmin,
-    );
-    if (deniedCapability) return deniedCapability;
+    // Same capable-set gate as PUT above.
+    const capableIds = await capableInstallationIds(c, c.get('user').installationIds, orgAdmin);
+    if (capableIds.length === 0) {
+      return c.json({ error: "'settings' capability required for this action" }, 403);
+    }
     if (agent.is_builtin) return c.json({ error: 'built-in agents cannot be deleted' }, 403);
-    // Fan out by slug: deleting a generic agent removes every installation's copy.
-    const siblings = (await listAgents(c.get('user').installationIds)).filter(
+    // Fan out by slug: deleting a generic agent removes every capable
+    // installation's copy.
+    const siblings = (await listAgents(capableIds)).filter(
       (a) => a.slug === agent.slug && !a.is_builtin,
     );
     await Promise.all(siblings.map((s) => deleteAgent(s.id)));
@@ -2312,9 +2320,11 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
   app.get('/skills', async (c) => {
     const { installationIds } = c.get('user');
     const skills = await listSkills(installationIds);
+    // Same capable-copy preference as GET /agents.
+    const capable = new Set(await capableInstallationIds(c, installationIds, orgAdmin));
     const seen = new Set<string>();
     return c.json<ApiSkillsList>({
-      skills: skills
+      skills: preferCapableCopies(skills, capable)
         .filter((s) => (seen.has(s.slug) ? false : (seen.add(s.slug), true)))
         .map((s) => ({
           id: s.id,
@@ -2365,13 +2375,12 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
   app.put('/skills/:id', async (c) => {
     const skill = await authorizedSkill(c);
     if (!skill) return c.json({ error: 'unknown skill' }, 404);
-    const deniedCapability = await requireCapability(
-      c,
-      skill.installation_id,
-      'settings',
-      orgAdmin,
-    );
-    if (deniedCapability) return deniedCapability;
+    // Capable-set gate, as on PUT /agents/:id.
+    const { installationIds } = c.get('user');
+    const capableIds = await capableInstallationIds(c, installationIds, orgAdmin);
+    if (capableIds.length === 0) {
+      return c.json({ error: "'settings' capability required for this action" }, 403);
+    }
     const body = await c.req.json<JsonObject>().catch(() => null);
     if (!body) return c.json({ error: 'invalid JSON body' }, 400);
     const values = readSkillPayload(body);
@@ -2380,14 +2389,13 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
     // The slug is immutable after creation; the fan-out below always keys off
     // the existing slug regardless of what the request body sent.
     values.slug = skill.slug;
-    // Fan out by slug so the edit applies everywhere; skills that predate a
+    // Fan out by slug across the capable installations; skills that predate a
     // caller's installation gain their missing per-installation copies.
-    const { installationIds } = c.get('user');
-    const siblings = (await listSkills(installationIds)).filter((s) => s.slug === skill.slug);
+    const siblings = (await listSkills(capableIds)).filter((s) => s.slug === skill.slug);
     await Promise.all(siblings.map((s) => updateSkill(s.id, values)));
     const covered = new Set(siblings.map((s) => s.installation_id));
     await Promise.all(
-      installationIds.filter((id) => !covered.has(id)).map((id) => createSkill(id, values)),
+      capableIds.filter((id) => !covered.has(id)).map((id) => createSkill(id, values)),
     );
     return c.json({ ok: true });
   });
@@ -2395,17 +2403,14 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
   app.delete('/skills/:id', async (c) => {
     const skill = await authorizedSkill(c);
     if (!skill) return c.json({ error: 'unknown skill' }, 404);
-    const deniedCapability = await requireCapability(
-      c,
-      skill.installation_id,
-      'settings',
-      orgAdmin,
-    );
-    if (deniedCapability) return deniedCapability;
-    // Fan out by slug: deleting a generic skill removes every installation's copy.
-    const siblings = (await listSkills(c.get('user').installationIds)).filter(
-      (s) => s.slug === skill.slug,
-    );
+    // Capable-set gate, as on DELETE /agents/:id.
+    const capableIds = await capableInstallationIds(c, c.get('user').installationIds, orgAdmin);
+    if (capableIds.length === 0) {
+      return c.json({ error: "'settings' capability required for this action" }, 403);
+    }
+    // Fan out by slug: deleting a generic skill removes every capable
+    // installation's copy.
+    const siblings = (await listSkills(capableIds)).filter((s) => s.slug === skill.slug);
     await Promise.all(siblings.map((s) => deleteSkill(s.id)));
     return c.json({ ok: true });
   });

--- a/src/http/api.worker.test.ts
+++ b/src/http/api.worker.test.ts
@@ -872,6 +872,80 @@ describe('organization member management', () => {
     expect(agentDenied.status).toBe(403);
   });
 
+  // Agents are generic across installations. An owner of one org must be able
+  // to edit a shared agent even when the list handed the edit page another
+  // org's copy, where they are a plain member — the edit lands on the copies
+  // they hold 'settings' for and leaves the rest alone.
+  it('edits a shared agent through the installations where the caller holds settings', async () => {
+    await seedOrg('member');
+    await seedCoOwner();
+    await testDatabase()
+      .prepare(
+        `INSERT INTO "organization" (id, name, slug, "installationId", "createdAt")
+				 VALUES ('org2', 'other', 'other', 2002, '2026-01-01T00:00:00.000Z')`,
+      )
+      .run();
+    await testDatabase()
+      .prepare(
+        `INSERT INTO "member" (id, "organizationId", "userId", role, "createdAt")
+				 VALUES ('m3', 'org2', 'u1', 'owner', '2026-01-01T00:00:00.000Z')`,
+      )
+      .run();
+    await ensureBuiltinAgents(1001);
+    await ensureBuiltinAgents(2002);
+    // orgAdmin false: no GitHub-derived elevation, only the seeded rows count.
+    const app = apiApp({
+      authenticate: async () => ({ ...acmeUser, installationIds: [1001, 2002] }),
+      canPushToRepo: async () => true,
+      orgAdmin: async () => false,
+    });
+    const copyFor = (installationId: number) =>
+      testDatabase()
+        .prepare(`SELECT id, name FROM agents WHERE installation_id = ?1 AND slug = 'review'`)
+        .bind(installationId)
+        .first<{ id: number; name: string }>();
+    const memberCopy = await copyFor(1001);
+    const ownerCopy = await copyFor(2002);
+
+    // The list hands the edit page the copy the caller can actually edit.
+    const list = await app.request('https://turbodiff.test/api/agents');
+    expect(list.status).toBe(200);
+    expect(await list.json()).toMatchObject({
+      agents: expect.arrayContaining([
+        expect.objectContaining({ slug: 'review', id: Number(ownerCopy?.id) }),
+      ]),
+    });
+
+    // Editing through the member-only copy still succeeds and lands on the
+    // owner installation's copy only.
+    const response = await app.request(`https://turbodiff.test/api/agents/${memberCopy?.id}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed', instructions: 'Review carefully' }),
+    });
+    expect(response.status).toBe(200);
+    expect((await copyFor(2002))?.name).toBe('Renamed');
+    expect((await copyFor(1001))?.name).toBe(memberCopy?.name);
+  });
+
+  it('refuses an agent edit only when the caller holds settings nowhere', async () => {
+    await seedOrg('member');
+    await seedCoOwner();
+    await ensureBuiltinAgents(1001);
+    const copy = await testDatabase()
+      .prepare(`SELECT id FROM agents WHERE installation_id = 1001 AND slug = 'review'`)
+      .first<{ id: number }>();
+    const response = await authenticatedApi(
+      async () => true,
+      async () => false,
+    ).request(`https://turbodiff.test/api/agents/${copy?.id}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed', instructions: 'Review carefully' }),
+    });
+    expect(response.status).toBe(403);
+  });
+
   it('lets an owner mutate repo posture once both settings capability and push permission are present', async () => {
     await seedOrg('owner');
     const response = await authenticatedApi(async () => true).request(


### PR DESCRIPTION
## Problem

Editing an agent in prod failed with `'settings' capability required for this organization` for an org owner.

Agents and skills are generic across installations: one edit fans out to every installation the caller belongs to. But `PUT/DELETE /agents/:id` (and the skill twins) gated the capability on the **single installation owning the row id in the URL**, while `GET /agents` collapses copies per slug and hands the edit page an arbitrary one. An owner of org A editing a shared agent could therefore land on org B's copy, where they are only a plain member, and get refused despite holding the capability elsewhere. The create route already avoided this by narrowing the fan-out to the capable set.

## Fix

- `PUT/DELETE /agents/:id` and `/skills/:id` compute the capable installation set (same helper as create), refuse only when it is empty, and fan the edit/delete out to that set only.
- `GET /agents` and `GET /skills` put copies from capable installations first, so the edit page gets an editable copy whenever one exists and the post-save refetch reads the updated row.

Other capability gates (repos, automations, integrations, factory features, org members) are per-installation by construction and unaffected.

## Tests

Two new cases in the org-management suite: an owner of one org editing through the other org's member-only copy succeeds and lands only on the owner installation's copy, and a caller holding the capability nowhere still gets a 403. `src/http/api.worker.test.ts` passes locally (66 tests) against a fresh Postgres; `tsc` and lint are clean for the changed files.

Based on `main`. Overlaps with #143 only in the `PUT/DELETE /skills/:id` gate lines; whichever merges second needs a trivial rebase there (the skills.sh backfill call keeps its extra fields, just over `capableIds`).

Not covered here: the GitHub org-admin bootstrap still fails closed when the App can't read org members, so an owner with no member row in an org keeps needing one inserted by hand for that org's copies to be included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)