### PR TITLE
fix(cockpit): show the premortem verdict instead of N/N proven

### DIFF
--- a/src/ai/runners/verifier.ts
+++ b/src/ai/runners/verifier.ts
@@ -32,7 +32,11 @@ import { CR_BOT_AUTHOR, maybeAutoMergeCr } from '../../services/change-requests.
 import { enqueueFactoryMessage } from '../../services/factory-queue.ts';
 import { certificateUrl } from '../../services/certificates.ts';
 import { cockpitFeatureUrl } from '../../services/urls.ts';
-import { formatUnmetCriteriaFindings, type CriterionResult } from '../../domain/verification.ts';
+import {
+  formatUnmetCriteriaFindings,
+  PREMORTEM_CRITERION,
+  type CriterionResult,
+} from '../../domain/verification.ts';
 import { parseUtc } from '../../shared/time.ts';
 import { signArtifactKey } from '../../integrations/security/crypto.ts';
 import { resolveRunnerAuth, runnerEnvironment, type RunnerAuth } from '../runtime/runner-auth.ts';
@@ -77,8 +81,6 @@ const HUMAN_FIX_TRIGGERS = new Set(['cockpit_comment', 'chat']);
 // the diff, the author's reasoning, nor the criteria must form its own theory
 // of the reported behavior and try to make it survive the branch.
 const PREMORTEM_TIMEOUT_MS = 10 * 60_000;
