### PR TITLE
remove(verifier): drop the premortem gate

### DIFF
--- a/src/ai/runners/verifier.ts
+++ b/src/ai/runners/verifier.ts
@@ -32,11 +32,7 @@ import { CR_BOT_AUTHOR, maybeAutoMergeCr } from '../../services/change-requests.
 import { enqueueFactoryMessage } from '../../services/factory-queue.ts';
 import { certificateUrl } from '../../services/certificates.ts';
 import { cockpitFeatureUrl } from '../../services/urls.ts';
-import {
-  formatUnmetCriteriaFindings,
-  PREMORTEM_CRITERION,
-  type CriterionResult,
-} from '../../domain/verification.ts';
+import { formatUnmetCriteriaFindings, type CriterionResult } from '../../domain/verification.ts';
 import { parseUtc } from '../../shared/time.ts';
 import { signArtifactKey } from '../../integrations/security/crypto.ts';
 import { resolveRunnerAuth, runnerEnvironment, type RunnerAuth } from '../runtime/runner-auth.ts';
@@ -73,14 +69,6 @@ const AGENT_TIMEOUT_MS = 20 * 60_000;
 // would silently revert what the human asked for, so the conflict guard
 // below halts for their decision instead.
 const HUMAN_FIX_TRIGGERS = new Set(['cockpit_comment', 'chat']);
