### PR TITLE
fix(factory): idempotent verify step + lifecycle repair carries unmet criteria

### DIFF
--- a/src/ai/runners/verifier.ts
+++ b/src/ai/runners/verifier.ts
@@ -283,7 +283,17 @@ async function runPremortem(
   return { mechanism: mechanism || null, ruledOut };
 }
 
-export async function runVerification(featureId: number): Promise<void> {
+export async function runVerification(
+  featureId: number,
+  options: {
+    // Set when the run is a lifecycle verify stage: the coordinator reads the
+    // recorded verdict and schedules the repair (carrying the unmet
+    // criteria) itself, so the verifier must not dispatch its own fix — the
+    // two would race for the PR's single-flight repair slot, and the
+    // coordinator's one would lose with "another repair is already running".
+    lifecycleOwned?: boolean;
+  } = {},
+): Promise<void> {
   const feature = await getFeature(featureId);
   if (!feature || !feature.branch || !feature.pr_number) {
     console.warn(`turbodiff: verify skipped, feature ${featureId} has no branch/PR`);
@@ -300,7 +310,7 @@ export async function runVerification(featureId: number): Promise<void> {
   const verificationId = await createVerification(featureId);
 
   try {
-    const outcome = await verify(feature, repo, criteria);
+    const outcome = await verify(feature, repo, criteria, options.lifecycleOwned === true);
     await finishVerification(verificationId, outcome.status, {
       results: outcome.results,
       summary: outcome.summary,
@@ -323,6 +333,7 @@ async function verify(
   feature: FeatureRow,
   repo: RepositoryRow,
   criteria: string[],
+  lifecycleOwned: boolean,
 ): Promise<{
   status: string;
   results: CriterionResult[];
@@ -506,6 +517,10 @@ async function verify(
         await postCriteriaConflictNotice(token, repo, feature, criteria, results);
         console.log(
           `turbodiff: criteria conflict flagged for feature ${feature.id} — awaiting decision`,
+        );
+      } else if (lifecycleOwned) {
+        console.log(
+          `turbodiff: unmet criteria for feature ${feature.id} left to the lifecycle repair stage`,
         );
       } else {
         await enqueueFactoryMessage({

--- a/src/ai/workflows/verification.ts
+++ b/src/ai/workflows/verification.ts
@@ -1,7 +1,7 @@
 import { env, WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from 'cloudflare:workers';
 import { getFeature, latestVerificationForFeature } from '../../data/db.ts';
 import { runVerification } from '../runners/verifier.ts';
-import { verificationSkipReason } from '../../domain/verification.ts';
+import { verdictRecordedSince, verificationSkipReason } from '../../domain/verification.ts';
 import { notifyFeatureLive } from '../../services/live-updates.ts';
 import { completeLifecycleStage } from '../../services/lifecycle.ts';
 import type { VerifyQueueMessage } from '../../shared/factory-messages.ts';
@@ -13,6 +13,12 @@ import type { VerifyQueueMessage } from '../../shared/factory-messages.ts';
 // never throws for business reasons, so one long-budget step suffices; the
 // retry (limit 1) only fires on infrastructure death, and the stranded-row
 // sweep in db.ts mops up any run the engine itself loses.
+//
+// That retry can also re-execute a callback that already finished (the
+// engine reports "Attempt failed due to internal workflows error" after the
+// verdict was recorded), so the step is idempotent on the verdict: a
+// terminal verification recorded since this instance was queued is reused
+// instead of paying for a second run — see verdictRecordedSince.
 
 export type VerificationParams = {
   featureId: number;
@@ -28,7 +34,18 @@ export class VerificationWorkflow extends WorkflowEntrypoint<unknown, Verificati
         'run verification',
         { retries: { limit: 1, delay: '5 minutes' }, timeout: '40 minutes' },
         async () => {
-          await runVerification(featureId);
+          const prior = await latestVerificationForFeature(featureId);
+          if (verdictRecordedSince(prior, event.timestamp.getTime())) {
+            console.log(
+              `turbodiff: verification for feature ${featureId} already recorded by an earlier ` +
+                `attempt of ${event.instanceId} — not re-running`,
+            );
+          } else {
+            // Under the lifecycle the coordinator schedules the repair from
+            // the recorded verdict; the verifier's own fix dispatch is only
+            // for legacy runs.
+            await runVerification(featureId, { lifecycleOwned: stageRunId !== undefined });
+          }
           await notifyFeatureLive(featureId);
         },
       );

--- a/src/domain/verification.test.ts
+++ b/src/domain/verification.test.ts
@@ -3,6 +3,7 @@ import {
   formatUnmetCriteriaFindings,
   gradedCriteria,
   PREMORTEM_CRITERION,
+  verdictRecordedSince,
   verificationSkipReason,
 } from './verification.ts';
 
@@ -30,6 +31,35 @@ describe('verificationSkipReason', () => {
   it('dispatches when the latest run already finished', () => {
     const latest = { status: 'passed', created_at: '2026-08-29 11:59:00' };
     expect(verificationSkipReason({ status: 'pr_opened' }, latest, now)).toBeNull();
+  });
+});
+
+describe('verdictRecordedSince', () => {
+  const queuedAt = Date.parse('2026-09-07T20:02:23Z');
+
+  it('reuses a terminal verdict recorded after the instance was queued', () => {
+    for (const status of ['passed', 'failed']) {
+      const latest = { status, created_at: '2026-09-07 20:02:27' };
+      expect(verdictRecordedSince(latest, queuedAt)).toBe(true);
+    }
+  });
+
+  it('tolerates the database clock running slightly behind the engine', () => {
+    const latest = { status: 'failed', created_at: '2026-09-07 20:01:40' };
+    expect(verdictRecordedSince(latest, queuedAt)).toBe(true);
+  });
+
+  it('re-runs over a verdict that predates the instance', () => {
+    const latest = { status: 'failed', created_at: '2026-09-07 19:30:00' };
+    expect(verdictRecordedSince(latest, queuedAt)).toBe(false);
+  });
+
+  it('re-runs over a dead earlier attempt and with no row at all', () => {
+    for (const status of ['running', 'error']) {
+      const latest = { status, created_at: '2026-09-07 20:02:27' };
+      expect(verdictRecordedSince(latest, queuedAt)).toBe(false);
+    }
+    expect(verdictRecordedSince(null, queuedAt)).toBe(false);
   });
 });
 

--- a/src/domain/verification.ts
+++ b/src/domain/verification.ts
@@ -25,6 +25,28 @@ export function verificationSkipReason(
   return null;
 }
 
+// Clock tolerance between the Workflows engine's instance timestamp and the
+// database's row timestamps.
+const INSTANCE_CLOCK_SKEW_MS = 60_000;
+
+// A Workflows step callback can execute more than once: the engine re-runs
+// it when an attempt ends in an internal error, even after the callback's
+// own work finished (live finding: verify-6's first attempt recorded a full
+// failed verdict and dispatched the fix, then died with "Attempt failed due
+// to internal workflows error" and was re-executed at once — a second
+// verification of a checkout that predated the fix already in flight). A
+// terminal verdict recorded since this instance was queued is this
+// instance's verdict, so the re-run has nothing to add. A 'running' or
+// 'error' row is a dead earlier attempt: re-running is the intended
+// recovery (the fresh row supersedes it).
+export function verdictRecordedSince(
+  latest: { status: string; created_at: string } | null,
+  instanceQueuedAt: number,
+): boolean {
+  if (!latest || (latest.status !== 'passed' && latest.status !== 'failed')) return false;
+  return parseUtc(latest.created_at) >= instanceQueuedAt - INSTANCE_CLOCK_SKEW_MS;
+}
+
 export interface CriterionResult {
   index: number;
   verdict: 'pass' | 'fail' | 'skip';

--- a/src/http/webhooks.worker.test.ts
+++ b/src/http/webhooks.worker.test.ts
@@ -11,8 +11,10 @@ import {
   createFeature,
   countBudgetedFixAttempts,
   createFactoryRunWithStage,
+  createVerification,
   ensureBuiltinAgents,
   finishFixAttempt,
+  finishVerification,
   getChangeByProviderKey,
   getFactoryRun,
   getFeature,
@@ -590,6 +592,86 @@ describe('composable feature delivery', () => {
     // Only a parked run can be retried.
     await expect(resumeFailedStage(created.run.id, 'nico', enqueue)).resolves.toMatchObject({
       kind: 'rejected',
+    });
+  });
+
+  it('hands a repair scheduled after a failed verify the unmet criteria', async () => {
+    await seedRepo();
+    await ensureBuiltinAgents(1001);
+    const featureId = await createFeature(101, 'Model picker', 'Add a model select', [
+      'Users can pick a runner model',
+    ]);
+    const change = await upsertChange({
+      repositoryId: 101,
+      providerKey: 'github:95',
+      number: 95,
+      origin: 'factory',
+      title: 'Model picker',
+      externalUrl: 'https://github.com/acme/api/pull/95',
+      sourceBranch: 'turbodiff/feature-95',
+      targetBranch: 'main',
+      status: 'open',
+      sourceHead: 'a'.repeat(40),
+      targetHead: 'b'.repeat(40),
+      draft: false,
+      capabilities: ['read_change', 'publish_review', 'write_head', 'merge'],
+    });
+    await updateFeature(featureId, { status: 'pr_opened', prNumber: 95, changeId: change.id });
+    const created = await createFactoryRunWithStage({
+      repositoryId: 101,
+      changeId: change.id,
+      profileKey: 'full_delivery',
+      startStage: 'verify',
+      stopAfterStage: 'merge',
+      policySnapshot: { key: 'full_delivery' },
+      trigger: 'test',
+      eventKind: 'human.resume_requested',
+      decision: { kind: 'schedule', stage: 'verify' },
+      idempotencyKey: `verify-findings:${featureId}`,
+      stageInput: { featureId },
+    });
+    const queued: FactoryMessage[] = [];
+    const enqueue = async (message: FactoryMessage) => void queued.push(message);
+    const dispatch: ReviewDispatcher = async () => true;
+    const verify: RunStageCommand = {
+      kind: 'run_stage',
+      factoryRunId: created.run.id,
+      stageRunId: created.stageRun!.id,
+      stage: 'verify',
+      idempotencyKey: created.stageRun!.idempotency_key,
+      changeId: change.id,
+    };
+    await runLifecycleStage(verify, dispatch, { enqueue });
+    // The verifier records the verdict; under the lifecycle it dispatches no
+    // fix of its own, so the coordinator's repair must carry the findings.
+    const verificationId = await createVerification(featureId);
+    await finishVerification(verificationId, 'failed', {
+      results: [{ index: 0, verdict: 'fail', note: 'the automation form has no model select' }],
+    });
+    queued.length = 0;
+    await completeLifecycleStage(
+      verify.stageRunId,
+      'verify',
+      true,
+      { kind: 'verification_completed', status: 'failed' },
+      { verificationPassed: false },
+      enqueue,
+    );
+    const [repair] = stageCommands(queued);
+    expect(repair.stage).toBe('repair');
+    queued.length = 0;
+    await runLifecycleStage(repair, dispatch, { enqueue });
+    const fix = queued.find((message) => message.kind === 'fix');
+    expect(fix).toMatchObject({
+      trigger: 'lifecycle_repair',
+      stageRunId: repair.stageRunId,
+      findings: expect.stringContaining('Users can pick a runner model'),
+    });
+    expect(fix).toMatchObject({
+      findings: expect.stringContaining('the automation form has no model select'),
+    });
+    await expect(getStageRun(repair.stageRunId)).resolves.toMatchObject({
+      output: { kind: 'repair_enqueued', source: 'verification' },
     });
   });
 

--- a/src/services/lifecycle.ts
+++ b/src/services/lifecycle.ts
@@ -16,6 +16,7 @@ import {
   getStageRun,
   headHasCompletedReview,
   latestAcceptanceContractForChange,
+  latestVerificationForFeature,
   listCrChecks,
   listStageRuns,
   markReviewFailed,
@@ -28,6 +29,7 @@ import {
 } from '../data/db.ts';
 import { decideLifecycle, type LifecycleContext } from '../domain/lifecycle-coordinator.ts';
 import { canResumeLifecycleRun } from '../domain/lifecycle-resume.ts';
+import { formatUnmetCriteriaFindings } from '../domain/verification.ts';
 import { isDeliveryProcessProfile, processProfile } from '../domain/process-profiles.ts';
 import type {
   LifecycleDecision,
@@ -46,6 +48,7 @@ import {
 import { parseUtc } from '../shared/time.ts';
 import {
   FIX_MAX_ATTEMPTS,
+  type FixQueueMessage,
   type GenerateQueueMessage,
   type VerifyQueueMessage,
 } from '../shared/factory-messages.ts';
@@ -624,6 +627,27 @@ export async function completeLifecycleStage(
   await coordinateStageOutcome(command, success, enqueue, outcomeFacts);
 }
 
+// The work order for a repair scheduled after a failed verify stage. Without
+// it the fixer falls back to the latest blocking review — which, after a
+// clean review, is nothing — so the unmet criteria only ever reached a fixer
+// through the verifier's own dispatch, racing the coordinator's repair for
+// the PR's single-flight slot. Repairs scheduled after a blocking review keep
+// that review fallback: the verdict here is only consulted when the stage
+// this repair follows is a verify.
+async function unmetCriteriaRepairFindings(
+  runId: number,
+  feature: { id: number; acceptance: string[] | null },
+): Promise<string | undefined> {
+  const stages = await listStageRuns(runId);
+  const preceding = stages
+    .filter((stage) => stage.status === 'completed' && stage.stage !== 'repair')
+    .at(-1);
+  if (preceding?.stage !== 'verify') return undefined;
+  const verification = await latestVerificationForFeature(feature.id);
+  if (verification?.status !== 'failed' || !verification.results) return undefined;
+  return formatUnmetCriteriaFindings(feature.acceptance ?? [], verification.results) || undefined;
+}
+
 export async function runLifecycleStage(
   command: RunStageCommand,
   dispatchReview: ReviewDispatcher,
@@ -702,7 +726,8 @@ export async function runLifecycleStage(
     return;
   }
   if (stageRun.stage === 'repair') {
-    await enqueue({
+    const findings = feature ? await unmetCriteriaRepairFindings(run.id, feature) : undefined;
+    const fix: FixQueueMessage = {
       kind: 'fix',
       repoId: repo.id,
       prNumber: change.number,
@@ -710,8 +735,13 @@ export async function runLifecycleStage(
       factoryRunId: run.id,
       stageRunId: stageRun.id,
       changeId: change.id,
+    };
+    if (findings) fix.findings = findings;
+    await enqueue(fix);
+    await recordStageRunOutput(stageRun.id, {
+      kind: 'repair_enqueued',
+      source: findings ? 'verification' : 'review',
     });
-    await recordStageRunOutput(stageRun.id, { kind: 'repair_enqueued' });
     return;
   }
   if (stageRun.stage === 'verify') {


### PR DESCRIPTION
## What happened on feature 6 (TD-0006, PR #150)

One failed verdict produced **two full verifications and two fixes**, then the run parked with `another repair is already running`. Not the review↔repair loop from #148 (that budget held); two other mechanisms:

1. **The Workflows engine re-executed the `run verification` step.** `wrangler workflows instances describe verify-6-1788811342320` shows attempt 1 (20:02–20:13 UTC) ending in `WorkflowInternalError: Attempt failed due to internal workflows error` *after* it had recorded verification 8 (failed on the premortem) and dispatched fix 11. Attempt 2 started the same second and ran verification 9 ($4.52) on a checkout that predated fix 11's commit, while fix 11's own re-verify was skipped as "in flight".
2. **Two fix paths raced for the PR.** Under the lifecycle the verifier still enqueued its legacy `verification_failed` fix, and the coordinator scheduled a `repair` stage for the same verdict. The lifecycle repair carried no findings (the fixer's fallback is the latest *blocking review*, which was clean), lost the single-flight slot, and the run went to `awaiting_human`. The legacy fix 12 then ran against already-fixed code: `no_changes`.

## Changes

- `verdictRecordedSince` (domain): a terminal verification recorded since the instance was queued is that instance's verdict; the step reuses it instead of re-running. Dead `running`/`error` rows still re-run (existing recovery).
- `runVerification({ lifecycleOwned })`: lifecycle verify stages no longer dispatch the verifier's own fix; the criteria-conflict guard is unchanged.
- Lifecycle `repair` scheduled after a failed `verify` now carries `formatUnmetCriteriaFindings(...)` (premortem row included); repairs after a blocking review keep the review fallback. Stage output records `source: 'verification' | 'review'`.

## Tests

- `verdictRecordedSince` unit cases (terminal/skew/predates/dead attempt).
- Worker test: verify fails → repair command → fix message carries the criterion text and evidence; stage output `repair_enqueued/verification`.
- Verified locally: `vp test` 249 passed, `vp test --config vitest.worker.config.ts` 194 passed, `tsc` ×3 clean, `vp lint` no errors.

## Not covered

- The engine-side internal error itself (platform). The retry delay of 5 minutes was not honoured for it.
- A lifecycle repair that ends `no_changes` still fails the stage and pauses the run; feature 6's parked run will need a re-verify rather than a resume of the repair.
- `fixLabel('lifecycle_repair')` still says "review findings" in the commit message even when the work order is unmet criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