-const PREMORTEM_CRITERION =
-  'Premortem: an independent adversarial pass found no mechanism by which the reported behavior survives this change';
 
 function verifyPrompt(feature: FeatureRow, repo: RepositoryRow, criteria: string[]): string {
   const OUT_DIR = outDir(feature.id);

--- a/src/client/pages/feature.tsx
+++ b/src/client/pages/feature.tsx
@@ -324,9 +324,9 @@ function LifecycleHistory({
                     <span
                       className={cn(
                         'mt-1.5 size-2 shrink-0 rounded-full',
-                        stage.status === 'completed'
+                        stage.status === 'completed' && stage.verdict !== 'failed'
                           ? 'bg-go-bright'
-                          : stage.status === 'failed'
+                          : stage.status === 'failed' || stage.verdict === 'failed'
                             ? 'bg-danger'
                             : stage.status === 'running'
                               ? 'bg-hold lamp-glow-hold animate-pulse-dot'
@@ -340,7 +340,10 @@ function LifecycleHistory({
                           attempt {stage.attempt}
                         </span>
                       ) : null}
-                      <span className="ml-2 text-xs text-mute">{sentence(stage.status)}</span>
+                      <span className="ml-2 text-xs text-mute">
+                        {sentence(stage.status)}
+                        {stage.verdict === 'failed' ? ' · verification failed' : ''}
+                      </span>
                       {stage.error ? (
                         <span className="mt-0.5 block text-xs text-danger">{stage.error}</span>
                       ) : null}

--- a/src/domain/verification.test.ts
+++ b/src/domain/verification.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { formatUnmetCriteriaFindings, verificationSkipReason } from './verification.ts';
+import {
+  formatUnmetCriteriaFindings,
+  gradedCriteria,
+  PREMORTEM_CRITERION,
+  verificationSkipReason,
+} from './verification.ts';
 
 describe('verificationSkipReason', () => {
   // D1-format timestamps ('YYYY-MM-DD HH:MM:SS', UTC) so the helper's
@@ -46,5 +51,54 @@ describe('formatUnmetCriteriaFindings', () => {
 
   it('returns an empty string when everything passed', () => {
     expect(formatUnmetCriteriaFindings(['a'], [{ index: 0, verdict: 'pass', note: '' }])).toBe('');
+  });
+});
+
+describe('gradedCriteria', () => {
+  const acceptance = ['GET /a returns 200', 'POST /b validates its body'];
+
+  it('pairs stored criteria with their results by index and keeps ungraded rows', () => {
+    const rows = gradedCriteria(acceptance, [{ index: 1, verdict: 'pass', note: 'ok' }]);
+    expect(rows).toEqual([
+      { text: acceptance[0], result: null },
+      { text: acceptance[1], result: { index: 1, verdict: 'pass', note: 'ok' } },
+    ]);
+  });
+
+  it('re-derives the premortem row the verifier appended beyond the stored criteria', () => {
+    const premortem = { index: 2, verdict: 'fail', note: 'Surviving mechanism: …' } as const;
+    const rows = gradedCriteria(acceptance, [
+      { index: 0, verdict: 'pass', note: 'ok' },
+      { index: 1, verdict: 'pass', note: 'ok' },
+      premortem,
+    ]);
+    expect(rows).toHaveLength(3);
+    expect(rows[2]).toEqual({ text: PREMORTEM_CRITERION, result: premortem });
+  });
+
+  it('labels any further appended rows generically instead of as the premortem', () => {
+    const rows = gradedCriteria(
+      ['only'],
+      [
+        { index: 2, verdict: 'pass', note: 'extra' },
+        { index: 1, verdict: 'pass', note: 'premortem' },
+      ],
+    );
+    expect(rows.map((r) => r.text)).toEqual(['only', PREMORTEM_CRITERION, 'Verification check #3']);
+  });
+});
+
+describe('formatUnmetCriteriaFindings', () => {
+  it('names the premortem when it is the failing row', () => {
+    const findings = formatUnmetCriteriaFindings(
+      ['stored criterion'],
+      [
+        { index: 0, verdict: 'pass', note: 'ok' },
+        { index: 1, verdict: 'fail', note: 'Surviving mechanism: X' },
+      ],
+    );
+    expect(findings).toContain(`not met: ${PREMORTEM_CRITERION}`);
+    expect(findings).toContain('Evidence: Surviving mechanism: X');
+    expect(findings).not.toContain('undefined');
   });
 });

--- a/src/domain/verification.ts
+++ b/src/domain/verification.ts
@@ -32,14 +32,53 @@ export interface CriterionResult {
   screenshot?: string;
 }
 
+// The premortem is an independent adversarial pass the verifier appends to
+// the feature's acceptance criteria at run time (only when those would pass).
+// Its verdict is stored with the results at index N, but the feature row
+// keeps only the N human criteria — so every reader of (acceptance, results)
+// must re-derive the appended row from here or silently drop the one
+// criterion that failed (live finding: the cockpit showed N/N proven while
+// the PR comment said 1 not met).
+export const PREMORTEM_CRITERION =
+  'Premortem: an independent adversarial pass found no mechanism by which the reported behavior survives this change';
+
+// Every criterion a verification graded, in result order: the feature's
+// stored acceptance criteria (verdict null when the run recorded nothing for
+// them) followed by any run-time criterion the results carry beyond them.
+// The first appended row is the premortem; anything further is labeled
+// generically rather than mis-attributed.
+export function gradedCriteria(
+  acceptance: string[],
+  results: CriterionResult[],
+): { text: string; result: CriterionResult | null }[] {
+  const rows = acceptance.map((text, i) => ({
+    text,
+    result: results.find((r) => r.index === i) ?? null,
+  }));
+  const appended = results
+    .filter((r) => r.index >= acceptance.length)
+    .sort((a, b) => a.index - b.index);
+  for (const result of appended) {
+    rows.push({
+      text:
+        result.index === acceptance.length
+          ? PREMORTEM_CRITERION
+          : `Verification check #${result.index + 1}`,
+      result,
+    });
+  }
+  return rows;
+}
+
 export function formatUnmetCriteriaFindings(
   criteria: string[],
   results: CriterionResult[],
 ): string {
-  return results
-    .filter((r) => r.verdict === 'fail')
+  return gradedCriteria(criteria, results)
+    .filter((row) => row.result?.verdict === 'fail')
     .map(
-      (f) => `**P1** — Acceptance criterion not met: ${criteria[f.index]}\n\nEvidence: ${f.note}`,
+      (row) =>
+        `**P1** — Acceptance criterion not met: ${row.text}\n\nEvidence: ${row.result?.note ?? ''}`,
     )
     .join('\n\n');
 }

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -3,7 +3,11 @@ import { env } from 'cloudflare:workers';
 import { Hono, type Context } from 'hono';
 import { factoryUnsupportedReason } from '../integrations/git/provider.ts';
 import { parseUtc } from '../shared/time.ts';
-import { formatUnmetCriteriaFindings, type CriterionResult } from '../domain/verification.ts';
+import {
+  formatUnmetCriteriaFindings,
+  gradedCriteria,
+  type CriterionResult,
+} from '../domain/verification.ts';
 import {
   agentUsageForMonth,
   automationUsageForMonth,
@@ -326,6 +330,14 @@ export interface ApiRouteDependencies {
   orgAdmin?: typeof userIsGithubOrgAdmin;
   // Injectable for tests (the worker-test fixture has no queue binding).
   enqueueFactory?: typeof enqueueFactoryMessage;
+}
+
+// A verify stage completes whenever the verification ran (its pass/fail is a
+// coordinator fact, not a stage failure), so the stage row alone reads green
+// for a failed verdict. Surface the recorded verdict for the cockpit.
+function stageVerdict(output: JsonValue | null): string | null {
+  if (!isJsonObject(output) || output.kind !== 'verification_completed') return null;
+  return isString(output.status) ? output.status : null;
 }
 
 export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
@@ -1343,6 +1355,7 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
             stage: stage.stage,
             attempt: stage.attempt,
             status: stage.status,
+            verdict: stageVerdict(stage.output),
             error: stage.error,
             started_at: stage.started_at,
             completed_at: stage.completed_at,
@@ -1468,23 +1481,25 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         caption: demo.caption ?? null,
       };
     }
-    const criteria = feature.acceptance ?? [];
-    const results = verification?.results ?? [];
+    // gradedCriteria re-derives the run-time premortem row the verifier
+    // appends beyond the stored criteria — zipping by index alone dropped the
+    // one failing row and painted N/N proven under a failed verdict.
     base.criteria = await Promise.all(
-      criteria.map(async (text, i) => {
-        const r = results.find((x) => x.index === i);
-        let screenshotUrl: string | null = null;
-        if (r?.screenshot) {
-          const key = `verify/${feature.id}/${r.screenshot.replace(/[^\w.-]/g, '')}`;
-          screenshotUrl = `/artifacts/${key}?sig=${await signArtifactKey(key)}`;
-        }
-        return {
-          text,
-          verdict: r?.verdict ?? null,
-          note: r?.note ?? null,
-          screenshot_url: screenshotUrl,
-        };
-      }),
+      gradedCriteria(feature.acceptance ?? [], verification?.results ?? []).map(
+        async ({ text, result: r }) => {
+          let screenshotUrl: string | null = null;
+          if (r?.screenshot) {
+            const key = `verify/${feature.id}/${r.screenshot.replace(/[^\w.-]/g, '')}`;
+            screenshotUrl = `/artifacts/${key}?sig=${await signArtifactKey(key)}`;
+          }
+          return {
+            text,
+            verdict: r?.verdict ?? null,
+            note: r?.note ?? null,
+            screenshot_url: screenshotUrl,
+          };
+        },
+      ),
     );
     base.verification = verificationSummary(
       verification?.status ?? null,

--- a/src/http/api.worker.test.ts
+++ b/src/http/api.worker.test.ts
@@ -7,7 +7,14 @@ import { testDatabase } from '../test/database-fixture.ts';
 import { Hono } from 'hono';
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import type { AuthedUser } from '../services/auth.ts';
-import type { ApiBoard, ApiModels, ApiSettings, ApiUsage } from '../shared/api-types.ts';
+import { PREMORTEM_CRITERION } from '../domain/verification.ts';
+import type {
+  ApiBoard,
+  ApiFeatureDetail,
+  ApiModels,
+  ApiSettings,
+  ApiUsage,
+} from '../shared/api-types.ts';
 import { isJsonObject, isString, parseJson, type JsonObject } from '../shared/json.ts';
 import { RUNNER_MODELS } from '../shared/runner-models.ts';
 import { createApiRoutes, type ApiRouteDependencies } from './api.ts';
@@ -642,6 +649,50 @@ describe('verification stall display', () => {
       .prepare('SELECT status FROM verifications WHERE id = 801')
       .first<{ status: string }>();
     expect(row?.status).toBe('running');
+  });
+
+  it('shows the premortem row the verifier appended beyond the stored criteria', async () => {
+    // Feature 502 has one human criterion; its failed verification carries a
+    // second result at index 1 — the run-time premortem. The cockpit must
+    // list it (and its failure), not paint 1/1 proven under a failed verdict.
+    // An artifacts-hosted repo keeps the route off GitHub; a PR number is
+    // needed because criteria are only graded once a change exists.
+    await testDatabase().batch([
+      testDatabase().prepare(
+        `INSERT INTO installations (id, account_login, account_id, account_type, provider)
+         VALUES (3003, 'acme-artifacts', 3003, 'Organization', 'artifacts')`,
+      ),
+      testDatabase().prepare(
+        `INSERT INTO repositories (id, installation_id, owner, name, provider, artifacts_repo, default_branch)
+         VALUES (303, 3003, 'acme', 'hosted', 'artifacts', 'acme--hosted', 'main')`,
+      ),
+      testDatabase().prepare(
+        `INSERT INTO features (id, repository_id, title, spec, status, pr_number, acceptance)
+         VALUES (502, 303, 'Ship it', 'spec', 'pr_opened', 1, '["GET /a returns 200"]'::jsonb)`,
+      ),
+      testDatabase().prepare(
+        `INSERT INTO verifications (id, feature_id, status, results)
+         VALUES (802, 502, 'failed',
+           '[{"index":0,"verdict":"pass","note":"ok"},
+             {"index":1,"verdict":"fail","note":"Surviving mechanism: X"}]'::jsonb)`,
+      ),
+    ]);
+    const app = apiApp({
+      authenticate: async () => ({ ...acmeUser, installationIds: [1001, 3003] }),
+      canPushToRepo: async () => true,
+      orgAdmin: async () => true,
+    });
+    const response = await app.request('https://turbodiff.test/api/factory/features/502');
+    expect(response.status).toBe(200);
+    // SAFETY: the 200 body is the ApiFeatureDetail contract under test; the
+    // assertions below fail on any drift in the criteria/verification shape.
+    const detail = (await response.json()) as ApiFeatureDetail;
+    expect(detail.criteria.map((c) => [c.text, c.verdict])).toEqual([
+      ['GET /a returns 200', 'pass'],
+      [PREMORTEM_CRITERION, 'fail'],
+    ]);
+    expect(detail.criteria[1]?.note).toBe('Surviving mechanism: X');
+    expect(detail.verification).toEqual({ status: 'failed', total: 2, failed: 1 });
   });
 
   it("reports a completed 'passed' row as 'passed' regardless of age", async () => {

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -243,6 +243,9 @@ export interface ApiLifecycleRun {
     stage: string;
     attempt: number;
     status: 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+    // Verify stages: the verification's own status ('passed' | 'failed' |
+    // 'error'); a completed stage with a failed verdict is not green.
+    verdict: string | null;
     error: string | null;
     started_at: string | null;
     completed_at: string | null;


### PR DESCRIPTION
## Why

Feature #4's cockpit showed every acceptance criterion green and the lifecycle's verify stage green while the PR comment said "1 criteria not met". The unmet criterion is the premortem, which the verifier appends at run time beyond the feature's stored criteria; the feature API zipped stored criteria with results by index and silently dropped the appended row.

## What

- `src/domain/verification.ts`: `PREMORTEM_CRITERION` lives here now; new `gradedCriteria(acceptance, results)` re-derives the appended row(s) for any reader, and `formatUnmetCriteriaFindings` uses it (the criteria-conflict fix findings rendered the premortem as `undefined` before).
- `src/http/api.ts`: the feature detail's criteria list comes from `gradedCriteria`; lifecycle stage rows carry a `verdict` (the verification's status) because a verify stage completes whenever the run finished, pass or fail.
- `src/client/pages/feature.tsx`: a completed verify stage with a failed verdict shows the danger dot and "completed · verification failed".
- Tests: domain unit tests; a worker test seeding a failed verification with the appended result and reading it back through `/api/factory/features/:id`.

Not changed: the coordinator's treatment of a failed verdict (repair or handoff) already keys off `verificationPassed`; only the display was wrong. The Verify lamp on the go/no-go board was already correct, since it counts raw results.

Verified locally: `check:types`, `lint`, `test` (154), and the worker suite (170) against a fresh scratch database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