-
-// The premortem is an independent adversarial pass gating the would-pass
-// outcome. Independence is the point: the acceptance criteria descend from
-// the implementation plan, so grading them can only confirm the plan's own
-// causal theory, never test it. A fresh agent process that has seen neither
-// the diff, the author's reasoning, nor the criteria must form its own theory
-// of the reported behavior and try to make it survive the branch.
-const PREMORTEM_TIMEOUT_MS = 10 * 60_000;
 
 function verifyPrompt(feature: FeatureRow, repo: RepositoryRow, criteria: string[]): string {
   const OUT_DIR = outDir(feature.id);
@@ -211,78 +199,6 @@ ${criteria.map((c, i) => `${i}. ${c}`).join('\n')}
 `;
 }
 
-function premortemPrompt(feature: FeatureRow, repo: RepositoryRow): string {
-  const OUT_DIR = outDir(feature.id);
-  return `You are an adversarial pre-mortem agent for ${repo.owner}/${repo.name}. You are in a checkout of a pull-request branch that claims to resolve the work item below. You have deliberately NOT been shown the diff, the author's reasoning, or the acceptance criteria: form your own theory. You may read anything and run the app, but do NOT modify tracked files, commit, or push.
-
-Assume this message arrives tomorrow: "it's STILL happening." Your job is to
-find the mechanism that survives — the code path, race, timing window,
-environment difference, or overlooked writer of shared state that would
-reproduce the reported behavior even with this branch merged.
-
-## Work item
-### ${feature.title}
-
-${feature.spec}
-
-## Method
-1. From the description alone, list the distinct mechanisms that could produce
-   the behavior. Find at least two candidates — the first plausible mechanism
-   is where the original author most likely stopped looking.
-2. Where shared state is involved (a client cache, a store, a database row, an
-   event stream), enumerate EVERY code path that writes or invalidates it —
-   grep for them; do not stop at the ones near the obvious fix — and consider
-   each firing at the worst possible moment.
-3. Check each mechanism against the actual code on this branch and conclude:
-   fixed here, still possible, or undecidable in this sandbox. Cite file paths.
-
-## Output (write this file, creating ${OUT_DIR} first if needed)
-${OUT_DIR}/premortem.json:
-{"surviving_mechanism": "<one paragraph: the concrete mechanism and the files involved — or null if none survives>", "ruled_out": ["<mechanism>: <why it cannot survive this branch>", ...]}
-
-A null surviving_mechanism next to an empty ruled_out list is a failed
-premortem — show your search either way.
-
-${UNTRUSTED_CONTENT_RULES}
-`;
-}
-
-type PremortemOutcome = { mechanism: string | null; ruledOut: string[] };
-
-async function runPremortem(
-  sandbox: Sandbox,
-  auth: RunnerAuth,
-  feature: FeatureRow,
-  repo: RepositoryRow,
-  workDir: string,
-  scrub: (s: string) => string,
-): Promise<PremortemOutcome> {
-  const OUT = outDir(feature.id);
-  await sandbox.writeFile(`${OUT}/premortem-task.md`, premortemPrompt(feature, repo));
-  const run = await sandbox.exec(
-    `claude -p --dangerously-skip-permissions --output-format json < ${OUT}/premortem-task.md`,
-    { cwd: workDir, timeout: PREMORTEM_TIMEOUT_MS, env: runnerEnvironment(auth, NPM_CACHE_ENV) },
-  );
-  const text = claudeCliResultText(run.stdout);
-  // Rides the 'verify' run kind — the premortem is part of this verification,
-  // and agent_runs_kind_check is a closed list.
-  await persistAgentLog(
-    'verify',
-    scrub(`[premortem]\n${text}\n${run.stderr}`.trim()),
-    run.success,
-    {
-      featureId: feature.id,
-    },
-  );
-  if (!run.success) throw new Error(`premortem agent exited ${run.exitCode}`);
-  const parsed = parseJson((await sandbox.readFile(`${OUT}/premortem.json`)).content);
-  if (!isJsonObject(parsed)) throw new Error('premortem.json is not an object');
-  const mechanism = isString(parsed.surviving_mechanism) ? parsed.surviving_mechanism.trim() : '';
-  const ruledOut = isJsonArray(parsed.ruled_out) ? parsed.ruled_out.filter(isString) : [];
-  if (!mechanism && ruledOut.length === 0) throw new Error('premortem recorded no search');
-  return { mechanism: mechanism || null, ruledOut };
-}
-
 export async function runVerification(
   featureId: number,
   options: {
@@ -390,34 +306,8 @@ async function verify(
       );
     }
 
-    let results = await readResults(sandbox, OUT, criteria.length);
+    const results = await readResults(sandbox, OUT, criteria.length);
     const summary = await readText(sandbox, `${OUT}/summary.md`);
-
-    // Premortem gates only the would-pass outcome — a failing verification is
-    // already headed to the fix loop, so the extra run would add cost without
-    // changing the route. Its verdict joins the criteria/results pair, which
-    // carries it through the report, the CR check, auto-merge gating, and the
-    // fix loop (a surviving mechanism becomes the finding the fixer receives)
-    // without further plumbing. Best-effort: an errored premortem is logged
-    // and verification stands on the criteria alone.
-    if (results.every((r) => r.verdict !== 'fail')) {
-      try {
-        const premortem = await runPremortem(sandbox, auth, feature, repo, WORK, scrub);
-        criteria = [...criteria, PREMORTEM_CRITERION];
-        results = [
-          ...results,
-          {
-            index: criteria.length - 1,
-            verdict: premortem.mechanism ? 'fail' : 'pass',
-            note: premortem.mechanism
-              ? `Surviving mechanism: ${premortem.mechanism}`.slice(0, 2_000)
-              : `Ruled out — ${premortem.ruledOut.join('; ')}`.slice(0, 2_000),
-          },
-        ];
-      } catch (err) {
-        console.warn('turbodiff: premortem pass errored (verification stands on criteria):', err);
-      }
-    }
 
     const shots = await uploadScreenshots(sandbox, feature.id, results);
     const demo = repo.demo_videos ? await uploadDemo(sandbox, feature.id) : undefined;

--- a/src/domain/verification.test.ts
+++ b/src/domain/verification.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vite-plus/test';
 import {
   formatUnmetCriteriaFindings,
   gradedCriteria,
-  PREMORTEM_CRITERION,
   verdictRecordedSince,
   verificationSkipReason,
   verifyStageOutcome,
@@ -96,31 +95,23 @@ describe('gradedCriteria', () => {
     ]);
   });
 
-  it('re-derives the premortem row the verifier appended beyond the stored criteria', () => {
-    const premortem = { index: 2, verdict: 'fail', note: 'Surviving mechanism: …' } as const;
+  it('keeps rows a verification recorded beyond the stored criteria, labeled as retired', () => {
+    const appended = { index: 2, verdict: 'fail', note: 'Surviving mechanism: …' } as const;
     const rows = gradedCriteria(acceptance, [
       { index: 0, verdict: 'pass', note: 'ok' },
       { index: 1, verdict: 'pass', note: 'ok' },
-      premortem,
+      appended,
     ]);
     expect(rows).toHaveLength(3);
-    expect(rows[2]).toEqual({ text: PREMORTEM_CRITERION, result: premortem });
-  });
-
-  it('labels any further appended rows generically instead of as the premortem', () => {
-    const rows = gradedCriteria(
-      ['only'],
-      [
-        { index: 2, verdict: 'pass', note: 'extra' },
-        { index: 1, verdict: 'pass', note: 'premortem' },
-      ],
-    );
-    expect(rows.map((r) => r.text)).toEqual(['only', PREMORTEM_CRITERION, 'Verification check #3']);
+    expect(rows[2]).toEqual({ text: 'Verification check #3 (retired)', result: appended });
+    expect(
+      gradedCriteria(['only'], [{ index: 2, verdict: 'pass', note: 'x' }]).map((r) => r.text),
+    ).toEqual(['only', 'Verification check #3 (retired)']);
   });
 });
 
 describe('formatUnmetCriteriaFindings', () => {
-  it('names the premortem when it is the failing row', () => {
+  it('names a retired appended row when it is the failing one', () => {
     const findings = formatUnmetCriteriaFindings(
       ['stored criterion'],
       [
@@ -128,7 +119,7 @@ describe('formatUnmetCriteriaFindings', () => {
         { index: 1, verdict: 'fail', note: 'Surviving mechanism: X' },
       ],
     );
-    expect(findings).toContain(`not met: ${PREMORTEM_CRITERION}`);
+    expect(findings).toContain('not met: Verification check #2 (retired)');
     expect(findings).toContain('Evidence: Surviving mechanism: X');
     expect(findings).not.toContain('undefined');
   });

--- a/src/domain/verification.ts
+++ b/src/domain/verification.ts
@@ -72,21 +72,13 @@ export interface CriterionResult {
   screenshot?: string;
 }
 
-// The premortem is an independent adversarial pass the verifier appends to
-// the feature's acceptance criteria at run time (only when those would pass).
-// Its verdict is stored with the results at index N, but the feature row
-// keeps only the N human criteria — so every reader of (acceptance, results)
-// must re-derive the appended row from here or silently drop the one
-// criterion that failed (live finding: the cockpit showed N/N proven while
-// the PR comment said 1 not met).
-export const PREMORTEM_CRITERION =
-  'Premortem: an independent adversarial pass found no mechanism by which the reported behavior survives this change';
-
 // Every criterion a verification graded, in result order: the feature's
 // stored acceptance criteria (verdict null when the run recorded nothing for
-// them) followed by any run-time criterion the results carry beyond them.
-// The first appended row is the premortem; anything further is labeled
-// generically rather than mis-attributed.
+// them) followed by any row the results carry beyond them. Verifications
+// recorded before 2026-09-08 carry one such row from a since-removed
+// adversarial "premortem" pass (8 of 8 runs failed it, no feature ever
+// cleared it); readers must still show it rather than paint N/N proven
+// under a failed verdict.
 export function gradedCriteria(
   acceptance: string[],
   results: CriterionResult[],
@@ -99,13 +91,7 @@ export function gradedCriteria(
     .filter((r) => r.index >= acceptance.length)
     .sort((a, b) => a.index - b.index);
   for (const result of appended) {
-    rows.push({
-      text:
-        result.index === acceptance.length
-          ? PREMORTEM_CRITERION
-          : `Verification check #${result.index + 1}`,
-      result,
-    });
+    rows.push({ text: `Verification check #${result.index + 1} (retired)`, result });
   }
   return rows;
 }

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -1708,9 +1708,9 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
         caption: demo.caption ?? null,
       };
     }
