### PR TITLE
fix(lifecycle): advance from the completed stage attempt

### DIFF
--- a/src/domain/lifecycle-contract.test.ts
+++ b/src/domain/lifecycle-contract.test.ts
@@ -3,6 +3,7 @@ import {
   LIFECYCLE_STAGES,
   PROCESS_PROFILE_KEYS,
   type LifecycleScenario,
+  type LifecycleStage,
 } from './lifecycle-contract.ts';
 import { decideLifecycle } from './lifecycle-coordinator.ts';
 
@@ -125,6 +126,7 @@ export const LIFECYCLE_SCENARIOS: LifecycleScenario[] = [
     profile: 'full_delivery',
     given: {
       event: 'stage.completed',
+      completedStage: 'implement',
       origin: 'factory',
       startStage: 'plan',
       stopAfterStage: 'merge',
@@ -153,6 +155,7 @@ export const LIFECYCLE_SCENARIOS: LifecycleScenario[] = [
     profile: 'full_delivery',
     given: {
       event: 'stage.completed',
+      completedStage: 'plan',
       origin: 'factory',
       startStage: 'plan',
       stopAfterStage: 'merge',
@@ -167,6 +170,7 @@ export const LIFECYCLE_SCENARIOS: LifecycleScenario[] = [
     profile: 'idea_to_pr',
     given: {
       event: 'stage.completed',
+      completedStage: 'publish',
       origin: 'factory',
       startStage: 'plan',
       stopAfterStage: 'publish',
@@ -234,6 +238,7 @@ export const LIFECYCLE_SCENARIOS: LifecycleScenario[] = [
     profile: 'review_and_repair',
     given: {
       event: 'stage.completed',
+      completedStage: 'review',
       origin: 'human',
       startStage: 'review',
       stopAfterStage: 'repair',
@@ -305,6 +310,7 @@ export const LIFECYCLE_SCENARIOS: LifecycleScenario[] = [
     profile: 'full_delivery',
     given: {
       event: 'stage.completed',
+      completedStage: 'verify',
       origin: 'factory',
       startStage: 'plan',
       stopAfterStage: 'merge',
@@ -320,6 +326,7 @@ export const LIFECYCLE_SCENARIOS: LifecycleScenario[] = [
     profile: 'full_delivery',
     given: {
       event: 'stage.completed',
+      completedStage: 'verify',
       origin: 'factory',
       startStage: 'plan',
       stopAfterStage: 'merge',
@@ -356,6 +363,7 @@ export const LIFECYCLE_SCENARIOS: LifecycleScenario[] = [
     profile: 'full_delivery',
     given: {
       event: 'stage.completed',
+      completedStage: 'verify',
       origin: 'factory',
       startStage: 'plan',
       stopAfterStage: 'merge',
@@ -522,5 +530,102 @@ describe('composable lifecycle acceptance contract', () => {
     for (const required of requiredBoundaries) {
       expect(boundaries.has(required)).toBe(true);
     }
+  });
+});
+
+describe('repeated lifecycle stages', () => {
+  it.each(['full_delivery', 'assisted_delivery', 'native_turnkey', 'legacy_factory'] as const)(
+    '%s reaches verification after repeated review and repair cycles',
+    (profile) => {
+      const completedStages: LifecycleStage[] = ['implement', 'publish'];
+      for (const [completedStage, blockingFindings, next] of [
+        ['review', true, 'repair'],
+        ['repair', false, 'review'],
+        ['review', true, 'repair'],
+        ['repair', false, 'review'],
+        ['review', false, 'verify'],
+      ] as const) {
+        completedStages.push(completedStage);
+        expect(
+          decideLifecycle(profile, {
+            event: 'stage.completed',
+            completedStage,
+            origin: 'factory',
+            startStage: 'implement',
+            stopAfterStage: profile === 'assisted_delivery' ? 'verify' : 'merge',
+            completedStages,
+            capabilities: ['read_change', 'publish_review', 'write_head', 'merge'],
+            facts: { acceptanceContractPresent: true, blockingFindings },
+          }),
+        ).toEqual({ kind: 'schedule', stage: next });
+      }
+    },
+  );
+
+  it('finishes review-and-repair after a clean re-review', () => {
+    expect(
+      decideLifecycle('review_and_repair', {
+        event: 'stage.completed',
+        completedStage: 'review',
+        origin: 'human',
+        startStage: 'review',
+        stopAfterStage: 'merge',
+        completedStages: ['review', 'repair', 'review'],
+        capabilities: ['read_change', 'publish_review', 'write_head'],
+        facts: { blockingFindings: false },
+      }),
+    ).toEqual({ kind: 'complete' });
+  });
+
+  it('does not reuse old verification after a repair', () => {
+    const completedStages: LifecycleStage[] = ['review', 'verify'];
+    for (const [completedStage, facts, next] of [
+      ['verify', { verificationPassed: false, repairAttemptsRemaining: true }, 'repair'],
+      ['repair', {}, 'review'],
+      ['review', { blockingFindings: false }, 'verify'],
+      ['verify', { verificationPassed: true }, 'merge'],
+    ] as const) {
+      completedStages.push(completedStage);
+      expect(
+        decideLifecycle('full_delivery', {
+          event: 'stage.completed',
+          completedStage,
+          origin: 'factory',
+          startStage: 'review',
+          stopAfterStage: 'merge',
+          completedStages,
+          capabilities: ['read_change', 'publish_review', 'write_head', 'merge'],
+          facts: { acceptanceContractPresent: true, ...facts },
+        }),
+      ).toEqual({ kind: 'schedule', stage: next });
+    }
+  });
+
+  it('does not reach a stop boundary using a historical completion', () => {
+    expect(
+      decideLifecycle('assisted_delivery', {
+        event: 'stage.completed',
+        completedStage: 'review',
+        origin: 'factory',
+        startStage: 'review',
+        stopAfterStage: 'verify',
+        completedStages: ['review', 'verify', 'repair', 'review'],
+        capabilities: ['read_change', 'publish_review', 'write_head'],
+        facts: { acceptanceContractPresent: true, blockingFindings: false },
+      }),
+    ).toEqual({ kind: 'schedule', stage: 'verify' });
+  });
+
+  it('waits for completion identity instead of guessing from history', () => {
+    expect(
+      decideLifecycle('full_delivery', {
+        event: 'stage.completed',
+        origin: 'factory',
+        startStage: 'review',
+        stopAfterStage: 'merge',
+        completedStages: ['review', 'repair'],
+        capabilities: ['read_change', 'publish_review', 'write_head'],
+      }),
+    ).toEqual({ kind: 'wait', reason: 'completed stage required' });
   });
 });

--- a/src/domain/lifecycle-contract.ts
+++ b/src/domain/lifecycle-contract.ts
@@ -97,6 +97,9 @@ export interface LifecycleScenario {
     startStage: LifecycleStage;
     stopAfterStage: LifecycleStage;
     completedStages?: LifecycleStage[];
+    // The attempt that emitted stage.completed; history may contain older
+    // repairs or verifications even when this attempt is a re-review.
+    completedStage?: LifecycleStage;
     capabilities?: ChangeCapability[];
     facts?: Record<string, boolean | string | number | null>;
   };

--- a/src/domain/lifecycle-coordinator.ts
+++ b/src/domain/lifecycle-coordinator.ts
@@ -18,7 +18,7 @@ function fact(context: LifecycleContext, key: string): boolean {
   return context.facts?.[key] === true;
 }
 
-function lastCompletedStage(context: LifecycleContext): LifecycleStage | null {
+function furthestCompletedStage(context: LifecycleContext): LifecycleStage | null {
   const completed = new Set(context.completedStages ?? []);
   let latest: LifecycleStage | null = null;
   for (const stage of LIFECYCLE_STAGES) {
@@ -123,7 +123,7 @@ export function decideLifecycle(
     return schedule('implement', context);
   }
   if (context.event === 'human.approved') {
-    const latest = lastCompletedStage(context) ?? context.startStage;
+    const latest = furthestCompletedStage(context) ?? context.startStage;
     const next = nextEnabledStage(profileKey, latest);
     return next ? schedule(next, context) : { kind: 'complete' };
   }
@@ -165,15 +165,16 @@ export function decideLifecycle(
       };
     }
 
-    const completed = context.completedStages ?? [];
-    if (completed.includes(context.stopAfterStage)) {
+    // A review after a repair is a new completion, even though repair is
+    // further along the stage order. Only this attempt can advance the run
+    // or reach its stop boundary; older attempts are historical evidence.
+    const latest = context.completedStage;
+    if (!latest) return { kind: 'wait', reason: 'completed stage required' };
+    if (latest === context.stopAfterStage) {
       return context.stopAfterStage === 'merge'
         ? { kind: 'complete' }
         : { kind: 'handoff', reason: 'requested stop boundary reached' };
     }
-
-    const latest = lastCompletedStage(context);
-    if (!latest) return schedule(context.startStage, context);
 
     if (latest === 'review' && fact(context, 'blockingFindings')) {
       return schedule('repair', context);

--- a/src/http/webhooks.worker.test.ts
+++ b/src/http/webhooks.worker.test.ts
@@ -592,6 +592,138 @@ describe('composable feature delivery', () => {
     });
   });
 
+  it.each([1, 2])('reaches verification and merge after %i repair rounds', async (repairs) => {
+    await seedRepo();
+    await ensureBuiltinAgents(1001);
+    const featureId = await createFeature(101, 'Repaired delivery', 'Ship it', ['It works']);
+    const change = await upsertChange({
+      repositoryId: 101,
+      providerKey: 'github:93',
+      number: 93,
+      origin: 'factory',
+      title: 'Repaired delivery',
+      externalUrl: 'https://github.com/acme/api/pull/93',
+      sourceBranch: 'turbodiff/feature-93',
+      targetBranch: 'main',
+      status: 'open',
+      sourceHead: 'a'.repeat(40),
+      targetHead: 'b'.repeat(40),
+      draft: false,
+      capabilities: ['read_change', 'publish_review', 'write_head', 'publish_check', 'merge'],
+    });
+    await updateFeature(featureId, { status: 'pr_opened', prNumber: 93, changeId: change.id });
+    const created = await createFactoryRunWithStage({
+      repositoryId: 101,
+      changeId: change.id,
+      profileKey: 'full_delivery',
+      startStage: 'review',
+      stopAfterStage: 'merge',
+      policySnapshot: { key: 'full_delivery' },
+      trigger: 'test',
+      eventKind: 'human.resume_requested',
+      decision: { kind: 'schedule', stage: 'review' },
+      idempotencyKey: `repair-delivery:${featureId}`,
+      stageInput: { featureId },
+    });
+    const queued: FactoryMessage[] = [];
+    const enqueue = async (message: FactoryMessage) => void queued.push(message);
+    const dispatch: ReviewDispatcher = async (agent, repo, prNumber, _url, trigger, options) => {
+      return (
+        (await tryRecordReview(
+          repo.id,
+          repo.installation_id,
+          prNumber,
+          trigger,
+          agent.slug,
+          `${agent.slug}--${repo.owner}--${repo.name}--${prNumber}`,
+          options?.riskTier ?? null,
+          options?.stageRunId ?? null,
+          options?.headSha ?? null,
+        )) !== null
+      );
+    };
+    let review: RunStageCommand = {
+      kind: 'run_stage',
+      factoryRunId: created.run.id,
+      stageRunId: created.stageRun!.id,
+      stage: 'review',
+      idempotencyKey: created.stageRun!.idempotency_key,
+      changeId: change.id,
+    };
+    for (let round = 0; round <= repairs; round++) {
+      await runLifecycleStage(review, dispatch, { computeRisk: async () => 'full', enqueue });
+      queued.length = 0;
+      const blocking = round < repairs;
+      await completeLifecycleReview(
+        'review--acme--api--93',
+        null,
+        blocking ? 1 : 0,
+        blocking ? 'request_changes' : 'approve',
+        blocking ? ['src/a.ts'] : [],
+        enqueue,
+      );
+      expect(stageCommands(queued)).toHaveLength(1);
+      const [next] = stageCommands(queued);
+      expect(next.stage).toBe(blocking ? 'repair' : 'verify');
+      if (!blocking) break;
+      await runLifecycleStage(next, dispatch, { enqueue });
+      expect(queued).toContainEqual(
+        expect.objectContaining({
+          kind: 'fix',
+          stageRunId: next.stageRunId,
+          factoryRunId: created.run.id,
+        }),
+      );
+      await testDatabase()
+        .prepare('UPDATE changes SET source_head = ?1 WHERE id = ?2')
+        .bind(String(round + 1).repeat(40), change.id)
+        .run();
+      queued.length = 0;
+      await completeLifecycleRepair(next.stageRunId, true, { kind: 'fixed' }, enqueue);
+      expect(stageCommands(queued)).toHaveLength(1);
+      [review] = stageCommands(queued);
+      expect(review.stage).toBe('review');
+    }
+    const [verify] = stageCommands(queued);
+    await runLifecycleStage(verify, dispatch, { enqueue });
+    expect(queued).toContainEqual({
+      kind: 'verify',
+      featureId,
+      factoryRunId: created.run.id,
+      stageRunId: verify.stageRunId,
+    });
+    queued.length = 0;
+    await completeLifecycleStage(
+      verify.stageRunId,
+      'verify',
+      true,
+      { kind: 'verification_completed', status: 'passed' },
+      { verificationPassed: true },
+      enqueue,
+    );
+    // A duplicated completion must not dispatch a second merge or review.
+    await completeLifecycleStage(
+      verify.stageRunId,
+      'verify',
+      true,
+      { kind: 'verification_completed', status: 'passed' },
+      { verificationPassed: true },
+      enqueue,
+    );
+    expect(stageCommands(queued)).toHaveLength(1);
+    const [merge] = stageCommands(queued);
+    expect(merge.stage).toBe('merge');
+    const mergeGithub = vi.fn(async () => {});
+    await runLifecycleStage(merge, dispatch, { enqueue, mergeGithub });
+    expect(mergeGithub).toHaveBeenCalledExactlyOnceWith(101, 93);
+    await expect(getFactoryRun(created.run.id)).resolves.toMatchObject({ status: 'completed' });
+    const stages = await listStageRuns(created.run.id);
+    expect(stages.filter((stage) => stage.stage === 'review')).toHaveLength(repairs + 1);
+    expect(stages.filter((stage) => stage.stage === 'repair')).toHaveLength(repairs);
+    expect(stages.filter((stage) => stage.stage === 'verify')).toHaveLength(1);
+    expect(stages.every((stage) => stage.status === 'completed')).toBe(true);
+  });
+
   it('hands verified delivery to the merge executor and completes the run', async () => {
     await seedRepo();
     const featureId = await createFeature(101, 'Verified delivery', 'Ship it', [
@@ -1237,6 +1369,18 @@ describe('push re-reviews', () => {
     });
     expect(h.calls.length).toBeGreaterThan(0);
     await expect(getStageRun(attempt2.stageRunId)).resolves.toMatchObject({ status: 'running' });
+
+    const commandCount = h.commands().length;
+    for (const call of h.calls) {
+      await completeLifecycleReview(instance(call.slug), null, 0, 'approve', [], h.enqueue);
+    }
+    await expect(getFactoryRun(pushB.factoryRunId)).resolves.toMatchObject({ status: 'completed' });
+    expect(h.commands()).toHaveLength(commandCount);
+    await expect(listStageRuns(pushB.factoryRunId)).resolves.toMatchObject([
+      { stage: 'review', attempt: 1, status: 'completed' },
+      { stage: 'repair', attempt: 1, status: 'completed' },
+      { stage: 'review', attempt: 2, status: 'completed' },
+    ]);
   });
 });
 

--- a/src/services/lifecycle.ts
+++ b/src/services/lifecycle.ts
@@ -393,16 +393,13 @@ async function coordinateStageOutcome(
   const feature = featureId ? await getFeature(featureId) : null;
   const acceptanceContract = change ? await latestAcceptanceContractForChange(change.id) : null;
 
-  const completed = (await listStageRuns(run.id))
-    .filter((stageRun) => stageRun.status === 'completed')
-    .map((stageRun) => stageRun.stage);
   const event: LifecycleEventKind = success ? 'stage.completed' : 'stage.failed';
   const context: LifecycleContext = {
     event,
     origin: change?.origin ?? 'imported',
     startStage: run.start_stage,
     stopAfterStage: run.stop_after_stage,
-    completedStages: completed,
+    completedStage: command.stage,
     capabilities: change?.capabilities,
     facts: {
       repositoryEnabled: repo.enabled,


### PR DESCRIPTION
After a repair, the coordinator treated that historical repair as the latest completed stage even when a newer review had finished. This repeatedly scheduled reviews of unchanged code and prevented verification from starting, as observed in factory feature 5 / PR #147.

Pass the completing attempt's stage explicitly into the decision function and use it for both advancement and stop boundaries. A clean re-review now advances to verification (or completes a review-and-repair run); remaining blockers schedule another repair. Historical verification also cannot skip the review and verification required after a later repair. Completions without a stage wait instead of guessing from history.

Regression coverage exercises repeated repair cycles across delivery profiles, review-and-repair completion, historical verification and stop boundaries, and duplicate completion delivery. PostgreSQL/Worker tests run one and two repair rounds through actual review settlement, verification enqueue, and the injected merge executor.

Validation:
- New unit regressions failed against the previous coordinator and pass with the fix.
- 231 unit tests and 189 Worker/PostgreSQL integration tests passed, using a dedicated local test database.
- Typecheck, lint (existing warnings only), changed-file formatting, migration validation, fresh schema test, production build, and Wrangler deployment dry-run passed.

No migration is required. Already parked runs still require a resume after deployment; this PR does not restart feature 5 or change review budgets.
