### PR TITLE
fix(factory): free the cache ref for the verifier, fail an errored verify stage, resume a failed repair as its check

### DIFF
--- a/src/ai/runtime/repository-workspace.ts
+++ b/src/ai/runtime/repository-workspace.ts
@@ -45,16 +45,27 @@ export async function prepareCachedWorktree({
 }: PrepareCachedWorktreeOptions): Promise<void> {
   const scrub = (s: string) => redactSecrets(s, [remote.token, ...secrets]);
   const git = `git ${remote.configFlags}`;
+  // The branchless path fetches straight into refs/heads/$BASE_REF, which git
+  // refuses while that ref is the cache's checked-out branch — and a cold
+  // bootstrap leaves exactly that checked out (clone --branch). Live finding:
+  // the first verification after a container rollout bootstrapped the cache
+  // on the PR branch, and the re-verification after the repair died with
+  // "Refusing to fetch into current branch". The cache's HEAD is detached
+  // before the fetch and after the bootstrap, so the ref is always free.
+  const detach = `git -C ${cacheDir} checkout -q --detach && `;
   const warmFetch = branch
     ? `${git} -C ${cacheDir} fetch --depth 50 "${remote.authUrl}" "$BASE_REF" && ` +
       `git -C ${cacheDir} checkout -q -B "$BASE_REF" FETCH_HEAD; `
-    : `${git} -C ${cacheDir} fetch --depth 50 "${remote.authUrl}" "+refs/heads/$BASE_REF:refs/heads/$BASE_REF"; `;
+    : detach +
+      `${git} -C ${cacheDir} fetch --depth 50 "${remote.authUrl}" "+refs/heads/$BASE_REF:refs/heads/$BASE_REF"; `;
   const sync = await sandbox.exec(
     `if [ -d ${cacheDir}/.git ]; then ` +
       warmFetch +
       `else ${git} clone --depth 50 --single-branch --branch "$BASE_REF" ` +
       `"${remote.authUrl}" ${cacheDir} && ` +
-      `git -C ${cacheDir} remote set-url origin "${remote.cleanUrl}"; fi`,
+      `git -C ${cacheDir} remote set-url origin "${remote.cleanUrl}"` +
+      (branch ? '' : ` && git -C ${cacheDir} checkout -q --detach`) +
+      `; fi`,
     { env: { ...remote.env, BASE_REF: base }, timeout: 5 * 60_000 },
   );
   if (!sync.success) {

--- a/src/ai/workflows/verification.ts
+++ b/src/ai/workflows/verification.ts
@@ -1,7 +1,11 @@
 import { env, WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from 'cloudflare:workers';
 import { getFeature, latestVerificationForFeature } from '../../data/db.ts';
 import { runVerification } from '../runners/verifier.ts';
-import { verdictRecordedSince, verificationSkipReason } from '../../domain/verification.ts';
+import {
+  verdictRecordedSince,
+  verificationSkipReason,
+  verifyStageOutcome,
+} from '../../domain/verification.ts';
 import { notifyFeatureLive } from '../../services/live-updates.ts';
 import { completeLifecycleStage } from '../../services/lifecycle.ts';
 import type { VerifyQueueMessage } from '../../shared/factory-messages.ts';
@@ -52,13 +56,13 @@ export class VerificationWorkflow extends WorkflowEntrypoint<unknown, Verificati
       if (stageRunId) {
         await step.do('settle lifecycle verification', async () => {
           const result = await latestVerificationForFeature(featureId);
-          const passed = result?.status === 'passed';
+          const outcome = verifyStageOutcome(result?.status);
           await completeLifecycleStage(
             stageRunId,
             'verify',
-            result !== null,
+            outcome.success,
             { kind: 'verification_completed', featureId, status: result?.status ?? 'missing' },
-            { verificationPassed: passed },
+            outcome.facts,
           );
         });
       }

--- a/src/client/pages/feature.tsx
+++ b/src/client/pages/feature.tsx
@@ -22,7 +22,11 @@ import type {
   ApiMe,
   ApiVerificationSummary,
 } from '../../shared/api-types.ts';
-import { canResumeLifecycleRun, isRepairBudgetPause } from '../../domain/lifecycle-resume.ts';
+import {
+  canResumeLifecycleRun,
+  isRepairBudgetPause,
+  resumeTargetStage,
+} from '../../domain/lifecycle-resume.ts';
 import { api, ApiError } from '../lib/api.ts';
 import { useDictation } from '../lib/dictation.ts';
 import { sentence } from '../lib/format.ts';
@@ -386,7 +390,7 @@ function LifecycleHistory({
                   >
                     {isRepairBudgetPause(run, run.stages.at(-1))
                       ? 'Resume checks'
-                      : `Retry ${sentence(run.stages.at(-1)?.stage ?? 'stage')}`}
+                      : `Retry ${sentence(resumeTargetStage(run.stages)?.stage ?? 'stage')}`}
                   </Button>
                   {isRepairBudgetPause(run, run.stages.at(-1)) ? (
                     <p className="mt-2 text-xs text-mute">

--- a/src/domain/lifecycle-resume.test.ts
+++ b/src/domain/lifecycle-resume.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vite-plus/test';
 import {
   canResumeLifecycleRun,
+  resumeTargetStage,
   REVIEW_REPAIR_EXHAUSTED,
   VERIFY_REPAIR_EXHAUSTED,
 } from './lifecycle-resume.ts';
@@ -58,5 +59,39 @@ describe('lifecycle resume eligibility shared by the service and UI', () => {
         { stage: 'review', status: 'queued' },
       ),
     ).toBe(false);
+  });
+});
+
+describe('resumeTargetStage', () => {
+  const done = (stage: string) => ({ stage, status: 'completed' });
+
+  it('resumes a failed repair as the check it was repairing for', () => {
+    const stages = [
+      done('implement'),
+      done('review'),
+      done('verify'),
+      { stage: 'repair', status: 'failed' },
+    ];
+    expect(resumeTargetStage(stages)).toBe(stages[2]);
+    const afterReview = [
+      done('review'),
+      done('repair'),
+      done('review'),
+      { stage: 'repair', status: 'failed' },
+    ];
+    expect(resumeTargetStage(afterReview)).toBe(afterReview[2]);
+  });
+
+  it('retries any other failed stage as itself', () => {
+    const stages = [done('implement'), { stage: 'review', status: 'failed' }];
+    expect(resumeTargetStage(stages)).toBe(stages[1]);
+    const verify = [done('review'), { stage: 'verify', status: 'failed' }];
+    expect(resumeTargetStage(verify)).toBe(verify[1]);
+  });
+
+  it('falls back to the repair itself when no check precedes it, and to nothing on an empty run', () => {
+    const stages = [{ stage: 'repair', status: 'failed' }];
+    expect(resumeTargetStage(stages)).toBe(stages[0]);
+    expect(resumeTargetStage([])).toBeUndefined();
   });
 });

--- a/src/domain/lifecycle-resume.ts
+++ b/src/domain/lifecycle-resume.ts
@@ -34,3 +34,22 @@ export function canResumeLifecycleRun(
     (latest?.status === 'failed' || isRepairBudgetPause(run, latest))
   );
 }
+
+// The stage a resume schedules. A failed repair is not retried as a repair:
+// the fixer already found nothing to do or the budget is spent, and what
+// the human did in the meantime (a manual fix, a config change, an
+// infrastructure fix) is proven by re-running the check the repair was
+// scheduled for — the last completed review or verify before it. Live
+// finding: a run parked on its third, empty repair offered only "Retry
+// repair", which could only fail on the exhausted budget.
+export function resumeTargetStage<S extends ResumableStage>(stages: readonly S[]): S | undefined {
+  const latest = stages.at(-1);
+  if (!latest || latest.stage !== 'repair' || latest.status !== 'failed') return latest;
+  for (let i = stages.length - 2; i >= 0; i--) {
+    const stage = stages[i];
+    if ((stage.stage === 'review' || stage.stage === 'verify') && stage.status === 'completed') {
+      return stage;
+    }
+  }
+  return latest;
+}

--- a/src/domain/verification.test.ts
+++ b/src/domain/verification.test.ts
@@ -5,6 +5,7 @@ import {
   PREMORTEM_CRITERION,
   verdictRecordedSince,
   verificationSkipReason,
+  verifyStageOutcome,
 } from './verification.ts';
 
 describe('verificationSkipReason', () => {
@@ -130,5 +131,24 @@ describe('formatUnmetCriteriaFindings', () => {
     expect(findings).toContain(`not met: ${PREMORTEM_CRITERION}`);
     expect(findings).toContain('Evidence: Surviving mechanism: X');
     expect(findings).not.toContain('undefined');
+  });
+});
+
+describe('verifyStageOutcome', () => {
+  it('completes the stage on a verdict and carries it as a fact', () => {
+    expect(verifyStageOutcome('passed')).toEqual({
+      success: true,
+      facts: { verificationPassed: true },
+    });
+    expect(verifyStageOutcome('failed')).toEqual({
+      success: true,
+      facts: { verificationPassed: false },
+    });
+  });
+
+  it('fails the stage without a verdict fact when the run errored or never recorded', () => {
+    for (const status of ['error', 'running', null, undefined]) {
+      expect(verifyStageOutcome(status)).toEqual({ success: false, facts: {} });
+    }
   });
 });

--- a/src/domain/verification.ts
+++ b/src/domain/verification.ts
@@ -47,6 +47,24 @@ export function verdictRecordedSince(
   return parseUtc(latest.created_at) >= instanceQueuedAt - INSTANCE_CLOCK_SKEW_MS;
 }
 
+// The lifecycle outcome of a verify stage, from the verification it ran.
+// Only a verdict completes the stage; an 'error' (sandbox, git, agent crash)
+// or a missing row fails it, so the coordinator parks the run for a retry of
+// verify instead of spending a repair on a verdict that was never reached.
+// Live finding: a cache-sync error read as "verification failed" scheduled
+// the last repair in the budget, which found nothing to fix, and the run
+// parked on a failed repair with no way back to verify.
+export interface VerifyStageOutcome {
+  success: boolean;
+  facts: { verificationPassed?: boolean };
+}
+export function verifyStageOutcome(status: string | null | undefined): VerifyStageOutcome {
+  if (status === 'passed' || status === 'failed') {
+    return { success: true, facts: { verificationPassed: status === 'passed' } };
+  }
+  return { success: false, facts: {} };
+}
+
 export interface CriterionResult {
   index: number;
   verdict: 'pass' | 'fail' | 'skip';

--- a/src/http/webhooks.worker.test.ts
+++ b/src/http/webhooks.worker.test.ts
@@ -673,6 +673,24 @@ describe('composable feature delivery', () => {
     await expect(getStageRun(repair.stageRunId)).resolves.toMatchObject({
       output: { kind: 'repair_enqueued', source: 'verification' },
     });
+
+    // The repair finds nothing to change and fails; resuming re-runs the
+    // verify it was scheduled for rather than another repair.
+    queued.length = 0;
+    await completeLifecycleRepair(repair.stageRunId, false, { kind: 'no_changes' }, enqueue);
+    await expect(getFactoryRun(created.run.id)).resolves.toMatchObject({
+      status: 'awaiting_human',
+    });
+    expect(await resumeFailedStage(created.run.id, 'nico', enqueue)).toMatchObject({
+      kind: 'scheduled',
+      stage: 'verify',
+    });
+    expect(stageCommands(queued).map((command) => command.stage)).toEqual(['verify']);
+    await expect(listStageRuns(created.run.id)).resolves.toMatchObject([
+      { stage: 'verify', status: 'completed', attempt: 1 },
+      { stage: 'repair', status: 'failed', attempt: 1 },
+      { stage: 'verify', status: 'queued', attempt: 2 },
+    ]);
   });
 
   it.each(['review', 'verify'] as const)(

--- a/src/services/lifecycle.ts
+++ b/src/services/lifecycle.ts
@@ -28,7 +28,7 @@ import {
   type StageRunRow,
 } from '../data/db.ts';
 import { decideLifecycle, type LifecycleContext } from '../domain/lifecycle-coordinator.ts';
-import { canResumeLifecycleRun } from '../domain/lifecycle-resume.ts';
+import { canResumeLifecycleRun, resumeTargetStage } from '../domain/lifecycle-resume.ts';
 import { formatUnmetCriteriaFindings } from '../domain/verification.ts';
 import { isDeliveryProcessProfile, processProfile } from '../domain/process-profiles.ts';
 import type {
@@ -547,21 +547,24 @@ export async function resumeFailedStage(
       reason: `run is ${run.status.replaceAll('_', ' ')}, not waiting on a human`,
     };
   }
-  const latest = (await listStageRuns(run.id)).at(-1);
+  const stages = await listStageRuns(run.id);
+  const latest = stages.at(-1);
   if (!latest || !canResumeLifecycleRun(run, latest)) {
     return { kind: 'rejected', reason: 'the latest stage is not available to resume' };
   }
+  // A failed repair resumes as the check it was repairing for.
+  const target = resumeTargetStage(stages) ?? latest;
   const repo = await getRepoById(run.repository_id);
   if (!repo) return { kind: 'rejected', reason: 'repository missing' };
-  const changeId = latest.change_id ?? run.change_id;
+  const changeId = target.change_id ?? latest.change_id ?? run.change_id;
   const change = changeId ? await getChange(changeId) : null;
-  const featureId = featureIdFromInput(latest.input);
+  const featureId = featureIdFromInput(target.input ?? latest.input);
   const feature = featureId ? await getFeature(featureId) : null;
   const acceptanceContract = change ? await latestAcceptanceContractForChange(change.id) : null;
   const decision = decideLifecycle(run.profile_key, {
     event: 'human.resume_requested',
     origin: change?.origin ?? (feature ? 'factory' : 'imported'),
-    startStage: latest.stage,
+    startStage: target.stage,
     stopAfterStage: run.stop_after_stage,
     capabilities: change?.capabilities,
     facts: {
@@ -583,7 +586,7 @@ export async function resumeFailedStage(
     { stageRunId: latest.id, actor },
     decision,
     `resume:${run.id}:${latest.id}`,
-    latest.input ?? undefined,
+    target.input ?? latest.input ?? undefined,
   );
   if (!next) return { kind: 'rejected', reason: 'this stage was already retried' };
   await resumeFactoryRun(run.id);


### PR DESCRIPTION
## What feature 7's second cycle exposed (run 51, after #153 unblocked the review)

After the retried review passed, verify 1 failed only on the premortem (a real finding), repair 2 fixed it, review 4 passed, and then:

1. **Verify 2 errored in 12 s**: `repo cache sync failed: fatal: Refusing to fetch into current branch refs/heads/turbodiff/feat-7-... of non-bare repository`. The first verification after the 07:51 container rollout had bootstrapped the shared repo cache with `clone --branch <PR branch>`, leaving that branch checked out; the branchless warm path then tried to fetch into that same ref. The cache is also `rm -rf`'d on failure, so the pattern alternates: bootstrap works, the next sync fails.
2. **The error was read as a failed verdict.** The verify stage settled `success=true, verificationPassed=false` for status `error`, so the coordinator scheduled repair 3 with no findings; the fixer found nothing to change ($0.44) and the stage failed.
3. **The run parked with only "Retry repair"**, which can only fail on the exhausted 3-attempt budget. Feature 7 had no way back to verify from the UI.

## Changes

- `prepareCachedWorktree`: branchless path detaches the cache HEAD before the fetch and after a cold bootstrap. (`src/ai/runtime/repository-workspace.ts`)
- `verifyStageOutcome` (domain): only `passed`/`failed` complete the verify stage and carry the `verificationPassed` fact; `error`/missing fail the stage, which the coordinator turns into a retryable pause with no repair spent.
- `resumeTargetStage` (domain): a resume after a **failed repair** schedules the last completed review/verify before it. Used by `resumeFailedStage` and by the cockpit button label ("Retry Verify").

## Tests

- Unit: `verifyStageOutcome` cases; `resumeTargetStage` (after verify, after review, other failed stages, empty run).
- Worker: the existing verify→repair findings test now continues: repair fails with `no_changes` → run parks → resume schedules **verify** attempt 2, not a repair.
- Locally: `vp test` 257 passed; webhooks + fixer worker files 43 passed; `tsc` ×3 clean; `vp lint` no errors. Full worker suite running as this PR opens.

## Not verified here

- The git detach against a real sandbox; it's a one-line shell change guarded by the same failure path that already drops a wedged cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
