### PR TITLE
Refine paper shadows and button interaction depth

### DIFF
--- a/src/client/components/chat-rail.tsx
+++ b/src/client/components/chat-rail.tsx
@@ -604,7 +604,7 @@ function Transcript({
           onClick={() => scrollToBottom('smooth')}
           aria-label={unread > 0 ? `${unread} new replies — jump to latest` : 'Jump to latest'}
           className={cn(
-            'absolute bottom-3 left-1/2 flex -translate-x-1/2 cursor-pointer items-center gap-1.5 rounded-full font-mono text-[11px] font-semibold tracking-[0.04em] transition-transform hover:-translate-y-px active:translate-y-0',
+            'absolute bottom-3 left-1/2 flex -translate-x-1/2 cursor-pointer items-center gap-1.5 rounded-full font-mono text-[11px] font-semibold tracking-[0.04em] transition-[translate,box-shadow] duration-120 ease-out active:translate-y-px active:shadow-none',
             unread > 0
               ? 'bg-accent py-1.5 pr-3 pl-2.5 text-accent-ink shadow-edge-xs'
               : 'size-7 justify-center border border-line-2 bg-raised text-ink shadow-sticker',
@@ -753,7 +753,7 @@ function Composer({ chat, activeFile, composerRef, focusTick }: ComposerProps) {
               onClick={submit}
               disabled={!canSend}
               aria-label={inFlight ? 'Queue message' : 'Send message'}
-              className="flex size-7 cursor-pointer items-center justify-center rounded-md bg-accent text-accent-ink shadow-edge-xs transition-[transform,box-shadow,background-color] duration-100 hover:bg-accent-bright active:translate-x-px active:translate-y-px active:shadow-none disabled:pointer-events-none disabled:opacity-40 max-sm:size-11"
+              className="flex size-7 cursor-pointer items-center justify-center rounded-md bg-accent text-accent-ink shadow-edge-xs transition-[translate,box-shadow,background-color] duration-120 ease-out hover:bg-accent-bright active:translate-x-px active:translate-y-px active:shadow-none disabled:pointer-events-none disabled:opacity-40 max-sm:size-11"
             >
               <ArrowUp className="size-3.5" strokeWidth={2.5} aria-hidden />
             </button>
@@ -1056,7 +1056,7 @@ export function ChatRail(props: ChatRailProps) {
         type="button"
         onClick={() => setSheetOpen(true)}
         aria-label={chat.unread > 0 ? `Agent chat, ${chat.unread} new replies` : 'Agent chat'}
-        className="fixed right-4 bottom-[calc(env(safe-area-inset-bottom)+4.5rem)] z-40 flex cursor-pointer items-center gap-2 rounded-full bg-accent py-2.5 pr-3.5 pl-3 font-mono text-[11px] font-bold tracking-[0.04em] text-accent-ink shadow-edge transition-[transform,box-shadow,background-color] duration-100 hover:bg-accent-bright active:translate-x-0.5 active:translate-y-0.5 active:shadow-edge-sm md:bottom-6"
+        className="fixed right-4 bottom-[calc(env(safe-area-inset-bottom)+4.5rem)] z-40 flex cursor-pointer items-center gap-2 rounded-full bg-accent py-2.5 pr-3.5 pl-3 font-mono text-[11px] font-bold tracking-[0.04em] text-accent-ink shadow-edge transition-[translate,box-shadow,background-color] duration-120 ease-out hover:bg-accent-bright active:translate-x-px active:translate-y-px active:shadow-none md:bottom-6"
       >
         <MessageSquare className="size-3.5" strokeWidth={2.2} aria-hidden />
         Agent

--- a/src/client/components/ui/button.tsx
+++ b/src/client/components/ui/button.tsx
@@ -4,15 +4,13 @@ import { Loader2 } from 'lucide-react';
 import { cn } from '../../lib/utils.ts';
 
 export const buttonVariants = cva(
-  'inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md font-medium whitespace-nowrap transition-[color,background-color,border-color,transform,box-shadow] duration-100 ease-out disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md font-medium whitespace-nowrap transition-[color,background-color,border-color,transform,translate,box-shadow] duration-120 ease-out disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
-        // The yellow sticker: lifts into a bigger shadow on hover and presses
-        // into a smaller one on click (translate, not scale, so the offset
-        // shadow reads as depth).
+        // Keep the 1px paper edge steady on hover; pressing travels into it.
         default:
-          'bg-accent font-semibold text-accent-ink shadow-edge hover:-translate-x-px hover:-translate-y-px hover:bg-accent-bright hover:shadow-edge-lg active:translate-x-0.5 active:translate-y-0.5 active:shadow-edge-sm',
+          'bg-accent font-semibold text-accent-ink shadow-edge hover:bg-accent-bright active:translate-x-px active:translate-y-px active:shadow-none',
         secondary:
           'border border-line-2 bg-transparent text-ink hover:border-accent hover:bg-raised active:scale-[0.97]',
         danger:

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -3,7 +3,7 @@
 /* Turbodiff's identity as Tailwind v4 theme tokens: "Signage" — a warm
    graphite ground, bone text, and one working colour (chrome yellow) wherever
    the app is busy or asks for a click. Phosphor green survives only as GO:
-   success, never an action. Depth is hard-offset sticker shadows, no blur.
+   success, never an action. Depth is shallow paper edges, no blur.
    IBM Plex Sans for reading text, IBM Plex Mono for code, identifiers, and
    terminal chrome (both loaded in the shell). The Paper file is the source of
    truth for these values: https://app.paper.design/file/01M1H1H5D09QPHCSFA3X0727EN */
@@ -36,19 +36,20 @@
      the accent on purpose — the app is yellow where it is busy. */
   --color-warn: #d9a521;
   --color-hold: #ffc72c;
-  /* Sticker shadows: hard offsets, no blur. --shadow-sticker* sit under dark
-     surfaces; --shadow-edge* sit under yellow fills (bone offset). */
+  /* Paper edges: 1px for cards, controls and stamps; 2px for media and
+     popovers; 3px for dialogs. Hover keeps the same offset. --shadow-sticker*
+     sit under dark surfaces; --shadow-edge* sit under yellow fills. */
   --color-shadow: var(--color-line);
   --color-shadow-live: var(--color-accent);
   --color-sticker-edge: var(--color-ink);
-  --shadow-sticker: 3px 3px 0 var(--color-shadow);
-  --shadow-sticker-lg: 4px 4px 0 var(--color-shadow);
-  --shadow-sticker-live: 3px 3px 0 var(--color-shadow-live);
-  --shadow-sticker-xl: 8px 8px 0 var(--color-shadow);
-  --shadow-edge: 3px 3px 0 var(--color-sticker-edge);
-  --shadow-edge-lg: 4px 4px 0 var(--color-sticker-edge);
+  --shadow-sticker: 1px 1px 0 var(--color-shadow);
+  --shadow-sticker-lg: 2px 2px 0 var(--color-shadow);
+  --shadow-sticker-live: 1px 1px 0 var(--color-shadow-live);
+  --shadow-sticker-xl: 3px 3px 0 var(--color-shadow);
+  --shadow-edge: 1px 1px 0 var(--color-sticker-edge);
+  --shadow-edge-lg: 2px 2px 0 var(--color-sticker-edge);
   --shadow-edge-sm: 1px 1px 0 var(--color-sticker-edge);
-  --shadow-edge-xs: 2px 2px 0 var(--color-sticker-edge);
+  --shadow-edge-xs: 1px 1px 0 var(--color-sticker-edge);
 
   /* Syntax-highlight hues (rendered markdown only). The UI chrome stays
      bone and yellow; code gets a real multi-hue palette so tokens are

--- a/src/http/auth-page.tsx
+++ b/src/http/auth-page.tsx
@@ -39,7 +39,7 @@ const CSS = `
 		width: 100%; max-width: 24rem;
 		background: var(--surface);
 		border: 1px solid var(--line-2); border-radius: 10px;
-		box-shadow: 4px 4px 0 var(--line);
+		box-shadow: 1px 1px 0 var(--line);
 		padding: 1.75rem;
 	}
 	.tabs { display: flex; gap: 0.25rem; margin-bottom: 1.4rem; }
@@ -77,12 +77,12 @@ const CSS = `
 		width: 100%; padding: 0.6rem 0; margin-top: 0.2rem;
 		font: 600 0.9rem/1 "IBM Plex Sans", system-ui, sans-serif;
 		color: var(--accent-ink); background: var(--accent); border: 0; border-radius: 6px;
-		box-shadow: 3px 3px 0 var(--ink);
+		box-shadow: 1px 1px 0 var(--ink);
 		cursor: pointer;
 		transition: transform 0.12s ease-out, box-shadow 0.12s ease-out, background 0.12s;
 	}
-	.submit:hover { background: var(--accent-bright); transform: translate(-1px, -1px); box-shadow: 4px 4px 0 var(--ink); }
-	.submit:active { transform: translate(2px, 2px); box-shadow: 1px 1px 0 var(--ink); }
+	.submit:hover { background: var(--accent-bright); }
+	.submit:active { transform: translate(1px, 1px); box-shadow: none; }
 	.submit[disabled] { opacity: 0.6; cursor: default; }
 	.divider {
 		display: flex; align-items: center; gap: 0.8rem; margin: 1.2rem 0;

--- a/src/http/blog.tsx
+++ b/src/http/blog.tsx
@@ -89,7 +89,7 @@ const CSS = `
 	.author { display: flex; align-items: center; gap: 0.9rem; font-style: normal; }
 	.author img {
 		width: 48px; height: 48px; border-radius: 50%; flex-shrink: 0;
-		border: 1px solid var(--line-2); box-shadow: 2px 2px 0 var(--line); background: var(--raised);
+		border: 1px solid var(--line-2); box-shadow: 1px 1px 0 var(--line); background: var(--raised);
 	}
 	.author b { display: block; font-size: 0.95rem; font-weight: 600; line-height: 1.3; }
 	.author span { font-family: var(--mono); font-size: 0.75rem; color: var(--mute); }

--- a/src/http/certificate-page.tsx
+++ b/src/http/certificate-page.tsx
@@ -39,7 +39,7 @@ const CSS = `
 			radial-gradient(120% 90% at 30% 0%, rgba(255,255,255,0.5), transparent 60%),
 			var(--paper);
 		border-radius: 6px;
-		box-shadow: 8px 8px 0 var(--accent);
+		box-shadow: 3px 3px 0 var(--accent);
 	}
 	.cert::after {
 		content: ""; position: absolute; inset: 0; border-radius: 6px; pointer-events: none;
@@ -173,7 +173,7 @@ const CSS = `
 	.colophon a { color: var(--accent); text-decoration: none; }
 	.colophon a:hover { text-decoration: underline; }
 	@media (max-width: 860px) {
-		.cert { grid-template-columns: 1fr; }
+		.cert { grid-template-columns: 1fr; box-shadow: 2px 2px 0 var(--accent); }
 		.stub { border-left: 0; border-top: 2px dashed rgba(36,42,50,0.5); }
 		.stub::before { top: -12px; left: -12px; }
 		.stub::after { top: -12px; left: auto; right: -12px; bottom: auto; }

--- a/src/http/landing.tsx
+++ b/src/http/landing.tsx
@@ -2,8 +2,8 @@
 // syntax, stringified in the Worker — no client-side React bundle).
 //
 // Signage direction: warm graphite ground, bone text, chrome yellow as the one
-// working colour, phosphor green only for GO. Depth is hard-offset sticker
-// shadows. The hero object is a terminal "sticker card" that drops onto the
+// working colour, phosphor green only for GO. Depth is shallow paper
+// edges. The hero object is a terminal "sticker card" that drops onto the
 // page with CSS keyframes and then types a factory run out with one timer —
 // no canvas, no WebGL, no third-party script. The Paper file is the source of
 // truth for the design: https://app.paper.design/file/01M1H1H5D09QPHCSFA3X0727EN
@@ -40,11 +40,11 @@ const CSS = `
 		padding: 0.8rem 1.4rem; border-radius: 8px;
 		background: var(--accent); color: var(--accent-ink);
 		font-weight: 700; font-size: 0.95rem;
-		box-shadow: 4px 4px 0 var(--ink);
+		box-shadow: 2px 2px 0 var(--ink);
 		transition: transform 0.12s ease-out, box-shadow 0.12s ease-out, background 0.12s;
 	}
-	.cta:hover { background: var(--accent-bright); transform: translate(-1px, -1px); box-shadow: 5px 5px 0 var(--ink); }
-	.cta:active { transform: translate(2px, 2px); box-shadow: 1px 1px 0 var(--ink); }
+	.cta:hover { background: var(--accent-bright); }
+	.cta:active { transform: translate(1px, 1px); box-shadow: 1px 1px 0 var(--ink); }
 	.cta svg { width: 1em; height: 1em; fill: currentColor; }
 	.read {
 		display: inline-flex; align-items: center; gap: 0.6em;
@@ -61,7 +61,7 @@ const CSS = `
 		position: relative;
 		border-radius: 12px; overflow: hidden;
 		background: var(--surface); border: 1.5px solid var(--line-2);
-		box-shadow: 8px 8px 0 var(--accent);
+		box-shadow: 3px 3px 0 var(--accent);
 		transform: rotate(1deg);
 		font-family: var(--mono);
 	}
@@ -100,12 +100,12 @@ const CSS = `
 	}
 	@keyframes land {
 		from { transform: rotate(0deg); box-shadow: 0 0 0 var(--accent); }
-		to { transform: rotate(1deg); box-shadow: 8px 8px 0 var(--accent); }
+		to { transform: rotate(1deg); box-shadow: 3px 3px 0 var(--accent); }
 	}
 	@media (max-width: 899px) {
 		.hero .wrap { grid-template-columns: 1fr; gap: 2.5rem; }
-		.term, .term.boot { transform: none; box-shadow: 6px 6px 0 var(--accent); }
-		@keyframes land { from { box-shadow: 0 0 0 var(--accent); } to { box-shadow: 6px 6px 0 var(--accent); } }
+		.term, .term.boot { transform: none; box-shadow: 2px 2px 0 var(--accent); }
+		@keyframes land { from { box-shadow: 0 0 0 var(--accent); } to { box-shadow: 2px 2px 0 var(--accent); } }
 	}
 
 	/* --- proof strip --- */
@@ -156,7 +156,7 @@ const CSS = `
 	.ghost:hover { background: rgba(255, 199, 44, 0.1); }
 	.certificate {
 		padding: 1.75rem; display: flex; flex-direction: column; gap: 1.1rem;
-		border-radius: 12px; border-width: 1.5px; box-shadow: 8px 8px 0 var(--line);
+		border-radius: 12px; border-width: 1.5px; box-shadow: 3px 3px 0 var(--line);
 		transform: rotate(-1deg);
 	}
 	.certificate .top { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
@@ -168,7 +168,7 @@ const CSS = `
 		padding: 0.35em 0.8em; border-radius: 5px;
 		background: var(--accent); color: var(--accent-ink);
 		font-family: var(--mono); font-size: 0.8rem; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
-		box-shadow: 3px 3px 0 var(--ink); transform: rotate(-8deg);
+		box-shadow: 1px 1px 0 var(--ink); transform: rotate(-8deg);
 	}
 	.criteria { padding: 0.9rem; border-radius: 8px; background: var(--bg); border: 1px solid var(--line-2); display: flex; flex-direction: column; gap: 0.55rem; }
 	.criteria .meta { font-size: 0.6rem; }
@@ -191,7 +191,7 @@ const CSS = `
 		.tiles { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 		.stages { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 		.cert .wrap { grid-template-columns: 1fr; gap: 2rem; }
-		.certificate { transform: none; box-shadow: 6px 6px 0 var(--line); }
+		.certificate { transform: none; box-shadow: 2px 2px 0 var(--line); }
 		.proof .head, .how .head { flex-direction: column; align-items: flex-start; gap: 0.8rem; }
 	}
 	@media (max-width: 600px) {

--- a/src/http/site-shell.tsx
+++ b/src/http/site-shell.tsx
@@ -46,20 +46,20 @@ export const SHELL_CSS = `
 		background: var(--accent); color: var(--accent-ink);
 		font-family: var(--mono); font-size: 0.66rem; font-weight: 700;
 		letter-spacing: 0.18em; text-transform: uppercase;
-		box-shadow: 2px 2px 0 var(--ink);
+		box-shadow: 1px 1px 0 var(--ink);
 		transform: rotate(-3deg);
 	}
 	.tag.flat { transform: rotate(-2deg); box-shadow: none; }
 	.mark {
 		display: block; width: 34px; height: 34px; border-radius: 7px;
-		box-shadow: 3px 3px 0 var(--accent);
+		box-shadow: 1px 1px 0 var(--accent);
 		transform: rotate(-6deg);
 	}
 	.card {
 		background: var(--surface); border: 1px solid var(--line-2); border-radius: 10px;
-		box-shadow: 3px 3px 0 var(--line);
+		box-shadow: 1px 1px 0 var(--line);
 	}
-	.card.live { border-color: var(--accent); box-shadow: 3px 3px 0 var(--accent); }
+	.card.live { border-color: var(--accent); box-shadow: 1px 1px 0 var(--accent); }
 	.lamp {
 		display: inline-block; width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
 	}


### PR DESCRIPTION
Buttons and cards had large offset shadows, and primary actions lifted on hover before moving 2px on press. Apply the refined [Paper guidance](https://app.paper.design/file/01M1H1H5D09QPHCSFA3X0727EN/1-0): 1px edges for controls, badges, and cards; 2px for media/popovers; 3px for large surfaces. Primary buttons keep their position on hover and press 1px into the edge.

Updates the shared SPA tokens, primary button and chat controls, plus landing, sign-in, article, and certificate styles. Landing hero shadows settle at 3px on desktop and 2px on mobile. Existing control dimensions, focus rings, and disabled/loading behavior are preserved.

Validation:

- Client production build passes, including bundle budgets.
- All 261 unit tests pass.
- Lint and all three TypeScript programs pass; lint reports existing warnings.
- Formatting passes for all eight changed files; the commit hook also passes.
- Browser-checked actual components with production CSS and server-rendered pages: shadow values, hover/press behavior, keyboard focus, disabled/loading states, mobile targets, and reduced-motion landing behavior.

`vp check` stops on existing formatting issues in migration snapshots 0013–0015 and `_journal.json`. These files are unchanged. The public certificate also has an existing mobile width overflow (410px content at a 390px viewport), confirmed against the baseline; this change only reduces its shadow.
