### PR TITLE
fix(factory): brake the review↔repair loop and stop emoji severity promotion

### DIFF
--- a/docs/software-factory-lifecycle.md
+++ b/docs/software-factory-lifecycle.md
@@ -46,8 +46,11 @@ The scenario ids are stable references shared with
 | `verify`    | Change and acceptance contract       | Evidence and verification verdict      |
 | `merge`     | Mergeable change and satisfied gates | Merged provider state                  |
 
-`repair` may loop back into `review` and `verify`. Conflict resolution and
-interactive chat are repair triggers, not separate lifecycle stages.
+`repair` may loop back into `review` and `verify`, but only while the run's
+repair attempt budget lasts; a review that still blocks after the budget is
+spent hands the run off to a human, who may resume it past the gate.
+Conflict resolution and interactive chat are repair triggers, not separate
+lifecycle stages.
 
 ## Domain objects
 
@@ -266,6 +269,7 @@ flowchart TB
 - `RUN`: orchestration, deduplication, retry, and terminal-state behavior.
 - `HND`: stop boundaries, wait states, handoff, and resume.
 - `CAP`: capability degradation and authorization.
+- `REP`: repair scheduling and the review↔repair attempt budget.
 - `VER`: acceptance contracts and verification loops.
 - `MRG`: external gates and merge readiness.
 - `CMP`: compatibility and migration behavior.

--- a/src/ai/tools/change-requests.ts
+++ b/src/ai/tools/change-requests.ts
@@ -25,11 +25,11 @@ import {
   assertPinned,
   filterDiffNoise,
   findingSchema,
-  findingSeverity,
   truncate,
   MAX_DIFF_CHARS,
   MAX_FILE_CHARS,
 } from './github.ts';
+import { findingSeverity } from '../../domain/review-findings.ts';
 
 // Native change-request tools for the PrReviewer agent
 // (docs/artifacts-provider.md). Deliberately the SAME tool names and input

--- a/src/ai/tools/github.ts
+++ b/src/ai/tools/github.ts
@@ -11,6 +11,7 @@ import {
   githubRequest as gh,
 } from '../../integrations/github/client.ts';
 import { REVIEW_NOISE_PATTERNS, splitDiffSegments } from '../../domain/review-diff.ts';
+import { findingSeverity } from '../../domain/review-findings.ts';
 
 // The repository a review dispatch is scoped to. The model supplies
 // owner/repo as tool arguments, and tokenFor resolves a full installation
@@ -281,22 +282,6 @@ export const findingSchema = v.object({
   severity: v.optional(v.picklist(['P1', 'P2']), 'P2'),
   body: v.pipe(v.string(), v.minLength(1)),
 });