-    // gradedCriteria re-derives the run-time premortem row the verifier
-    // appends beyond the stored criteria — zipping by index alone dropped the
-    // one failing row and painted N/N proven under a failed verdict.
+    // gradedCriteria keeps any result row beyond the stored criteria (older
+    // verifications carry one) — zipping by index alone dropped the one
+    // failing row and painted N/N proven under a failed verdict.
     base.criteria = await Promise.all(
       gradedCriteria(feature.acceptance ?? [], verification?.results ?? []).map(
         async ({ text, result: r }) => {

--- a/src/http/api.worker.test.ts
+++ b/src/http/api.worker.test.ts
@@ -7,7 +7,6 @@ import { testDatabase } from '../test/database-fixture.ts';
 import { Hono } from 'hono';
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import type { AuthedUser } from '../services/auth.ts';
-import { PREMORTEM_CRITERION } from '../domain/verification.ts';
 import type {
   ApiAutomationDetail,
   ApiBoard,
@@ -867,9 +866,9 @@ describe('verification stall display', () => {
     expect(row?.status).toBe('running');
   });
 
-  it('shows the premortem row the verifier appended beyond the stored criteria', async () => {
+  it('shows a row an older verification recorded beyond the stored criteria', async () => {
     // Feature 502 has one human criterion; its failed verification carries a
-    // second result at index 1 — the run-time premortem. The cockpit must
+    // second result at index 1 (a retired run-time check). The cockpit must
     // list it (and its failure), not paint 1/1 proven under a failed verdict.
     // An artifacts-hosted repo keeps the route off GitHub; a PR number is
     // needed because criteria are only graded once a change exists.
@@ -905,7 +904,7 @@ describe('verification stall display', () => {
     const detail = (await response.json()) as ApiFeatureDetail;
     expect(detail.criteria.map((c) => [c.text, c.verdict])).toEqual([
       ['GET /a returns 200', 'pass'],
-      [PREMORTEM_CRITERION, 'fail'],
+      ['Verification check #2 (retired)', 'fail'],
     ]);
     expect(detail.criteria[1]?.note).toBe('Surviving mechanism: X');
     expect(detail.verification).toEqual({ status: 'failed', total: 2, failed: 1 });


### PR DESCRIPTION
## Why

| | |
|---|---|
| Verifications with a verdict, all time | 11 |
| Failed on a human acceptance criterion | 0 |
| Premortem runs since 4 Sep | 8 |
| Premortem failures | 8 / 8 |
| Features it let through | 0 |
| Spent on verifications it failed | ~$47, plus the repairs and re-reviews it triggered |

The two features that ever passed verification did so before it existed. It is an unbounded "find any surviving mechanism" search, so it always has an answer; feature 7 found a new holder of the old model id on each of three rounds.

## Change

- `runPremortem`, its prompt, timeout and the gate in `verify()` are removed. Verification stands on the acceptance criteria.
- `PREMORTEM_CRITERION` is gone. `gradedCriteria` still surfaces result rows beyond the stored criteria (verifications 4–13 carry one) as "Verification check #N (retired)", so older pages keep showing the failing row instead of N/N proven.
- Tests updated accordingly; no behavior change elsewhere.

## Verified locally

`vp test` 256 passed · worker suite 200 passed (12 files) · `tsc` ×3 clean · `vp lint` no errors.

Not merged; merge when you want it live. On merge, feature 7 needs one more verify (Resume checks) to reach merge on its 4 criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
