### PR TITLE
fix(review): drop drizzle schema snapshots from review diffs, size the diff cap to the review model

### DIFF
--- a/src/ai/tools/github.ts
+++ b/src/ai/tools/github.ts
@@ -33,7 +33,13 @@ export function assertPinned(pin: RepoPin, owner: string, repo: string): void {
   }
 }
 
-export const MAX_DIFF_CHARS = 300_000;
+// Sized for the smallest review model in service: cloudflare/@cf/zai-org/
+// glm-4.7-flash has a 131,072-token window, dense JSON/code tokenizes at
+// about 3 chars per token, and a re-review after a push lands in the SAME
+// agent conversation as the first review — so two full fetches plus the
+// system prompt and tool traffic must fit. 300k chars did not (feature 7:
+// "estimated input and maximum output tokens (152525) exceeded ... 131072").
+export const MAX_DIFF_CHARS = 120_000;
 export const MAX_FILE_CHARS = 60_000;
 
 // Every GitHub call authenticates as the App installation that owns the repo.

--- a/src/client/pages/feature.tsx
+++ b/src/client/pages/feature.tsx
@@ -175,14 +175,18 @@ function stationsFor(data: ApiFeatureDetail): Station[] {
     ?.stages.filter((stage) => stage.stage === 'review')
     .at(-1);
   const build: Station = { label: 'Build', verdict: 'GO', tone: 'go' };
+  // A failed review stage outranks earlier rounds' verdicts: after a repair
+  // the re-review is the one that gates the run, and its failure parks the
+  // lifecycle — the lamp read GO off round one while the run sat awaiting a
+  // human (feature 7).
   const review: Station =
-    data.reviews.length === 0
-      ? lastReviewStage?.status === 'failed'
-        ? { label: 'Review', verdict: 'FAILED', tone: 'abort' }
-        : { label: 'Review', verdict: 'POLLING', tone: 'hold', pulse: true }
-      : blocking
-        ? { label: 'Review', verdict: 'NO-GO', tone: 'abort' }
-        : { label: 'Review', verdict: 'GO', tone: 'go' };
+    lastReviewStage?.status === 'failed'
+      ? { label: 'Review', verdict: 'FAILED', tone: 'abort' }
+      : data.reviews.length === 0
+        ? { label: 'Review', verdict: 'POLLING', tone: 'hold', pulse: true }
+        : blocking
+          ? { label: 'Review', verdict: 'NO-GO', tone: 'abort' }
+          : { label: 'Review', verdict: 'GO', tone: 'go' };
   const verify = verifyStation(v, merged);
   const ship: Station = merged
     ? { label: 'Ship', verdict: 'MERGED', tone: 'go' }
@@ -318,7 +322,14 @@ function LifecycleHistory({
   return (
     <>
       <SectionHeading>Factory lifecycle</SectionHeading>
-      <Accordion type="multiple">
+      {/* A run that needs a human opens expanded: the failed stage, its
+          reason, and the retry control must not sit behind a collapsed row. */}
+      <Accordion
+        type="multiple"
+        defaultValue={runs
+          .filter((run) => run.status === 'awaiting_human' || run.status === 'failed')
+          .map((run) => String(run.id))}
+      >
         {runs.map((run) => (
           <AccordionItem key={run.id} value={String(run.id)}>
             <AccordionTrigger

--- a/src/domain/review-diff.test.ts
+++ b/src/domain/review-diff.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { REVIEW_NOISE_PATTERNS, splitDiffSegments } from './review-diff.ts';
+
+const noiseReason = (path: string) =>
+  REVIEW_NOISE_PATTERNS.find((n) => n.pattern.test(path))?.reason ?? null;
+
+describe('REVIEW_NOISE_PATTERNS', () => {
+  it('treats a drizzle schema snapshot as noise but not the migration beside it', () => {
+    expect(noiseReason('db/migrations/meta/0015_snapshot.json')).toBe('drizzle schema snapshot');
+    expect(noiseReason('drizzle/meta/0000_snapshot.json')).toBe('drizzle schema snapshot');
+    expect(noiseReason('db/migrations/0015_fable-5-1.sql')).toBeNull();
+    expect(noiseReason('db/migrations/meta/_journal.json')).toBeNull();
+    expect(noiseReason('src/snapshot.json')).toBeNull();
+  });
+
+  it('keeps matching the lockfile, minified and source-map families', () => {
+    expect(noiseReason('pnpm-lock.yaml')).toBe('lockfile');
+    expect(noiseReason('packages/web/package-lock.json')).toBe('lockfile');
+    expect(noiseReason('public/app.min.js')).toBe('minified asset');
+    expect(noiseReason('public/app.js.map')).toBe('source map');
+    expect(noiseReason('src/app.ts')).toBeNull();
+  });
+});
+
+describe('splitDiffSegments', () => {
+  it('splits a unified diff into per-file segments keyed by the b-side path', () => {
+    const diff =
+      'diff --git a/src/a.ts b/src/a.ts\n--- a/src/a.ts\n+++ b/src/a.ts\n@@ -1 +1 @@\n-x\n+y\n' +
+      'diff --git "a/sp ace.ts" "b/sp ace.ts"\n--- "a/sp ace.ts"\n+++ "b/sp ace.ts"\n@@ -1 +1 @@\n-1\n+2\n';
+    expect(splitDiffSegments(diff).map((s) => s.path)).toEqual(['src/a.ts', 'sp ace.ts']);
+  });
+});

--- a/src/domain/review-diff.ts
+++ b/src/domain/review-diff.ts
@@ -7,6 +7,12 @@ export const REVIEW_NOISE_PATTERNS: { pattern: RegExp; reason: string }[] = [
   },
   { pattern: /\.min\.(js|css)$/, reason: 'minified asset' },
   { pattern: /\.map$/, reason: 'source map' },
+  // drizzle-kit writes a full schema snapshot (thousands of lines of JSON)
+  // beside every migration; the .sql next to it is what changes the schema
+  // and gets reviewed. The generated-marker heuristic in ai/tools/github.ts
+  // exempts migration paths on purpose, so the snapshot needs its own entry:
+  // one snapshot alone overflowed a 131k-token review model (feature 7).
+  { pattern: /(^|\/)meta\/\d{4}_snapshot\.json$/, reason: 'drizzle schema snapshot' },
 ];
 
 export interface DiffSegment {

--- a/src/services/lifecycle.ts
+++ b/src/services/lifecycle.ts
@@ -478,10 +478,18 @@ async function settleReviewStage(
   };
   if (stageRun.change_id !== null) command.changeId = stageRun.change_id;
   if (progress.completed === 0) {
-    // The first recorded reason rides on the stage error — that's what the
-    // lifecycle panel shows.
-    const why = progress.errors[0] ? `: ${progress.errors[0]}` : '';
-    await finishStageRun(stageRun.id, 'failed', output, `all review dispatches failed${why}`);
+    // Every distinct reason rides on the stage error — that's what the
+    // lifecycle panel shows. The first one alone hid the cause on feature 7:
+    // "agent run ended without posting a review" led, and the AI binding's
+    // 413 that explained it came second.
+    const reasons = [...new Set(progress.errors.filter(Boolean))];
+    const why = reasons.length > 0 ? `: ${reasons.join(' · ')}` : '';
+    await finishStageRun(
+      stageRun.id,
+      'failed',
+      output,
+      `all review dispatches failed${why}`.slice(0, 1_000),
+    );
     await coordinateStageOutcome(command, false, enqueue);
     return;
   }


### PR DESCRIPTION
## What stuck feature 7 (TD-0007, PR #152)

A 13-line change parked in `awaiting_human` after review attempt 2 failed:

```
Cloudflare AI binding request failed with 413 Payload Too Large: The estimated number of
input and maximum output tokens (152525) exceeded this model context window limit (131072)
```

- The PR's drizzle migration ships `db/migrations/meta/0015_snapshot.json` (7,634 lines). The noise filter exempts migration paths from the `@generated` heuristic on purpose (migration SQL needs review), so the snapshot went to the model in full, truncated only at 300k chars.
- Review agents run on `cloudflare/@cf/zai-org/glm-4.7-flash` (131k window). Round one already lost the general `review` agent ("ended without posting a review"). The o11y finding triggered a repair; the re-review after the push runs in the **same agent conversation**, so the second full diff fetch overflowed the window.

Not caused by #151 (verification/repair findings); the repair here worked. Feature 6's PR #150 carried the same kind of snapshot and only survived because none of its agents needed a second round.

## Changes

- `REVIEW_NOISE_PATTERNS` gains `meta/NNNN_snapshot.json` (drizzle's snapshot, both `drizzle/meta` and `db/migrations/meta` layouts). The `.sql` and `_journal.json` beside it are still reviewed. The risk-tier sizing uses the same list, so a snapshot no longer inflates a trivial PR to `full`.
- `MAX_DIFF_CHARS` 300k → 120k, sized so two fetches plus prompt and tool traffic fit the smallest review model.

## Tests

- New `src/domain/review-diff.test.ts`: snapshot vs migration/journal classification, existing families, `splitDiffSegments`.
- `vp test` 252 passed; `tsc` ×3 clean; `vp lint` no errors.

## Follow-ups not in this PR

- A re-review appending a second full diff to the same conversation is still wasteful; the push delta could drive `fetch_pr` to return only the changed segments.
- `review` agent runs that end without `post_review` are recorded with no error detail, which hid round one's failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