-
-// Severity gates merges in blocking mode, so the model's structured field is
-// not trusted alone: the body's visible tag is an independent claim of the
-// same fact. A finding counts as P1 when either says so — a mislabel can then
-// only escalate (a spurious REQUEST_CHANGES a re-review clears), never
-// silently APPROVE past a real P1 — and disagreements are logged.
-export function findingSeverity(f: v.InferOutput<typeof findingSchema>): 'P1' | 'P2' {
-  const bodyTagged = f.body.includes('**P1**') || f.body.includes('\u{1F534}');
-  if (bodyTagged !== (f.severity === 'P1')) {
-    console.warn(
-      `turbodiff: severity mismatch on finding ${f.path}:${f.line} — field says ${f.severity}, ` +
-        `body ${bodyTagged ? 'is' : 'is not'} tagged P1; treating as P1`,
-    );
-  }
-  return bodyTagged || f.severity === 'P1' ? 'P1' : 'P2';
-}
 
 function findingsAsMarkdown(findings: v.InferOutput<typeof findingSchema>[]): string {
   return findings.map((f) => `**\`${f.path}:${f.line}\`**\n${f.body}`).join('\n\n');

--- a/src/client/pages/feature.tsx
+++ b/src/client/pages/feature.tsx
@@ -22,6 +22,7 @@ import type {
   ApiMe,
   ApiVerificationSummary,
 } from '../../shared/api-types.ts';
+import { canResumeLifecycleRun, isRepairBudgetPause } from '../../domain/lifecycle-resume.ts';
 import { api, ApiError } from '../lib/api.ts';
 import { useDictation } from '../lib/dictation.ts';
 import { sentence } from '../lib/format.ts';
@@ -309,7 +310,7 @@ function LifecycleHistory({
   resuming,
 }: {
   runs: ApiFeatureDetail['lifecycle_runs'];
-  // Re-run the failed stage of a run parked on a human decision.
+  // Retry a failure or rerun checks after manual fixes.
   onResume: (runId: number) => void;
   resuming: boolean;
 }) {
@@ -364,7 +365,7 @@ function LifecycleHistory({
                   </li>
                 ))}
               </ol>
-              {run.status === 'awaiting_human' && run.stages.at(-1)?.status === 'failed' ? (
+              {canResumeLifecycleRun(run, run.stages.at(-1)) ? (
                 <div className="mt-3">
                   <Button
                     size="sm"
@@ -372,8 +373,16 @@ function LifecycleHistory({
                     onClick={() => onResume(run.id)}
                     loading={resuming}
                   >
-                    Retry {sentence(run.stages.at(-1)?.stage ?? 'stage')}
+                    {isRepairBudgetPause(run, run.stages.at(-1))
+                      ? 'Resume checks'
+                      : `Retry ${sentence(run.stages.at(-1)?.stage ?? 'stage')}`}
                   </Button>
+                  {isRepairBudgetPause(run, run.stages.at(-1)) ? (
+                    <p className="mt-2 text-xs text-mute">
+                      Fix the remaining issues manually, then resume checks. This does not reset the
+                      automated repair budget.
+                    </p>
+                  ) : null}
                 </div>
               ) : null}
               {run.handoff_reason ? (

--- a/src/data/factory.ts
+++ b/src/data/factory.ts
@@ -337,6 +337,25 @@ export async function countFixAttempts(repositoryId: number, prNumber: number): 
   return row?.n ?? 0;
 }
 
+// Keep orchestration and the atomic claim on the same per-PR budget. Chat
+// turns are supervised and excluded; attempts from earlier runs still count.
+function fixBudgetPredicate(repositoryId: number, prNumber: number, capTrigger?: string) {
+  return sql`repository_id = ${repositoryId} AND pr_number = ${prNumber}
+    AND ((${capTrigger ?? null}::text IS NOT NULL AND "trigger" = ${capTrigger ?? null})
+      OR (${capTrigger ?? null}::text IS NULL AND "trigger" <> 'chat'))`;
+}
+
+export async function countBudgetedFixAttempts(
+  repositoryId: number,
+  prNumber: number,
+): Promise<number> {
+  const row = await queryOne<{ n: number }>(sql`
+    SELECT COUNT(*) AS n FROM app.fix_attempts
+    WHERE ${fixBudgetPredicate(repositoryId, prNumber)}
+  `);
+  return row?.n ?? 0;
+}
+
 // Records an attempt only while under the cap and only when no attempt is
 // already running for this PR. The partial unique index is the concurrency
 // guard, so two consumers can't both claim the same sandbox.
@@ -372,9 +391,7 @@ export async function tryRecordFixAttempt(
         SELECT ${repositoryId}, ${prNumber}, ${trigger}, ${stageRunId}
         WHERE (
           SELECT COUNT(*) FROM app.fix_attempts
-          WHERE repository_id = ${repositoryId} AND pr_number = ${prNumber}
-            AND ((${capTrigger ?? null}::text IS NOT NULL AND "trigger" = ${capTrigger ?? null})
-              OR (${capTrigger ?? null}::text IS NULL AND "trigger" <> 'chat'))
+          WHERE ${fixBudgetPredicate(repositoryId, prNumber, capTrigger)}
         ) < ${cap}
         ON CONFLICT DO NOTHING
         RETURNING id

--- a/src/domain/lifecycle-contract.test.ts
+++ b/src/domain/lifecycle-contract.test.ts
@@ -244,7 +244,7 @@ export const LIFECYCLE_SCENARIOS: LifecycleScenario[] = [
       stopAfterStage: 'repair',
       completedStages: ['review'],
       capabilities: ['read_change', 'publish_review'],
-      facts: { blockingFindings: true },
+      facts: { blockingFindings: true, repairAttemptsRemaining: true },
     },
     expected: { kind: 'handoff', reason: 'change head is not writable' },
   },
@@ -275,6 +275,41 @@ export const LIFECYCLE_SCENARIOS: LifecycleScenario[] = [
       facts: { allGatesGreen: true },
     },
     expected: { kind: 'handoff', reason: 'merge authority unavailable' },
+  },
+  {
+    id: 'REP-001',
+    description: 'blocking findings schedule a repair while attempts remain',
+    profile: 'review_and_repair',
+    given: {
+      event: 'stage.completed',
+      completedStage: 'review',
+      origin: 'human',
+      startStage: 'review',
+      stopAfterStage: 'merge',
+      completedStages: ['review'],
+      capabilities: ['read_change', 'publish_review', 'write_head'],
+      facts: { blockingFindings: true, repairAttemptsRemaining: true },
+    },
+    expected: { kind: 'schedule', stage: 'repair' },
+  },
+  {
+    id: 'REP-002',
+    description: 'a still-blocking review with no repair budget parks the run instead of looping',
+    profile: 'full_delivery',
+    given: {
+      event: 'stage.completed',
+      completedStage: 'review',
+      origin: 'factory',
+      startStage: 'plan',
+      stopAfterStage: 'merge',
+      completedStages: ['plan', 'implement', 'publish', 'review'],
+      capabilities: ['read_change', 'publish_review', 'write_head', 'merge'],
+      facts: { blockingFindings: true, repairAttemptsRemaining: false },
+    },
+    expected: {
+      kind: 'handoff',
+      reason: 'blocking findings remain and repair policy is exhausted',
+    },
   },
   {
     id: 'VER-001',
@@ -470,7 +505,7 @@ describe('composable lifecycle acceptance contract', () => {
   it('uses stable, unique scenario ids', () => {
     const ids = LIFECYCLE_SCENARIOS.map((scenario) => scenario.id);
     expect(new Set(ids).size).toBe(ids.length);
-    for (const id of ids) expect(id).toMatch(/^(REV|RUN|HND|CAP|VER|MRG|CMP)-\d{3}$/);
+    for (const id of ids) expect(id).toMatch(/^(REV|RUN|HND|CAP|REP|VER|MRG|CMP)-\d{3}$/);
   });
 
   it('covers every built-in process profile', () => {
@@ -555,7 +590,11 @@ describe('repeated lifecycle stages', () => {
             stopAfterStage: profile === 'assisted_delivery' ? 'verify' : 'merge',
             completedStages,
             capabilities: ['read_change', 'publish_review', 'write_head', 'merge'],
-            facts: { acceptanceContractPresent: true, blockingFindings },
+            facts: {
+              acceptanceContractPresent: true,
+              blockingFindings,
+              repairAttemptsRemaining: true,
+            },
           }),
         ).toEqual({ kind: 'schedule', stage: next });
       }

--- a/src/domain/lifecycle-contract.test.ts
+++ b/src/domain/lifecycle-contract.test.ts
@@ -307,7 +307,7 @@ export const LIFECYCLE_SCENARIOS: LifecycleScenario[] = [
       facts: { blockingFindings: true, repairAttemptsRemaining: false },
     },
     expected: {
-      kind: 'handoff',
+      kind: 'wait',
       reason: 'blocking findings remain and repair policy is exhausted',
     },
   },

--- a/src/domain/lifecycle-coordinator.ts
+++ b/src/domain/lifecycle-coordinator.ts
@@ -177,7 +177,12 @@ export function decideLifecycle(
     }
 
     if (latest === 'review' && fact(context, 'blockingFindings')) {
-      return schedule('repair', context);
+      // The review↔repair cycle needs this brake: a reviewer that keeps
+      // blocking (or re-rolls its verdict on an unchanged head) would
+      // otherwise re-run the full review fleet forever. Parking keeps the
+      // human resume path open, which bypasses this gate.
+      if (fact(context, 'repairAttemptsRemaining')) return schedule('repair', context);
+      return { kind: 'handoff', reason: 'blocking findings remain and repair policy is exhausted' };
     }
     if (latest === 'verify' && context.facts?.verificationPassed === false) {
       if (fact(context, 'repairAttemptsRemaining')) return schedule('repair', context);

--- a/src/domain/lifecycle-coordinator.ts
+++ b/src/domain/lifecycle-coordinator.ts
@@ -6,6 +6,7 @@ import {
   type LifecycleStage,
   type ProcessProfileKey,
 } from './lifecycle-contract.ts';
+import { REVIEW_REPAIR_EXHAUSTED, VERIFY_REPAIR_EXHAUSTED } from './lifecycle-resume.ts';
 import { processProfile } from './process-profiles.ts';
 
 export type LifecycleContext = LifecycleScenario['given'];
@@ -177,16 +178,14 @@ export function decideLifecycle(
     }
 
     if (latest === 'review' && fact(context, 'blockingFindings')) {
-      // The review↔repair cycle needs this brake: a reviewer that keeps
-      // blocking (or re-rolls its verdict on an unchanged head) would
-      // otherwise re-run the full review fleet forever. Parking keeps the
-      // human resume path open, which bypasses this gate.
+      // Pause for manual fixes when the shared automatic repair budget is
+      // exhausted. A human can rerun the review without granting more repairs.
       if (fact(context, 'repairAttemptsRemaining')) return schedule('repair', context);
-      return { kind: 'handoff', reason: 'blocking findings remain and repair policy is exhausted' };
+      return { kind: 'wait', reason: REVIEW_REPAIR_EXHAUSTED };
     }
     if (latest === 'verify' && context.facts?.verificationPassed === false) {
       if (fact(context, 'repairAttemptsRemaining')) return schedule('repair', context);
-      return { kind: 'handoff', reason: 'verification failed and repair policy is exhausted' };
+      return { kind: 'wait', reason: VERIFY_REPAIR_EXHAUSTED };
     }
     if (latest === 'verify') return mergeDecision(context);
     if (latest === 'repair') return schedule('review', context);

--- a/src/domain/lifecycle-resume.test.ts
+++ b/src/domain/lifecycle-resume.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  canResumeLifecycleRun,
+  REVIEW_REPAIR_EXHAUSTED,
+  VERIFY_REPAIR_EXHAUSTED,
+} from './lifecycle-resume.ts';
+
+describe('lifecycle resume eligibility shared by the service and UI', () => {
+  it.each([
+    ['review', REVIEW_REPAIR_EXHAUSTED],
+    ['verify', VERIFY_REPAIR_EXHAUSTED],
+  ])('allows a completed %s check paused by the repair budget', (stage, reason) => {
+    expect(
+      canResumeLifecycleRun(
+        { status: 'awaiting_human', handoff_reason: reason },
+        { stage, status: 'completed' },
+      ),
+    ).toBe(true);
+  });
+
+  it('retains retries for stage failures', () => {
+    expect(
+      canResumeLifecycleRun(
+        {
+          status: 'awaiting_human',
+          handoff_reason: 'stage failure requires retry policy evaluation',
+        },
+        { stage: 'repair', status: 'failed' },
+      ),
+    ).toBe(true);
+  });
+
+  it.each(['active', 'handed_off', 'completed', 'cancelled', 'failed'])(
+    'does not resume a %s run',
+    (status) => {
+      expect(
+        canResumeLifecycleRun(
+          { status, handoff_reason: REVIEW_REPAIR_EXHAUSTED },
+          { stage: 'review', status: 'completed' },
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it('does not bypass a different human decision or resume a queued stage', () => {
+    expect(
+      canResumeLifecycleRun(
+        {
+          status: 'awaiting_human',
+          handoff_reason: 'acceptance criteria conflict requires a human decision',
+        },
+        { stage: 'verify', status: 'completed' },
+      ),
+    ).toBe(false);
+    expect(
+      canResumeLifecycleRun(
+        { status: 'awaiting_human', handoff_reason: REVIEW_REPAIR_EXHAUSTED },
+        { stage: 'review', status: 'queued' },
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/domain/lifecycle-resume.ts
+++ b/src/domain/lifecycle-resume.ts
@@ -1,0 +1,36 @@
+export const REVIEW_REPAIR_EXHAUSTED = 'blocking findings remain and repair policy is exhausted';
+export const VERIFY_REPAIR_EXHAUSTED = 'verification failed and repair policy is exhausted';
+
+interface ResumableRun {
+  status: string;
+  handoff_reason: string | null;
+}
+
+interface ResumableStage {
+  stage: string;
+  status: string;
+}
+
+// A completed check can pause on its verdict. Resume reruns that check after
+// human intervention; it never resets or bypasses the automatic repair cap.
+export function isRepairBudgetPause(
+  run: ResumableRun,
+  latest: ResumableStage | undefined,
+): boolean {
+  return (
+    run.status === 'awaiting_human' &&
+    latest?.status === 'completed' &&
+    ((latest.stage === 'review' && run.handoff_reason === REVIEW_REPAIR_EXHAUSTED) ||
+      (latest.stage === 'verify' && run.handoff_reason === VERIFY_REPAIR_EXHAUSTED))
+  );
+}
+
+export function canResumeLifecycleRun(
+  run: ResumableRun,
+  latest: ResumableStage | undefined,
+): boolean {
+  return (
+    run.status === 'awaiting_human' &&
+    (latest?.status === 'failed' || isRepairBudgetPause(run, latest))
+  );
+}

--- a/src/domain/review-findings.test.ts
+++ b/src/domain/review-findings.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+import { findingSeverity } from './review-findings.ts';
+
+const finding = (severity: 'P1' | 'P2', body: string) => ({
+  path: 'src/example.ts',
+  line: 42,
+  severity,
+  body,
+});
+
+describe('findingSeverity', () => {
+  it('keeps a conformant P2 at P2', () => {
+    expect(findingSeverity(finding('P2', '🟡 **P2** missing log on the failure path'))).toBe('P2');
+  });
+
+  it('keeps a conformant P1 at P1', () => {
+    expect(findingSeverity(finding('P1', '🔴 **P1** drops writes under concurrent pushes'))).toBe(
+      'P1',
+    );
+  });
+
+  it('does not promote a P2 decorated with a red emoji', () => {
+    // The PR #147 loop: an agent painted 🔴 on a P2 nit, the promoted finding
+    // turned the review blocking, and the repair cycle re-armed every round.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(findingSeverity(finding('P2', '🔴 **P2** missing log on the failure path'))).toBe('P2');
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('promotes a body tagged **P1** over a mislabeled P2 field, with a warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(findingSeverity(finding('P2', '🔴 **P1** leaks the installation token'))).toBe('P1');
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  it('trusts a P1 field even when the body forgot its tag', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(findingSeverity(finding('P1', 'unauthenticated route exposes the ledger'))).toBe('P1');
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+});

--- a/src/domain/review-findings.ts
+++ b/src/domain/review-findings.ts
@@ -1,0 +1,31 @@
+// Severity reconciliation for review findings. Lives in the domain layer so
+// the GitHub review tool and the native change-request engine share one
+// definition of what blocks a merge.
+
+// The fields a severity decision reads; both tool surfaces pass their full
+// validated finding objects.
+export interface ReviewFinding {
+  path: string;
+  line: number;
+  severity: 'P1' | 'P2';
+  body: string;
+}
+
+// Severity gates merges in blocking mode, so the model's structured field is
+// not trusted alone: the body's literal **P1** tag is an independent claim of
+// the same fact. A finding counts as P1 when either says so — a mislabel can
+// then only escalate (a spurious REQUEST_CHANGES a re-review clears), never
+// silently APPROVE past a real P1 — and disagreements are logged. The 🔴/🟡
+// emoji is NOT a severity claim: agents decorate P2 nits with 🔴 despite the
+// prompt's convention, and a promoted nit becomes a standing block that
+// re-arms the review↔repair loop on every round.
+export function findingSeverity(f: ReviewFinding): 'P1' | 'P2' {
+  const bodyTagged = f.body.includes('**P1**');
+  if (bodyTagged !== (f.severity === 'P1')) {
+    console.warn(
+      `turbodiff: severity mismatch on finding ${f.path}:${f.line} — field says ${f.severity}, ` +
+        `body ${bodyTagged ? 'is' : 'is not'} tagged P1; treating as P1`,
+    );
+  }
+  return bodyTagged || f.severity === 'P1' ? 'P1' : 'P2';
+}

--- a/src/http/webhooks.worker.test.ts
+++ b/src/http/webhooks.worker.test.ts
@@ -1382,6 +1382,53 @@ describe('push re-reviews', () => {
       { stage: 'review', attempt: 2, status: 'completed' },
     ]);
   });
+
+  it('re-runs only the concerned agents on the post-repair re-review', async () => {
+    await seedReviewedRepo({ processProfile: 'review_and_repair' });
+    const h = harness();
+    // The default agent blocks on src/a.ts; security approved but flagged
+    // src/b.ts; the other two approved cleanly.
+    await reviewedOpening(h, {
+      review: { verdict: 'request_changes', paths: ['src/a.ts'] },
+      security: { verdict: 'approve', paths: ['src/b.ts'] },
+    });
+    const opening = h.commands()[0];
+    const repair = h.commands().find((command) => command.stage === 'repair');
+    if (!repair) throw new Error('repair stage was not scheduled');
+    await runLifecycleStage(repair, h.dispatch, { enqueue: h.enqueue });
+    await completeLifecycleRepair(repair.stageRunId, true, { kind: 'fixed' }, h.enqueue);
+    const attempt2 = h
+      .commands()
+      .find((command) => command.stage === 'review' && command.stageRunId !== opening.stageRunId);
+    if (!attempt2) throw new Error('post-repair review was not scheduled');
+    await expect(getStageRun(attempt2.stageRunId)).resolves.toMatchObject({
+      trigger: 'stage.completed',
+    });
+
+    h.calls.length = 0;
+    // The repair's commits touched the blocker's file and security's flagged
+    // file, but nothing the clean approvers signed off on.
+    await runLifecycleStage(attempt2, h.dispatch, {
+      computeRisk: async () => 'full',
+      computeDelta: async () => ({
+        sinceHead: headA,
+        files: [
+          { filename: 'src/a.ts', additions: 4, deletions: 1 },
+          { filename: 'src/b.ts', additions: 1, deletions: 0 },
+        ],
+        tier: 'trivial' as const,
+      }),
+      enqueue: h.enqueue,
+    });
+    expect(h.calls.map((call) => call.slug).sort()).toEqual(['review', 'security']);
+    const stageRun = await getStageRun(attempt2.stageRunId);
+    expect(stageRun?.output).toMatchObject({
+      skipped: [
+        { slug: 'a11y', reason: 'approved earlier and the push does not touch its findings' },
+        { slug: 'o11y', reason: 'approved earlier and the push does not touch its findings' },
+      ],
+    });
+  });
 });
 
 describe('CI failure auto-fix', () => {

--- a/src/http/webhooks.worker.test.ts
+++ b/src/http/webhooks.worker.test.ts
@@ -9,6 +9,7 @@ import { Hono } from 'hono';
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   createFeature,
+  countBudgetedFixAttempts,
   createFactoryRunWithStage,
   ensureBuiltinAgents,
   finishFixAttempt,
@@ -590,6 +591,191 @@ describe('composable feature delivery', () => {
     await expect(resumeFailedStage(created.run.id, 'nico', enqueue)).resolves.toMatchObject({
       kind: 'rejected',
     });
+  });
+
+  it.each(['review', 'verify'] as const)(
+    'pauses an exhausted %s and resumes checks without granting more repairs',
+    async (stage) => {
+      await seedRepo();
+      await ensureBuiltinAgents(1001);
+      const featureId = await createFeature(101, 'Manual recovery', 'Ship it', ['It works']);
+      const change = await upsertChange({
+        repositoryId: 101,
+        providerKey: 'github:94',
+        number: 94,
+        origin: 'factory',
+        title: 'Manual recovery',
+        externalUrl: 'https://github.com/acme/api/pull/94',
+        sourceBranch: 'turbodiff/feature-94',
+        targetBranch: 'main',
+        status: 'open',
+        sourceHead: 'a'.repeat(40),
+        targetHead: 'b'.repeat(40),
+        draft: false,
+        capabilities: ['read_change', 'publish_review', 'write_head', 'merge'],
+      });
+      await updateFeature(featureId, { status: 'pr_opened', prNumber: 94, changeId: change.id });
+      // Earlier webhook fixes consume the same PR budget even though this new
+      // lifecycle run has no repair stages of its own.
+      for (let i = 0; i < FIX_MAX_ATTEMPTS; i++) {
+        const attempt = await tryRecordFixAttempt(101, 94, 'review', FIX_MAX_ATTEMPTS);
+        expect(attempt).not.toBeNull();
+        await finishFixAttempt(attempt!, 'failed');
+      }
+      const created = await createFactoryRunWithStage({
+        repositoryId: 101,
+        changeId: change.id,
+        profileKey: 'full_delivery',
+        startStage: stage,
+        stopAfterStage: 'merge',
+        policySnapshot: { key: 'full_delivery' },
+        trigger: 'test',
+        eventKind: 'human.resume_requested',
+        decision: { kind: 'schedule', stage },
+        idempotencyKey: `budget:${featureId}`,
+        stageInput: { featureId },
+      });
+      const queued: FactoryMessage[] = [];
+      const enqueue = async (message: FactoryMessage) => void queued.push(message);
+      const heads: (string | null)[] = [];
+      const dispatch: ReviewDispatcher = async (agent, repo, prNumber, _url, trigger, options) => {
+        heads.push(options?.headSha ?? null);
+        return (
+          (await tryRecordReview(
+            repo.id,
+            repo.installation_id,
+            prNumber,
+            trigger,
+            agent.slug,
+            `${agent.slug}--${repo.owner}--${repo.name}--${prNumber}`,
+            options?.riskTier ?? null,
+            options?.stageRunId ?? null,
+            options?.headSha ?? null,
+          )) !== null
+        );
+      };
+      let command: RunStageCommand = {
+        kind: 'run_stage',
+        factoryRunId: created.run.id,
+        stageRunId: created.stageRun!.id,
+        stage,
+        idempotencyKey: created.stageRun!.idempotency_key,
+        changeId: change.id,
+      };
+      // Resuming unchanged checks must pause again; after a manual fix they
+      // progress to verify/merge. Duplicate resume clicks cannot queue more work.
+      for (const passed of [false, false, true]) {
+        await runLifecycleStage(command, dispatch, { enqueue, computeRisk: async () => 'full' });
+        queued.length = 0;
+        if (stage === 'review') {
+          await completeLifecycleReview(
+            'review--acme--api--94',
+            null,
+            passed ? 0 : 1,
+            passed ? 'approve' : 'request_changes',
+            passed ? [] : ['src/a.ts'],
+            enqueue,
+          );
+        } else {
+          await completeLifecycleStage(
+            command.stageRunId,
+            'verify',
+            true,
+            { status: passed ? 'passed' : 'failed' },
+            { verificationPassed: passed },
+            enqueue,
+          );
+        }
+        expect(await countBudgetedFixAttempts(101, 94)).toBe(FIX_MAX_ATTEMPTS);
+        expect(await tryRecordFixAttempt(101, 94, 'lifecycle_repair', FIX_MAX_ATTEMPTS)).toBeNull();
+        if (passed) break;
+        expect(queued).toHaveLength(0);
+        await expect(getFactoryRun(created.run.id)).resolves.toMatchObject({
+          status: 'awaiting_human',
+        });
+        await expect(getStageRun(command.stageRunId)).resolves.toMatchObject({
+          status: 'completed',
+        });
+        await testDatabase()
+          .prepare('UPDATE changes SET source_head = ?1 WHERE id = ?2')
+          .bind('c'.repeat(40), change.id)
+          .run();
+        expect(await resumeFailedStage(created.run.id, 'nico', enqueue)).toMatchObject({
+          kind: 'scheduled',
+          stage,
+        });
+        expect(await resumeFailedStage(created.run.id, 'nico', enqueue)).toMatchObject({
+          kind: 'rejected',
+        });
+        expect(stageCommands(queued)).toHaveLength(1);
+        [command] = stageCommands(queued);
+      }
+      expect(stageCommands(queued)).toHaveLength(1);
+      expect(stageCommands(queued)[0].stage).toBe(stage === 'review' ? 'verify' : 'merge');
+      if (stage === 'review')
+        expect(heads).toEqual(['a'.repeat(40), 'c'.repeat(40), 'c'.repeat(40)]);
+    },
+  );
+
+  it('does not spend repair budget on scheduled stages, chat, or another PR', async () => {
+    await seedRepo();
+    const change = await upsertChange({
+      repositoryId: 101,
+      providerKey: 'github:95',
+      number: 95,
+      origin: 'human',
+      title: 'Budget',
+      externalUrl: 'https://github.com/acme/api/pull/95',
+      sourceBranch: 'fix',
+      targetBranch: 'main',
+      status: 'open',
+      sourceHead: 'a'.repeat(40),
+      targetHead: 'b'.repeat(40),
+      draft: false,
+      capabilities: ['read_change', 'publish_review', 'write_head'],
+    });
+    const created = await createFactoryRunWithStage({
+      repositoryId: 101,
+      changeId: change.id,
+      profileKey: 'full_delivery',
+      startStage: 'review',
+      stopAfterStage: 'merge',
+      policySnapshot: { key: 'full_delivery' },
+      trigger: 'test',
+      eventKind: 'human.resume_requested',
+      decision: { kind: 'schedule', stage: 'review' },
+      idempotencyKey: 'unspent-budget',
+    });
+    for (let i = 0; i < FIX_MAX_ATTEMPTS; i++) {
+      // Historical repairs that never reached the fixer do not consume claims.
+      await testDatabase()
+        .prepare(`INSERT INTO stage_runs
+        (factory_run_id, change_id, stage, attempt, status, trigger, idempotency_key)
+        VALUES (?1, ?2, 'repair', ?3, 'failed', 'test', ?4)`)
+        .bind(created.run.id, change.id, i + 1, `unclaimed:${i}`)
+        .run();
+      const chat = await tryRecordFixAttempt(101, 95, 'chat', 10, 'chat');
+      await finishFixAttempt(chat!, 'failed');
+      const other = await tryRecordFixAttempt(101, 96, 'review', FIX_MAX_ATTEMPTS);
+      await finishFixAttempt(other!, 'failed');
+    }
+    expect(await countBudgetedFixAttempts(101, 95)).toBe(0);
+    await testDatabase()
+      .prepare("UPDATE stage_runs SET status = 'running' WHERE id = ?1")
+      .bind(created.stageRun!.id)
+      .run();
+    const queued: FactoryMessage[] = [];
+    await completeLifecycleStage(
+      created.stageRun!.id,
+      'review',
+      true,
+      {},
+      { blockingFindings: true },
+      async (message) => void queued.push(message),
+    );
+    expect(stageCommands(queued)).toHaveLength(1);
+    expect(stageCommands(queued)[0].stage).toBe('repair');
+    expect(await tryRecordFixAttempt(101, 95, 'lifecycle_repair', FIX_MAX_ATTEMPTS)).not.toBeNull();
   });
 
   it.each([1, 2])('reaches verification and merge after %i repair rounds', async (repairs) => {

--- a/src/services/lifecycle.ts
+++ b/src/services/lifecycle.ts
@@ -4,6 +4,7 @@ import {
   cancelStageRun,
   claimStageRun,
   completeReview,
+  countBudgetedFixAttempts,
   createAcceptanceContract,
   createFactoryRunWithStage,
   finishStageRun,
@@ -26,6 +27,7 @@ import {
   type StageRunRow,
 } from '../data/db.ts';
 import { decideLifecycle, type LifecycleContext } from '../domain/lifecycle-coordinator.ts';
+import { canResumeLifecycleRun } from '../domain/lifecycle-resume.ts';
 import { isDeliveryProcessProfile, processProfile } from '../domain/process-profiles.ts';
 import type {
   LifecycleDecision,
@@ -397,12 +399,9 @@ async function coordinateStageOutcome(
   const feature = featureId ? await getFeature(featureId) : null;
   const acceptanceContract = change ? await latestAcceptanceContractForChange(change.id) : null;
 
-  // Every scheduled repair spends an attempt regardless of outcome, so a
-  // fixer that keeps failing or declining still terminates. Cancelled runs
-  // were skipped by a human, not attempted.
-  const repairAttempts = (await listStageRuns(run.id)).filter(
-    (stageRun) => stageRun.stage === 'repair' && stageRun.status !== 'cancelled',
-  ).length;
+  // Match the fixer's per-PR, non-chat budget across lifecycle runs. Merely
+  // scheduling a repair does not spend it; the atomic claim is the final guard.
+  const repairAttempts = change ? await countBudgetedFixAttempts(repo.id, change.number) : 0;
   const event: LifecycleEventKind = success ? 'stage.completed' : 'stage.failed';
   const context: LifecycleContext = {
     event,
@@ -522,10 +521,8 @@ export type ResumeStageResult =
   | { kind: 'scheduled'; stageRunId: number; stage: LifecycleStage; attempt: number }
   | { kind: 'rejected'; reason: string };
 
-// A run parked by a stage failure ("stage failure requires retry policy
-// evaluation") has no automatic retry policy yet — a human is the policy.
-// Re-run the failed stage as a fresh attempt on the same run, so the rest of
-// the delivery (verify, merge) continues from there once it passes.
+// Retry failed stages or rerun a check paused by the repair budget after a
+// manual fix. Resuming never resets the automatic repair budget.
 export async function resumeFailedStage(
   runId: number,
   actor: string | null,
@@ -540,8 +537,8 @@ export async function resumeFailedStage(
     };
   }
   const latest = (await listStageRuns(run.id)).at(-1);
-  if (!latest || latest.status !== 'failed') {
-    return { kind: 'rejected', reason: 'the latest stage did not fail' };
+  if (!latest || !canResumeLifecycleRun(run, latest)) {
+    return { kind: 'rejected', reason: 'the latest stage is not available to resume' };
   }
   const repo = await getRepoById(run.repository_id);
   if (!repo) return { kind: 'rejected', reason: 'repository missing' };

--- a/src/services/lifecycle.ts
+++ b/src/services/lifecycle.ts
@@ -837,6 +837,18 @@ export async function runLifecycleStage(
         headSha: scheduledHead,
         computeDelta: dependencies.computeDelta ?? computePushDelta,
       };
+    } else if (stageRun.trigger === 'stage.completed' && change.source_head) {
+      // The coordinator's own follow-on review (after a repair) reuses the
+      // push selection machinery against the current head: agents holding a
+      // block re-judge it, agents that already approved are re-dispatched
+      // only when the repair's delta reaches their findings, and an empty
+      // selection settles the stage clean instead of re-running the whole
+      // fleet. Explicit human triggers (manual resume, PR open) keep the
+      // full dispatch they asked for.
+      push = {
+        headSha: change.source_head,
+        computeDelta: dependencies.computeDelta ?? computePushDelta,
+      };
     }
     const result = await dispatchChangeReviews(
       change,

--- a/src/services/lifecycle.ts
+++ b/src/services/lifecycle.ts
@@ -42,7 +42,11 @@ import {
   type JsonValue,
 } from '../shared/json.ts';
 import { parseUtc } from '../shared/time.ts';
-import type { GenerateQueueMessage, VerifyQueueMessage } from '../shared/factory-messages.ts';
+import {
+  FIX_MAX_ATTEMPTS,
+  type GenerateQueueMessage,
+  type VerifyQueueMessage,
+} from '../shared/factory-messages.ts';
 import { installationToken } from '../integrations/github/app.ts';
 import { githubJson, githubPaginate } from '../integrations/github/client.ts';
 import {
@@ -393,6 +397,12 @@ async function coordinateStageOutcome(
   const feature = featureId ? await getFeature(featureId) : null;
   const acceptanceContract = change ? await latestAcceptanceContractForChange(change.id) : null;
 
+  // Every scheduled repair spends an attempt regardless of outcome, so a
+  // fixer that keeps failing or declining still terminates. Cancelled runs
+  // were skipped by a human, not attempted.
+  const repairAttempts = (await listStageRuns(run.id)).filter(
+    (stageRun) => stageRun.stage === 'repair' && stageRun.status !== 'cancelled',
+  ).length;
   const event: LifecycleEventKind = success ? 'stage.completed' : 'stage.failed';
   const context: LifecycleContext = {
     event,
@@ -405,6 +415,7 @@ async function coordinateStageOutcome(
       repositoryEnabled: repo.enabled,
       acceptanceContractPresent: acceptanceContract !== null || feature?.acceptance != null,
       criteriaConflict: feature?.criteria_conflict === true,
+      repairAttemptsRemaining: repairAttempts < FIX_MAX_ATTEMPTS,
       ...outcomeFacts,
     },
   };


### PR DESCRIPTION
Blocking reviews now use the same per-PR automatic repair budget as the fixer. When that budget is exhausted, review or verification pauses with a **Resume checks** action: after manual fixes, a human can rerun the check and continue delivery. Resuming does not reset the repair budget, and checks that still fail pause again.

- Share the fix-attempt counting predicate with the atomic fixer claim. Earlier attempts on the PR count regardless of outcome; chat turns and stages that never claimed an attempt do not.
- Share resume eligibility between the service and feature UI. Completed checks paused by repair exhaustion are recoverable; terminal handoffs remain terminal, and existing failed-stage retries still work.
- Preserve the severity correction: a red emoji alone no longer elevates an explicit P2 finding to P1.
- Preserve selective post-repair reviews against the current head; explicit human resumes dispatch a full review.

For feature 5 / PR #147, the main loop bug was historical stage selection, fixed in merged PR #149. The run executed one repair and published 20 reviews before reaching the installation's daily review limit; verification never started. It did not exhaust the automatic repair cap. This PR adds severity, budget, and review-selection safeguards on top of #149.

Validation: 245 unit tests and 193 Worker/PostgreSQL integration tests pass, including exhausted review/verification recovery, repeated resumes, current-head review, and budget accounting. Type checks, lint (existing warnings only), the production build, migration checks, fresh-schema test, and Worker deployment dry-run pass. Worker tests used a dedicated scratch PostgreSQL database.
