### PR TITLE
feat(review): fail closed on inconclusive evidence

### DIFF
--- a/db/migrations/0020_review-readiness-conclusions.sql
+++ b/db/migrations/0020_review-readiness-conclusions.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "app"."reviews" ADD COLUMN "conclusion" text;--> statement-breakpoint
+ALTER TABLE "app"."reviews" ADD COLUMN "coverage_status" text;--> statement-breakpoint
+ALTER TABLE "app"."reviews" ADD COLUMN "reviewable_file_count" integer;--> statement-breakpoint
+ALTER TABLE "app"."reviews" ADD COLUMN "covered_file_count" integer;--> statement-breakpoint
+ALTER TABLE "app"."reviews" ADD COLUMN "missing_paths" jsonb;--> statement-breakpoint
+ALTER TABLE "app"."reviews" ADD COLUMN "coverage_head_sha" text;--> statement-breakpoint
+ALTER TABLE "app"."reviews" ADD COLUMN "published_head_sha" text;--> statement-breakpoint
+ALTER TABLE "app"."reviews" ADD CONSTRAINT "reviews_conclusion_check" CHECK ((conclusion IS NULL) OR (conclusion = ANY (ARRAY['ready'::text, 'ready_with_warnings'::text, 'not_ready'::text, 'inconclusive'::text])));--> statement-breakpoint
+ALTER TABLE "app"."reviews" ADD CONSTRAINT "reviews_coverage_status_check" CHECK ((coverage_status IS NULL) OR (coverage_status = ANY (ARRAY['complete'::text, 'incomplete'::text, 'stale'::text])));--> statement-breakpoint
+ALTER TABLE "app"."reviews" ADD CONSTRAINT "reviews_coverage_counts_check" CHECK ((reviewable_file_count IS NULL AND covered_file_count IS NULL) OR
+        (reviewable_file_count >= 0 AND covered_file_count >= 0 AND covered_file_count <= reviewable_file_count));--> statement-breakpoint
+ALTER TABLE "app"."reviews" ADD CONSTRAINT "reviews_missing_paths_array_check" CHECK ((missing_paths IS NULL) OR (jsonb_typeof(missing_paths) = 'array'::text));

--- a/db/migrations/meta/0020_snapshot.json
+++ b/db/migrations/meta/0020_snapshot.json
@@ -1,0 +1,7618 @@
+{
+  "id": "105d308f-3ee2-4143-8bb8-fd594e3adfd1",
+  "prevId": "7722480a-2898-4abf-9b7a-ed819282c8ff",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app.acceptance_contracts": {
+      "name": "acceptance_contracts",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "acceptance_contracts_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria": {
+          "name": "criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "acceptance_contracts_work_item_idx": {
+          "name": "acceptance_contracts_work_item_idx",
+          "columns": [
+            {
+              "expression": "work_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acceptance_contracts_change_idx": {
+          "name": "acceptance_contracts_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acceptance_contracts_work_item_id_fkey": {
+          "name": "acceptance_contracts_work_item_id_fkey",
+          "tableFrom": "acceptance_contracts",
+          "tableTo": "work_items",
+          "schemaTo": "app",
+          "columnsFrom": ["work_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acceptance_contracts_change_id_fkey": {
+          "name": "acceptance_contracts_change_id_fkey",
+          "tableFrom": "acceptance_contracts",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": ["change_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acceptance_contracts_version_check": {
+          "name": "acceptance_contracts_version_check",
+          "value": "version > 0"
+        },
+        "acceptance_contracts_owner_check": {
+          "name": "acceptance_contracts_owner_check",
+          "value": "(work_item_id IS NOT NULL) OR (change_id IS NOT NULL)"
+        },
+        "acceptance_contracts_criteria_array_check": {
+          "name": "acceptance_contracts_criteria_array_check",
+          "value": "jsonb_typeof(criteria) = 'array'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.account": {
+      "name": "account",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_fkey": {
+          "name": "account_userId_fkey",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_provider_identity_unique": {
+          "name": "account_provider_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": ["accountId", "providerId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.agent_runs": {
+      "name": "agent_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "agent_runs_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fix_attempt_id": {
+          "name": "fix_attempt_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_run_id": {
+          "name": "automation_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_key": {
+          "name": "log_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "agent_runs_automation_idx": {
+          "name": "agent_runs_automation_idx",
+          "columns": [
+            {
+              "expression": "automation_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(automation_run_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_feature_idx": {
+          "name": "agent_runs_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(feature_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_fix_attempt_idx": {
+          "name": "agent_runs_fix_attempt_idx",
+          "columns": [
+            {
+              "expression": "fix_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(fix_attempt_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_plan_idx": {
+          "name": "agent_runs_plan_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(plan_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_plan_id_fkey": {
+          "name": "agent_runs_plan_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_feature_id_fkey": {
+          "name": "agent_runs_feature_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_fix_attempt_id_fkey": {
+          "name": "agent_runs_fix_attempt_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "fix_attempts",
+          "schemaTo": "app",
+          "columnsFrom": ["fix_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_automation_run_id_fkey": {
+          "name": "agent_runs_automation_run_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "automation_runs",
+          "schemaTo": "app",
+          "columnsFrom": ["automation_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_runs_kind_check": {
+          "name": "agent_runs_kind_check",
+          "value": "kind = ANY (ARRAY['plan_analyze'::text, 'plan_refine'::text, 'generate'::text, 'verify'::text, 'fix'::text, 'automation'::text, 'chat'::text, 'resolve_conflict'::text])"
+        },
+        "agent_runs_owner": {
+          "name": "agent_runs_owner",
+          "value": "num_nonnulls(plan_id, feature_id, fix_attempt_id, automation_run_id) >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.agents": {
+      "name": "agents",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "agents_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare/anthropic/claude-sonnet-5'"
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_installation_id_fkey": {
+          "name": "agents_installation_id_fkey",
+          "tableFrom": "agents",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_id_installation_unique": {
+          "name": "agents_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "installation_id"]
+        },
+        "agents_installation_slug_unique": {
+          "name": "agents_installation_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id", "slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agents_slug_format": {
+          "name": "agents_slug_format",
+          "value": "slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.automation_runs": {
+      "name": "automation_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "automation_runs_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "automation_runs_automation_idx": {
+          "name": "automation_runs_automation_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_one_running_idx": {
+          "name": "automation_runs_one_running_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_id_fkey": {
+          "name": "automation_runs_automation_id_fkey",
+          "tableFrom": "automation_runs",
+          "tableTo": "automations",
+          "schemaTo": "app",
+          "columnsFrom": ["automation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "automation_runs_status_check": {
+          "name": "automation_runs_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'pr_opened'::text, 'no_changes'::text, 'checks_failed'::text, 'failed'::text])"
+        },
+        "automation_runs_pr_number_check": {
+          "name": "automation_runs_pr_number_check",
+          "value": "(pr_number IS NULL) OR (pr_number > 0)"
+        },
+        "automation_runs_input_tokens_check": {
+          "name": "automation_runs_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "automation_runs_output_tokens_check": {
+          "name": "automation_runs_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "automation_runs_cache_read_tokens_check": {
+          "name": "automation_runs_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "automation_runs_cache_write_tokens_check": {
+          "name": "automation_runs_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "automation_runs_cost_usd_check": {
+          "name": "automation_runs_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.automations": {
+      "name": "automations",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "automations_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_kind": {
+          "name": "schedule_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_of_day": {
+          "name": "time_of_day",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "runner_model": {
+          "name": "runner_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "automations_due_idx": {
+          "name": "automations_due_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automations_repository_idx": {
+          "name": "automations_repository_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automations_repository_id_fkey": {
+          "name": "automations_repository_id_fkey",
+          "tableFrom": "automations",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "automations_schedule_kind_check": {
+          "name": "automations_schedule_kind_check",
+          "value": "schedule_kind = ANY (ARRAY['hourly'::text, 'daily'::text, 'weekly'::text])"
+        },
+        "automations_day_of_week_check": {
+          "name": "automations_day_of_week_check",
+          "value": "(day_of_week >= 0) AND (day_of_week <= 6)"
+        },
+        "automations_schedule_shape": {
+          "name": "automations_schedule_shape",
+          "value": "((schedule_kind = 'hourly'::text) AND (time_of_day IS NULL) AND (day_of_week IS NULL)) OR ((schedule_kind = 'daily'::text) AND (time_of_day IS NOT NULL) AND (day_of_week IS NULL)) OR ((schedule_kind = 'weekly'::text) AND (time_of_day IS NOT NULL) AND (day_of_week IS NOT NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.change_request_counters": {
+      "name": "change_request_counters",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_number": {
+          "name": "last_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "change_request_counters_repository_id_fkey": {
+          "name": "change_request_counters_repository_id_fkey",
+          "tableFrom": "change_request_counters",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "change_request_counters_last_number_check": {
+          "name": "change_request_counters_last_number_check",
+          "value": "last_number > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.change_requests": {
+      "name": "change_requests",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "change_requests_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_branch": {
+          "name": "source_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "source_head": {
+          "name": "source_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_head": {
+          "name": "target_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_base": {
+          "name": "merge_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mergeable": {
+          "name": "mergeable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_files": {
+          "name": "conflict_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff_key": {
+          "name": "diff_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patch_truncated": {
+          "name": "patch_truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_head": {
+          "name": "merged_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_by": {
+          "name": "opened_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'factory'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "change_requests_feature_idx": {
+          "name": "change_requests_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(feature_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_requests_change_unique": {
+          "name": "change_requests_change_unique",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_requests_open_branches_unique": {
+          "name": "change_requests_open_branches_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'open'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_requests_repo_status_idx": {
+          "name": "change_requests_repo_status_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_requests_feature_id_features_id_fk": {
+          "name": "change_requests_feature_id_features_id_fk",
+          "tableFrom": "change_requests",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "change_requests_change_id_changes_id_fk": {
+          "name": "change_requests_change_id_changes_id_fk",
+          "tableFrom": "change_requests",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": ["change_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_requests_repository_id_fkey": {
+          "name": "change_requests_repository_id_fkey",
+          "tableFrom": "change_requests",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "change_requests_repo_number_unique": {
+          "name": "change_requests_repo_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["repository_id", "number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "change_requests_number_check": {
+          "name": "change_requests_number_check",
+          "value": "number > 0"
+        },
+        "change_requests_status_check": {
+          "name": "change_requests_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'merged'::text, 'closed'::text])"
+        },
+        "change_requests_review_status_check": {
+          "name": "change_requests_review_status_check",
+          "value": "(review_status IS NULL) OR (review_status = ANY (ARRAY['approved'::text, 'changes_requested'::text]))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.changes": {
+      "name": "changes",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "changes_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_key": {
+          "name": "provider_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_branch": {
+          "name": "source_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "source_head": {
+          "name": "source_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_head": {
+          "name": "target_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "changes_repo_status_idx": {
+          "name": "changes_repo_status_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "changes_repository_id_fkey": {
+          "name": "changes_repository_id_fkey",
+          "tableFrom": "changes",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "changes_repo_provider_key_unique": {
+          "name": "changes_repo_provider_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["repository_id", "provider_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "changes_number_check": {
+          "name": "changes_number_check",
+          "value": "number > 0"
+        },
+        "changes_origin_check": {
+          "name": "changes_origin_check",
+          "value": "origin = ANY (ARRAY['human'::text, 'factory'::text, 'automation'::text, 'imported'::text])"
+        },
+        "changes_status_check": {
+          "name": "changes_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'merged'::text, 'closed'::text])"
+        },
+        "changes_capabilities_array_check": {
+          "name": "changes_capabilities_array_check",
+          "value": "jsonb_typeof(capabilities) = 'array'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.chat_messages": {
+      "name": "chat_messages",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "chat_messages_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'done'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "chat_messages_feature_idx": {
+          "name": "chat_messages_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_one_pending_user_idx": {
+          "name": "chat_messages_one_pending_user_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((role = 'user'::text) AND (status = ANY (ARRAY['queued'::text, 'running'::text])))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_feature_id_fkey": {
+          "name": "chat_messages_feature_id_fkey",
+          "tableFrom": "chat_messages",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_messages_role_check": {
+          "name": "chat_messages_role_check",
+          "value": "role = ANY (ARRAY['user'::text, 'assistant'::text])"
+        },
+        "chat_messages_status_check": {
+          "name": "chat_messages_status_check",
+          "value": "status = ANY (ARRAY['queued'::text, 'running'::text, 'done'::text, 'failed'::text])"
+        },
+        "chat_messages_outcome_check": {
+          "name": "chat_messages_outcome_check",
+          "value": "(outcome IS NULL) OR (outcome = ANY (ARRAY['changed'::text, 'no_changes'::text, 'tests_failed'::text]))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.cockpit_comments": {
+      "name": "cockpit_comments",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cockpit_comments_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'additions'"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "fix_attempt_id": {
+          "name": "fix_attempt_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "cockpit_comments_feature_idx": {
+          "name": "cockpit_comments_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cockpit_comments_fix_attempt_idx": {
+          "name": "cockpit_comments_fix_attempt_idx",
+          "columns": [
+            {
+              "expression": "fix_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(fix_attempt_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cockpit_comments_feature_id_fkey": {
+          "name": "cockpit_comments_feature_id_fkey",
+          "tableFrom": "cockpit_comments",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cockpit_comments_fix_attempt_id_fkey": {
+          "name": "cockpit_comments_fix_attempt_id_fkey",
+          "tableFrom": "cockpit_comments",
+          "tableTo": "fix_attempts",
+          "schemaTo": "app",
+          "columnsFrom": ["fix_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cockpit_comments_line_check": {
+          "name": "cockpit_comments_line_check",
+          "value": "line > 0"
+        },
+        "cockpit_comments_side_check": {
+          "name": "cockpit_comments_side_check",
+          "value": "side = ANY (ARRAY['additions'::text, 'deletions'::text])"
+        },
+        "cockpit_comments_status_check": {
+          "name": "cockpit_comments_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'dispatched'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.connections": {
+      "name": "connections",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "connections_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mcp'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_allowlist": {
+          "name": "tool_allowlist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_ciphertext": {
+          "name": "auth_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optional": {
+          "name": "optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "auth_config_ciphertext": {
+          "name": "auth_config_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_expires_at": {
+          "name": "oauth_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_needs_reauth": {
+          "name": "oauth_needs_reauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "oauth_has_refresh_token": {
+          "name": "oauth_has_refresh_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connections_installation_id_fkey": {
+          "name": "connections_installation_id_fkey",
+          "tableFrom": "connections",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_id_installation_unique": {
+          "name": "connections_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "installation_id"]
+        },
+        "connections_installation_name_unique": {
+          "name": "connections_installation_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connections_kind_check": {
+          "name": "connections_kind_check",
+          "value": "kind = ANY (ARRAY['mcp'::text, 'api'::text])"
+        },
+        "connections_auth_type_check": {
+          "name": "connections_auth_type_check",
+          "value": "auth_type = ANY (ARRAY['none'::text, 'bearer'::text, 'api_key'::text, 'client_credentials'::text, 'oauth'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.cr_checks": {
+      "name": "cr_checks",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cr_checks_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cr_checks_change_request_id_fkey": {
+          "name": "cr_checks_change_request_id_fkey",
+          "tableFrom": "cr_checks",
+          "tableTo": "change_requests",
+          "schemaTo": "app",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cr_checks_name_unique": {
+          "name": "cr_checks_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["change_request_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cr_checks_status_check": {
+          "name": "cr_checks_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'passed'::text, 'failed'::text, 'error'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.cr_comments": {
+      "name": "cr_comments",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cr_comments_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'comment'"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "cr_comments_change_request_idx": {
+          "name": "cr_comments_change_request_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cr_comments_change_request_id_fkey": {
+          "name": "cr_comments_change_request_id_fkey",
+          "tableFrom": "cr_comments",
+          "tableTo": "change_requests",
+          "schemaTo": "app",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cr_comments_line_check": {
+          "name": "cr_comments_line_check",
+          "value": "(line IS NULL) OR (line > 0)"
+        },
+        "cr_comments_kind_check": {
+          "name": "cr_comments_kind_check",
+          "value": "kind = ANY (ARRAY['comment'::text, 'finding'::text, 'summary'::text])"
+        },
+        "cr_comments_severity_check": {
+          "name": "cr_comments_severity_check",
+          "value": "(severity IS NULL) OR (severity = ANY (ARRAY['P1'::text, 'P2'::text, 'P3'::text]))"
+        },
+        "cr_comments_location": {
+          "name": "cr_comments_location",
+          "value": "((file IS NULL) AND (line IS NULL)) OR (file IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.factory_runs": {
+      "name": "factory_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "factory_runs_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_key": {
+          "name": "profile_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_stage": {
+          "name": "start_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stop_after_stage": {
+          "name": "stop_after_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_snapshot": {
+          "name": "policy_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "handoff_reason": {
+          "name": "handoff_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "factory_runs_repo_created_idx": {
+          "name": "factory_runs_repo_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "factory_runs_change_idx": {
+          "name": "factory_runs_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "factory_runs_work_item_idx": {
+          "name": "factory_runs_work_item_idx",
+          "columns": [
+            {
+              "expression": "work_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(work_item_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "factory_runs_repository_id_fkey": {
+          "name": "factory_runs_repository_id_fkey",
+          "tableFrom": "factory_runs",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "factory_runs_work_item_id_fkey": {
+          "name": "factory_runs_work_item_id_fkey",
+          "tableFrom": "factory_runs",
+          "tableTo": "work_items",
+          "schemaTo": "app",
+          "columnsFrom": ["work_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "factory_runs_change_id_fkey": {
+          "name": "factory_runs_change_id_fkey",
+          "tableFrom": "factory_runs",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": ["change_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "factory_runs_idempotency_key_unique": {
+          "name": "factory_runs_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["idempotency_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "factory_runs_status_check": {
+          "name": "factory_runs_status_check",
+          "value": "status = ANY (ARRAY['active'::text, 'awaiting_human'::text, 'handed_off'::text, 'completed'::text, 'failed'::text, 'cancelled'::text])"
+        },
+        "factory_runs_profile_check": {
+          "name": "factory_runs_profile_check",
+          "value": "profile_key = ANY (ARRAY['review_on_demand'::text, 'automatic_review'::text, 'review_and_repair'::text, 'idea_to_pr'::text, 'assisted_delivery'::text, 'full_delivery'::text, 'native_turnkey'::text, 'legacy_factory'::text])"
+        },
+        "factory_runs_stage_check": {
+          "name": "factory_runs_stage_check",
+          "value": "start_stage = ANY (ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text]) AND stop_after_stage = ANY (ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text])"
+        },
+        "factory_runs_stage_order_check": {
+          "name": "factory_runs_stage_order_check",
+          "value": "array_position(ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text], start_stage) <= array_position(ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text], stop_after_stage)"
+        },
+        "factory_runs_policy_object_check": {
+          "name": "factory_runs_policy_object_check",
+          "value": "jsonb_typeof(policy_snapshot) = 'object'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.factory_version": {
+      "name": "factory_version",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "factory_version_singleton_check": {
+          "name": "factory_version_singleton_check",
+          "value": "id = 1"
+        },
+        "factory_version_positive_check": {
+          "name": "factory_version_positive_check",
+          "value": "version > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.feature_explanations": {
+      "name": "feature_explanations",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "feature_explanations_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "agent_instance_id": {
+          "name": "agent_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feature_explanations_feature_head_idx": {
+          "name": "feature_explanations_feature_head_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feature_explanations_instance_idx": {
+          "name": "feature_explanations_instance_idx",
+          "columns": [
+            {
+              "expression": "agent_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feature_explanations_one_running_idx": {
+          "name": "feature_explanations_one_running_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_explanations_feature_id_fkey": {
+          "name": "feature_explanations_feature_id_fkey",
+          "tableFrom": "feature_explanations",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feature_explanations_status_check": {
+          "name": "feature_explanations_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'ready'::text, 'failed'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.features": {
+      "name": "features",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "features_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptance": {
+          "name": "acceptance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_login": {
+          "name": "coauthor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_id": {
+          "name": "coauthor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_started_at": {
+          "name": "run_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_model": {
+          "name": "runner_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criteria_conflict": {
+          "name": "criteria_conflict",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "acceptance_updated_at": {
+          "name": "acceptance_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_acceptance": {
+          "name": "proposed_acceptance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_session_id": {
+          "name": "chat_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "features_change_request_idx": {
+          "name": "features_change_request_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_request_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_change_idx": {
+          "name": "features_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_generating_created_idx": {
+          "name": "features_generating_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(status = 'generating'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_open_pr_idx": {
+          "name": "features_open_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((status = 'pr_opened'::text) AND (pr_number IS NOT NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_plan_idx": {
+          "name": "features_plan_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(plan_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_repository_created_idx": {
+          "name": "features_repository_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_repository_pr_idx": {
+          "name": "features_repository_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(pr_number IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "features_plan_id_plans_id_fk": {
+          "name": "features_plan_id_plans_id_fk",
+          "tableFrom": "features",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "features_change_request_id_change_requests_id_fk": {
+          "name": "features_change_request_id_change_requests_id_fk",
+          "tableFrom": "features",
+          "tableTo": "change_requests",
+          "schemaTo": "app",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "features_change_id_changes_id_fk": {
+          "name": "features_change_id_changes_id_fk",
+          "tableFrom": "features",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": ["change_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "features_repository_id_fkey": {
+          "name": "features_repository_id_fkey",
+          "tableFrom": "features",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "features_plan_repository_unique": {
+          "name": "features_plan_repository_unique",
+          "nullsNotDistinct": false,
+          "columns": ["plan_id", "repository_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "features_pr_number_check": {
+          "name": "features_pr_number_check",
+          "value": "pr_number > 0"
+        },
+        "features_status_check": {
+          "name": "features_status_check",
+          "value": "status = ANY (ARRAY['queued'::text, 'generating'::text, 'pr_opened'::text, 'no_changes'::text, 'checks_failed'::text, 'failed'::text, 'merged'::text, 'pr_closed'::text, 'abandoned'::text])"
+        },
+        "features_input_tokens_check": {
+          "name": "features_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "features_output_tokens_check": {
+          "name": "features_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "features_cache_read_tokens_check": {
+          "name": "features_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "features_cache_write_tokens_check": {
+          "name": "features_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "features_cost_usd_check": {
+          "name": "features_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.fix_attempts": {
+      "name": "fix_attempts",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "fix_attempts_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage_run_id": {
+          "name": "stage_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "fix_attempts_one_running_idx": {
+          "name": "fix_attempts_one_running_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fix_attempts_pr_idx": {
+          "name": "fix_attempts_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fix_attempts_stage_run_idx": {
+          "name": "fix_attempts_stage_run_idx",
+          "columns": [
+            {
+              "expression": "stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(stage_run_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fix_attempts_stage_run_id_stage_runs_id_fk": {
+          "name": "fix_attempts_stage_run_id_stage_runs_id_fk",
+          "tableFrom": "fix_attempts",
+          "tableTo": "stage_runs",
+          "schemaTo": "app",
+          "columnsFrom": ["stage_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fix_attempts_repository_id_fkey": {
+          "name": "fix_attempts_repository_id_fkey",
+          "tableFrom": "fix_attempts",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "fix_attempts_pr_number_check": {
+          "name": "fix_attempts_pr_number_check",
+          "value": "pr_number > 0"
+        },
+        "fix_attempts_status_check": {
+          "name": "fix_attempts_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'fixed'::text, 'no_changes'::text, 'tests_failed'::text, 'failed'::text])"
+        },
+        "fix_attempts_input_tokens_check": {
+          "name": "fix_attempts_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "fix_attempts_output_tokens_check": {
+          "name": "fix_attempts_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "fix_attempts_cache_read_tokens_check": {
+          "name": "fix_attempts_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "fix_attempts_cache_write_tokens_check": {
+          "name": "fix_attempts_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "fix_attempts_cost_usd_check": {
+          "name": "fix_attempts_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.installation_repo_sync": {
+      "name": "installation_repo_sync",
+      "schema": "app",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncing_until": {
+          "name": "syncing_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "installation_repo_sync_installation_id_fkey": {
+          "name": "installation_repo_sync_installation_id_fkey",
+          "tableFrom": "installation_repo_sync",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.installations": {
+      "name": "installations",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval('app.native_entity_id_seq'::regclass)"
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended": {
+          "name": "suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "installer_github_id": {
+          "name": "installer_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "installations_installer_idx": {
+          "name": "installations_installer_idx",
+          "columns": [
+            {
+              "expression": "installer_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(installer_github_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "installations_id_provider_unique": {
+          "name": "installations_id_provider_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "provider"]
+        },
+        "installations_provider_login_unique": {
+          "name": "installations_provider_login_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider", "account_login"]
+        },
+        "installations_provider_account_unique": {
+          "name": "installations_provider_account_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider", "account_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "installations_account_type_check": {
+          "name": "installations_account_type_check",
+          "value": "account_type = ANY (ARRAY['Organization'::text, 'User'::text])"
+        },
+        "installations_provider_check": {
+          "name": "installations_provider_check",
+          "value": "provider = ANY (ARRAY['github'::text, 'artifacts'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.invitation": {
+      "name": "invitation",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviterId": {
+          "name": "inviterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_email_status_idx": {
+          "name": "invitation_email_status_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_idx": {
+          "name": "invitation_inviter_idx",
+          "columns": [
+            {
+              "expression": "inviterId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_organization_idx": {
+          "name": "invitation_organization_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_pending_email_unique": {
+          "name": "invitation_pending_email_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'pending'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organizationId_fkey": {
+          "name": "invitation_organizationId_fkey",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "schemaTo": "auth",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviterId_fkey": {
+          "name": "invitation_inviterId_fkey",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["inviterId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "role = ANY (ARRAY['owner'::text, 'admin'::text, 'member'::text])"
+        },
+        "invitation_status_check": {
+          "name": "invitation_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'accepted'::text, 'rejected'::text, 'canceled'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.lifecycle_events": {
+      "name": "lifecycle_events",
+      "schema": "app",
+      "columns": {
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "factory_run_id": {
+          "name": "factory_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "lifecycle_events_factory_run_idx": {
+          "name": "lifecycle_events_factory_run_idx",
+          "columns": [
+            {
+              "expression": "factory_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lifecycle_events_change_idx": {
+          "name": "lifecycle_events_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lifecycle_events_factory_run_id_fkey": {
+          "name": "lifecycle_events_factory_run_id_fkey",
+          "tableFrom": "lifecycle_events",
+          "tableTo": "factory_runs",
+          "schemaTo": "app",
+          "columnsFrom": ["factory_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lifecycle_events_change_id_fkey": {
+          "name": "lifecycle_events_change_id_fkey",
+          "tableFrom": "lifecycle_events",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": ["change_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lifecycle_events_kind_check": {
+          "name": "lifecycle_events_kind_check",
+          "value": "kind = ANY (ARRAY['work.requested'::text, 'plan.ready'::text, 'human.approved'::text, 'change.opened'::text, 'change.updated'::text, 'change.closed'::text, 'stage.completed'::text, 'stage.failed'::text, 'external.checks_updated'::text, 'human.resume_requested'::text, 'human.handoff_requested'::text, 'run.cancelled'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.member": {
+      "name": "member",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organizationId_fkey": {
+          "name": "member_organizationId_fkey",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "schemaTo": "auth",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_userId_fkey": {
+          "name": "member_userId_fkey",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member_organization_user_unique": {
+          "name": "member_organization_user_unique",
+          "nullsNotDistinct": false,
+          "columns": ["organizationId", "userId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "role = ANY (ARRAY['owner'::text, 'admin'::text, 'member'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.models": {
+      "name": "models",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "models_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'anthropic'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "for_runner": {
+          "name": "for_runner",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "for_reviewer": {
+          "name": "for_reviewer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "runner_default": {
+          "name": "runner_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "runner_fast_default": {
+          "name": "runner_fast_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reviewer_default": {
+          "name": "reviewer_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reviewer_experiment_weight": {
+          "name": "reviewer_experiment_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verifier_experiment_weight": {
+          "name": "verifier_experiment_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "models_runner_default_unique": {
+          "name": "models_runner_default_unique",
+          "columns": [
+            {
+              "expression": "runner_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "runner_default",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "models_runner_fast_default_unique": {
+          "name": "models_runner_fast_default_unique",
+          "columns": [
+            {
+              "expression": "runner_fast_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "runner_fast_default",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "models_reviewer_default_unique": {
+          "name": "models_reviewer_default_unique",
+          "columns": [
+            {
+              "expression": "reviewer_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "reviewer_default",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "models_provider_model_unique": {
+          "name": "models_provider_model_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider", "model_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "models_reviewer_experiment_weight_check": {
+          "name": "models_reviewer_experiment_weight_check",
+          "value": "reviewer_experiment_weight >= 0 AND reviewer_experiment_weight <= 10000"
+        },
+        "models_verifier_experiment_weight_check": {
+          "name": "models_verifier_experiment_weight_check",
+          "value": "verifier_experiment_weight >= 0 AND verifier_experiment_weight <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.oauthAccessToken": {
+      "name": "oauthAccessToken",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_expiry_idx": {
+          "name": "oauth_access_token_expiry_idx",
+          "columns": [
+            {
+              "expression": "accessTokenExpiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauthAccessToken_clientId_fkey": {
+          "name": "oauthAccessToken_clientId_fkey",
+          "tableFrom": "oauthAccessToken",
+          "tableTo": "oauthApplication",
+          "schemaTo": "auth",
+          "columnsFrom": ["clientId"],
+          "columnsTo": ["clientId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauthAccessToken_userId_fkey": {
+          "name": "oauthAccessToken_userId_fkey",
+          "tableFrom": "oauthAccessToken",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthAccessToken_accessToken_key": {
+          "name": "oauthAccessToken_accessToken_key",
+          "nullsNotDistinct": false,
+          "columns": ["accessToken"]
+        },
+        "oauthAccessToken_refreshToken_key": {
+          "name": "oauthAccessToken_refreshToken_key",
+          "nullsNotDistinct": false,
+          "columns": ["refreshToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.oauthApplication": {
+      "name": "oauthApplication",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientSecret": {
+          "name": "clientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectUrls": {
+          "name": "redirectUrls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauthApplication_userId_fkey": {
+          "name": "oauthApplication_userId_fkey",
+          "tableFrom": "oauthApplication",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthApplication_clientId_key": {
+          "name": "oauthApplication_clientId_key",
+          "nullsNotDistinct": false,
+          "columns": ["clientId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.oauthConsent": {
+      "name": "oauthConsent",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentGiven": {
+          "name": "consentGiven",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauthConsent_clientId_fkey": {
+          "name": "oauthConsent_clientId_fkey",
+          "tableFrom": "oauthConsent",
+          "tableTo": "oauthApplication",
+          "schemaTo": "auth",
+          "columnsFrom": ["clientId"],
+          "columnsTo": ["clientId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauthConsent_userId_fkey": {
+          "name": "oauthConsent_userId_fkey",
+          "tableFrom": "oauthConsent",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_consent_client_user_unique": {
+          "name": "oauth_consent_client_user_unique",
+          "nullsNotDistinct": false,
+          "columns": ["clientId", "userId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.organization": {
+      "name": "organization",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installationId": {
+          "name": "installationId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_installationId_fkey": {
+          "name": "organization_installationId_fkey",
+          "tableFrom": "organization",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_key": {
+          "name": "organization_slug_key",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "organization_installationId_key": {
+          "name": "organization_installationId_key",
+          "nullsNotDistinct": false,
+          "columns": ["installationId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.plan_repositories": {
+      "name": "plan_repositories",
+      "schema": "app",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "plan_repositories_repository_idx": {
+          "name": "plan_repositories_repository_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plan_repositories_plan_id_fkey": {
+          "name": "plan_repositories_plan_id_fkey",
+          "tableFrom": "plan_repositories",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_repositories_repository_id_fkey": {
+          "name": "plan_repositories_repository_id_fkey",
+          "tableFrom": "plan_repositories",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "plan_repositories_pkey": {
+          "name": "plan_repositories_pkey",
+          "columns": ["plan_id", "repository_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "plan_repositories_position_unique": {
+          "name": "plan_repositories_position_unique",
+          "nullsNotDistinct": false,
+          "columns": ["plan_id", "position"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plan_repositories_position_check": {
+          "name": "plan_repositories_position_check",
+          "value": "(\"position\" >= 0) AND (\"position\" <= 2)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.plans": {
+      "name": "plans",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "plans_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "todo_id": {
+          "name": "todo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptance": {
+          "name": "acceptance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'analyzing'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_login": {
+          "name": "created_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_model": {
+          "name": "runner_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "plans_active_idx": {
+          "name": "plans_active_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(NOT archived)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plans_feature_idx": {
+          "name": "plans_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(feature_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plans_repository_created_idx": {
+          "name": "plans_repository_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plans_todo_id_todos_id_fk": {
+          "name": "plans_todo_id_todos_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "todos",
+          "schemaTo": "app",
+          "columnsFrom": ["todo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plans_feature_id_features_id_fk": {
+          "name": "plans_feature_id_features_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plans_repository_id_fkey": {
+          "name": "plans_repository_id_fkey",
+          "tableFrom": "plans",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plans_todo_unique": {
+          "name": "plans_todo_unique",
+          "nullsNotDistinct": false,
+          "columns": ["todo_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plans_status_check": {
+          "name": "plans_status_check",
+          "value": "status = ANY (ARRAY['analyzing'::text, 'awaiting_answers'::text, 'refining'::text, 'plan_ready'::text, 'approving'::text, 'approved'::text, 'failed'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "push_subscriptions_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_github_id": {
+          "name": "user_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_idx": {
+          "name": "push_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_github_id_fkey": {
+          "name": "push_subscriptions_user_github_id_fkey",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_github_id"],
+          "columnsTo": ["githubId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_key": {
+          "name": "push_subscriptions_endpoint_key",
+          "nullsNotDistinct": false,
+          "columns": ["endpoint"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repo_agents": {
+      "name": "repo_agents",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_agents_agent_tenant_idx": {
+          "name": "repo_agents_agent_tenant_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_agents_repository_tenant_idx": {
+          "name": "repo_agents_repository_tenant_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_agents_repository_tenant_fk": {
+          "name": "repo_agents_repository_tenant_fk",
+          "tableFrom": "repo_agents",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_agents_agent_tenant_fk": {
+          "name": "repo_agents_agent_tenant_fk",
+          "tableFrom": "repo_agents",
+          "tableTo": "agents",
+          "schemaTo": "app",
+          "columnsFrom": ["agent_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repo_agents_pkey": {
+          "name": "repo_agents_pkey",
+          "columns": ["repository_id", "agent_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repo_connections": {
+      "name": "repo_connections",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviews": {
+          "name": "reviews",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "automations": {
+          "name": "automations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_connections_connection_tenant_idx": {
+          "name": "repo_connections_connection_tenant_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_connections_repository_tenant_idx": {
+          "name": "repo_connections_repository_tenant_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_connections_repository_tenant_fk": {
+          "name": "repo_connections_repository_tenant_fk",
+          "tableFrom": "repo_connections",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_connections_connection_tenant_fk": {
+          "name": "repo_connections_connection_tenant_fk",
+          "tableFrom": "repo_connections",
+          "tableTo": "connections",
+          "schemaTo": "app",
+          "columnsFrom": ["connection_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repo_connections_pkey": {
+          "name": "repo_connections_pkey",
+          "columns": ["repository_id", "connection_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repo_skills": {
+      "name": "repo_skills",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_skills_repository_tenant_idx": {
+          "name": "repo_skills_repository_tenant_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_skills_skill_tenant_idx": {
+          "name": "repo_skills_skill_tenant_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_skills_repository_tenant_fk": {
+          "name": "repo_skills_repository_tenant_fk",
+          "tableFrom": "repo_skills",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_skills_skill_tenant_fk": {
+          "name": "repo_skills_skill_tenant_fk",
+          "tableFrom": "repo_skills",
+          "tableTo": "skills",
+          "schemaTo": "app",
+          "columnsFrom": ["skill_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repo_skills_pkey": {
+          "name": "repo_skills_pkey",
+          "columns": ["repository_id", "skill_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repositories": {
+      "name": "repositories",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval('app.native_entity_id_seq'::regclass)"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "artifacts_repo": {
+          "name": "artifacts_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_push_at": {
+          "name": "last_push_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_on_push": {
+          "name": "review_on_push",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_push_debounce_minutes": {
+          "name": "review_push_debounce_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "review_intake": {
+          "name": "review_intake",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'factory_only'"
+        },
+        "process_profile": {
+          "name": "process_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy_factory'"
+        },
+        "blocking_reviews": {
+          "name": "blocking_reviews",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_fix": {
+          "name": "auto_fix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "check_command": {
+          "name": "check_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_command": {
+          "name": "run_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_port": {
+          "name": "app_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_merge": {
+          "name": "auto_merge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "demo_videos": {
+          "name": "demo_videos",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "launchable": {
+          "name": "launchable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_resolve_conflicts": {
+          "name": "auto_resolve_conflicts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "repositories_artifacts_repo_unique": {
+          "name": "repositories_artifacts_repo_unique",
+          "columns": [
+            {
+              "expression": "artifacts_repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(artifacts_repo IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_enabled_idx": {
+          "name": "repositories_enabled_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_installation_idx": {
+          "name": "repositories_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_installation_provider_fk": {
+          "name": "repositories_installation_provider_fk",
+          "tableFrom": "repositories",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id", "provider"],
+          "columnsTo": ["id", "provider"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repositories_id_installation_unique": {
+          "name": "repositories_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "installation_id"]
+        },
+        "repositories_owner_name_unique": {
+          "name": "repositories_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["owner", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "repositories_review_push_debounce_check": {
+          "name": "repositories_review_push_debounce_check",
+          "value": "(review_push_debounce_minutes >= 0) AND (review_push_debounce_minutes <= 720)"
+        },
+        "repositories_provider_check": {
+          "name": "repositories_provider_check",
+          "value": "provider = ANY (ARRAY['github'::text, 'artifacts'::text])"
+        },
+        "repositories_app_port_check": {
+          "name": "repositories_app_port_check",
+          "value": "(app_port >= 1) AND (app_port <= 65535)"
+        },
+        "repositories_review_intake_check": {
+          "name": "repositories_review_intake_check",
+          "value": "review_intake = ANY (ARRAY['factory_only'::text, 'on_demand'::text, 'all_changes'::text])"
+        },
+        "repositories_process_profile_check": {
+          "name": "repositories_process_profile_check",
+          "value": "process_profile = ANY (ARRAY['review_on_demand'::text, 'automatic_review'::text, 'review_and_repair'::text, 'idea_to_pr'::text, 'assisted_delivery'::text, 'full_delivery'::text, 'native_turnkey'::text, 'legacy_factory'::text])"
+        },
+        "repositories_artifacts_shape": {
+          "name": "repositories_artifacts_shape",
+          "value": "((provider = 'artifacts'::text) AND (artifacts_repo IS NOT NULL) AND (default_branch IS NOT NULL)) OR ((provider = 'github'::text) AND (artifacts_repo IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.repository_refs": {
+      "name": "repository_refs",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pushed_at": {
+          "name": "pushed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "repository_refs_head_idx": {
+          "name": "repository_refs_head_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repository_refs_repository_id_fkey": {
+          "name": "repository_refs_repository_id_fkey",
+          "tableFrom": "repository_refs",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repository_refs_pkey": {
+          "name": "repository_refs_pkey",
+          "columns": ["repository_id", "ref"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.review_findings": {
+      "name": "review_findings",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "review_findings_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_index": {
+          "name": "candidate_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_path": {
+          "name": "failure_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verifier_confidence": {
+          "name": "verifier_confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifier_severity": {
+          "name": "verifier_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_reason": {
+          "name": "verification_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_by_github_id": {
+          "name": "feedback_by_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_at": {
+          "name": "feedback_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "review_findings_review_idx": {
+          "name": "review_findings_review_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_findings_feedback_idx": {
+          "name": "review_findings_feedback_idx",
+          "columns": [
+            {
+              "expression": "feedback",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "published",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_findings_review_id_reviews_id_fk": {
+          "name": "review_findings_review_id_reviews_id_fk",
+          "tableFrom": "review_findings",
+          "tableTo": "reviews",
+          "schemaTo": "app",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "review_findings_review_candidate_unique": {
+          "name": "review_findings_review_candidate_unique",
+          "nullsNotDistinct": false,
+          "columns": ["review_id", "candidate_index"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "review_findings_candidate_index_check": {
+          "name": "review_findings_candidate_index_check",
+          "value": "candidate_index >= 0"
+        },
+        "review_findings_line_check": {
+          "name": "review_findings_line_check",
+          "value": "line > 0"
+        },
+        "review_findings_side_check": {
+          "name": "review_findings_side_check",
+          "value": "side = ANY (ARRAY['LEFT'::text, 'RIGHT'::text])"
+        },
+        "review_findings_severity_check": {
+          "name": "review_findings_severity_check",
+          "value": "severity = ANY (ARRAY['P1'::text, 'P2'::text])"
+        },
+        "review_findings_verifier_confidence_check": {
+          "name": "review_findings_verifier_confidence_check",
+          "value": "(verifier_confidence IS NULL) OR (verifier_confidence = ANY (ARRAY['low'::text, 'medium'::text, 'high'::text]))"
+        },
+        "review_findings_verifier_severity_check": {
+          "name": "review_findings_verifier_severity_check",
+          "value": "(verifier_severity IS NULL) OR (verifier_severity = ANY (ARRAY['P1'::text, 'P2'::text]))"
+        },
+        "review_findings_feedback_check": {
+          "name": "review_findings_feedback_check",
+          "value": "(feedback IS NULL) OR (feedback = ANY (ARRAY['useful'::text, 'false_positive'::text, 'fixed'::text, 'dismissed'::text]))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.reviews": {
+      "name": "reviews",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "reviews_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event": {
+          "name": "trigger_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_url": {
+          "name": "review_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_instance_id": {
+          "name": "agent_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_tier": {
+          "name": "risk_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_count": {
+          "name": "findings_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_count": {
+          "name": "candidate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_model": {
+          "name": "verification_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_input_tokens": {
+          "name": "verification_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verification_output_tokens": {
+          "name": "verification_output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verification_cost_usd": {
+          "name": "verification_cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verification_latency_ms": {
+          "name": "verification_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiment_key": {
+          "name": "experiment_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage_run_id": {
+          "name": "stage_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_status": {
+          "name": "coverage_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewable_file_count": {
+          "name": "reviewable_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered_file_count": {
+          "name": "covered_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "missing_paths": {
+          "name": "missing_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_head_sha": {
+          "name": "coverage_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_head_sha": {
+          "name": "published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_paths": {
+          "name": "finding_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "reviews_agent_instance_idx": {
+          "name": "reviews_agent_instance_idx",
+          "columns": [
+            {
+              "expression": "agent_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_installation_time_idx": {
+          "name": "reviews_installation_time_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_one_running_instance_idx": {
+          "name": "reviews_one_running_instance_idx",
+          "columns": [
+            {
+              "expression": "agent_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((status = 'running'::text) AND (agent_instance_id IS NOT NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_repo_pr_idx": {
+          "name": "reviews_repo_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_repository_installation_idx": {
+          "name": "reviews_repository_installation_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_running_installation_idx": {
+          "name": "reviews_running_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_stage_run_idx": {
+          "name": "reviews_stage_run_idx",
+          "columns": [
+            {
+              "expression": "stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(stage_run_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_stage_run_id_stage_runs_id_fk": {
+          "name": "reviews_stage_run_id_stage_runs_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "stage_runs",
+          "schemaTo": "app",
+          "columnsFrom": ["stage_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reviews_repository_tenant_fk": {
+          "name": "reviews_repository_tenant_fk",
+          "tableFrom": "reviews",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reviews_output_tokens_check": {
+          "name": "reviews_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "reviews_cache_read_tokens_check": {
+          "name": "reviews_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "reviews_cache_write_tokens_check": {
+          "name": "reviews_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "reviews_pr_number_check": {
+          "name": "reviews_pr_number_check",
+          "value": "pr_number > 0"
+        },
+        "reviews_status_check": {
+          "name": "reviews_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'completed'::text, 'failed'::text])"
+        },
+        "reviews_input_tokens_check": {
+          "name": "reviews_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "reviews_cost_usd_check": {
+          "name": "reviews_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        },
+        "reviews_risk_tier_check": {
+          "name": "reviews_risk_tier_check",
+          "value": "(risk_tier IS NULL) OR (risk_tier = ANY (ARRAY['trivial'::text, 'lite'::text, 'full'::text]))"
+        },
+        "reviews_findings_count_check": {
+          "name": "reviews_findings_count_check",
+          "value": "(findings_count IS NULL) OR (findings_count >= 0)"
+        },
+        "reviews_candidate_count_check": {
+          "name": "reviews_candidate_count_check",
+          "value": "(candidate_count IS NULL) OR (candidate_count >= 0)"
+        },
+        "reviews_verification_status_check": {
+          "name": "reviews_verification_status_check",
+          "value": "(verification_status IS NULL) OR (verification_status = ANY (ARRAY['skipped'::text, 'completed'::text, 'failed'::text, 'incomplete'::text]))"
+        },
+        "reviews_verification_input_tokens_check": {
+          "name": "reviews_verification_input_tokens_check",
+          "value": "verification_input_tokens >= 0"
+        },
+        "reviews_verification_output_tokens_check": {
+          "name": "reviews_verification_output_tokens_check",
+          "value": "verification_output_tokens >= 0"
+        },
+        "reviews_verification_cost_usd_check": {
+          "name": "reviews_verification_cost_usd_check",
+          "value": "verification_cost_usd >= (0)::numeric"
+        },
+        "reviews_verification_latency_ms_check": {
+          "name": "reviews_verification_latency_ms_check",
+          "value": "(verification_latency_ms IS NULL) OR (verification_latency_ms >= 0)"
+        },
+        "reviews_verdict_check": {
+          "name": "reviews_verdict_check",
+          "value": "(verdict IS NULL) OR (verdict = ANY (ARRAY['approve'::text, 'comment'::text, 'request_changes'::text]))"
+        },
+        "reviews_conclusion_check": {
+          "name": "reviews_conclusion_check",
+          "value": "(conclusion IS NULL) OR (conclusion = ANY (ARRAY['ready'::text, 'ready_with_warnings'::text, 'not_ready'::text, 'inconclusive'::text]))"
+        },
+        "reviews_coverage_status_check": {
+          "name": "reviews_coverage_status_check",
+          "value": "(coverage_status IS NULL) OR (coverage_status = ANY (ARRAY['complete'::text, 'incomplete'::text, 'stale'::text]))"
+        },
+        "reviews_coverage_counts_check": {
+          "name": "reviews_coverage_counts_check",
+          "value": "(reviewable_file_count IS NULL AND covered_file_count IS NULL) OR\n        (reviewable_file_count >= 0 AND covered_file_count >= 0 AND covered_file_count <= reviewable_file_count)"
+        },
+        "reviews_missing_paths_array_check": {
+          "name": "reviews_missing_paths_array_check",
+          "value": "(missing_paths IS NULL) OR (jsonb_typeof(missing_paths) = 'array'::text)"
+        },
+        "reviews_completion_shape": {
+          "name": "reviews_completion_shape",
+          "value": "((status = 'running'::text) AND (completed_at IS NULL)) OR (status <> 'running'::text)"
+        },
+        "reviews_finding_paths_array_check": {
+          "name": "reviews_finding_paths_array_check",
+          "value": "(finding_paths IS NULL) OR (jsonb_typeof(finding_paths) = 'array'::text)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.session": {
+      "name": "session",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeOrganizationId": {
+          "name": "activeOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_active_organization_idx": {
+          "name": "session_active_organization_idx",
+          "columns": [
+            {
+              "expression": "activeOrganizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"activeOrganizationId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_expires_at_idx": {
+          "name": "session_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_fkey": {
+          "name": "session_userId_fkey",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_fk": {
+          "name": "session_active_organization_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "schemaTo": "auth",
+          "columnsFrom": ["activeOrganizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_key": {
+          "name": "session_token_key",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.skills": {
+      "name": "skills",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "skills_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skills_installation_id_fkey": {
+          "name": "skills_installation_id_fkey",
+          "tableFrom": "skills",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_id_installation_unique": {
+          "name": "skills_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "installation_id"]
+        },
+        "skills_installation_slug_unique": {
+          "name": "skills_installation_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id", "slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "skills_slug_format": {
+          "name": "skills_slug_format",
+          "value": "slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.stage_runs": {
+      "name": "stage_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "stage_runs_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "factory_run_id": {
+          "name": "factory_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_instance": {
+          "name": "workflow_instance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "stage_runs_factory_run_idx": {
+          "name": "stage_runs_factory_run_idx",
+          "columns": [
+            {
+              "expression": "factory_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stage_runs_change_idx": {
+          "name": "stage_runs_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stage_runs_factory_run_id_fkey": {
+          "name": "stage_runs_factory_run_id_fkey",
+          "tableFrom": "stage_runs",
+          "tableTo": "factory_runs",
+          "schemaTo": "app",
+          "columnsFrom": ["factory_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stage_runs_change_id_fkey": {
+          "name": "stage_runs_change_id_fkey",
+          "tableFrom": "stage_runs",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": ["change_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stage_runs_idempotency_key_unique": {
+          "name": "stage_runs_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["idempotency_key"]
+        },
+        "stage_runs_attempt_unique": {
+          "name": "stage_runs_attempt_unique",
+          "nullsNotDistinct": false,
+          "columns": ["factory_run_id", "stage", "attempt"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "stage_runs_attempt_check": {
+          "name": "stage_runs_attempt_check",
+          "value": "attempt > 0"
+        },
+        "stage_runs_status_check": {
+          "name": "stage_runs_status_check",
+          "value": "status = ANY (ARRAY['queued'::text, 'running'::text, 'completed'::text, 'failed'::text, 'cancelled'::text])"
+        },
+        "stage_runs_stage_check": {
+          "name": "stage_runs_stage_check",
+          "value": "stage = ANY (ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.todo_repositories": {
+      "name": "todo_repositories",
+      "schema": "app",
+      "columns": {
+        "todo_id": {
+          "name": "todo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "todo_repositories_repository_idx": {
+          "name": "todo_repositories_repository_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "todo_repositories_todo_id_fkey": {
+          "name": "todo_repositories_todo_id_fkey",
+          "tableFrom": "todo_repositories",
+          "tableTo": "todos",
+          "schemaTo": "app",
+          "columnsFrom": ["todo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "todo_repositories_repository_id_fkey": {
+          "name": "todo_repositories_repository_id_fkey",
+          "tableFrom": "todo_repositories",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "todo_repositories_pkey": {
+          "name": "todo_repositories_pkey",
+          "columns": ["todo_id", "repository_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "todo_repositories_position_unique": {
+          "name": "todo_repositories_position_unique",
+          "nullsNotDistinct": false,
+          "columns": ["todo_id", "position"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "todo_repositories_position_check": {
+          "name": "todo_repositories_position_check",
+          "value": "(\"position\" >= 0) AND (\"position\" <= 2)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.todos": {
+      "name": "todos",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "todos_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_login": {
+          "name": "created_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "todos_installation_unplanned_idx": {
+          "name": "todos_installation_unplanned_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(plan_id IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "todos_plan_unique": {
+          "name": "todos_plan_unique",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(plan_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "todos_plan_id_plans_id_fk": {
+          "name": "todos_plan_id_plans_id_fk",
+          "tableFrom": "todos",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "todos_installation_id_fkey": {
+          "name": "todos_installation_id_fkey",
+          "tableFrom": "todos",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.user": {
+      "name": "user",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubId": {
+          "name": "githubId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_github_id_unique": {
+          "name": "user_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["githubId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user_installation_access": {
+      "name": "user_installation_access",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_ids": {
+          "name": "installation_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_installation_access_user_id_fkey": {
+          "name": "user_installation_access_user_id_fkey",
+          "tableFrom": "user_installation_access",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_installation_access_no_null_ids": {
+          "name": "user_installation_access_no_null_ids",
+          "value": "array_position(installation_ids, NULL::bigint) IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.user_tokens": {
+      "name": "user_tokens",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_ciphertext": {
+          "name": "refresh_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.verification": {
+      "name": "verification",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_expires_at_idx": {
+          "name": "verification_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.verifications": {
+      "name": "verifications",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "verifications_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo": {
+          "name": "demo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "verifications_feature_idx": {
+          "name": "verifications_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verifications_one_running_idx": {
+          "name": "verifications_one_running_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verifications_running_created_idx": {
+          "name": "verifications_running_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verifications_feature_id_fkey": {
+          "name": "verifications_feature_id_fkey",
+          "tableFrom": "verifications",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verifications_status_check": {
+          "name": "verifications_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'passed'::text, 'failed'::text, 'error'::text, 'skipped'::text])"
+        },
+        "verifications_input_tokens_check": {
+          "name": "verifications_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "verifications_output_tokens_check": {
+          "name": "verifications_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "verifications_cache_read_tokens_check": {
+          "name": "verifications_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "verifications_cache_write_tokens_check": {
+          "name": "verifications_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "verifications_cost_usd_check": {
+          "name": "verifications_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.work_items": {
+      "name": "work_items",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "work_items_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "work_items_repo_created_idx": {
+          "name": "work_items_repo_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_items_repository_id_fkey": {
+          "name": "work_items_repository_id_fkey",
+          "tableFrom": "work_items",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "work_items_origin_check": {
+          "name": "work_items_origin_check",
+          "value": "origin = ANY (ARRAY['idea'::text, 'issue'::text, 'external_change'::text, 'automation'::text, 'api'::text])"
+        },
+        "work_items_status_check": {
+          "name": "work_items_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'closed'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "app": "app",
+    "auth": "auth"
+  },
+  "sequences": {
+    "app.native_entity_id_seq": {
+      "name": "native_entity_id_seq",
+      "schema": "app",
+      "increment": "1",
+      "startWith": "4000000000000000",
+      "minValue": "1",
+      "maxValue": "9007199254740991",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1789004826419,
       "tag": "0019_seed-cloudflare-runner-models",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1789004826420,
+      "tag": "0020_review-readiness-conclusions",
+      "breakpoints": true
     }
   ]
 }

--- a/src/ai/tools/change-requests.ts
+++ b/src/ai/tools/change-requests.ts
@@ -21,15 +21,13 @@ import { CR_BRANCH_NAME, CR_DIR } from '../runtime/cr-engine.ts';
 import { enqueueFactoryMessage } from '../../services/factory-queue.ts';
 import { generationSandbox } from '../runtime/sandbox.ts';
 import { cockpitFeatureUrl } from '../../services/urls.ts';
-import {
-  assertPinned,
-  filterDiffNoise,
-  findingSchema,
-  truncate,
-  MAX_DIFF_CHARS,
-  MAX_FILE_CHARS,
-} from './github.ts';
+import { assertPinned, findingSchema, MAX_DIFF_CHARS, MAX_FILE_CHARS, truncate } from './github.ts';
 import { findingSeverity } from '../../domain/review-findings.ts';
+import {
+  buildReviewDiffSnapshot,
+  missingReviewFiles,
+  reviewConclusion,
+} from '../../domain/review-context.ts';
 
 // Native change-request tools for the PrReviewer agent
 // (docs/artifacts-provider.md). Deliberately the SAME tool names and input
@@ -85,6 +83,7 @@ export const makeFetchCr = (pin: CrPin) =>
       const summary = comments.find((c) => c.kind === 'summary' && c.author === CR_BOT_AUTHOR);
       const diff = await getCrDiffPatch(cr);
       const files = changeRequestFiles(cr);
+      const snapshot = buildReviewDiffSnapshot(diff, MAX_DIFF_CHARS);
       return {
         output: {
           title: cr.title,
@@ -97,7 +96,17 @@ export const makeFetchCr = (pin: CrPin) =>
           changedFiles: files.length,
           additions: files.reduce((sum, f) => sum + (f.additions ?? 0), 0),
           deletions: files.reduce((sum, f) => sum + (f.deletions ?? 0), 0),
-          diff: truncate(filterDiffNoise(diff), MAX_DIFF_CHARS, 'diff'),
+          diff: snapshot.diff,
+          files: snapshot.files.map((file) => ({
+            path: file.path,
+            chars: file.chars,
+            reviewable: file.reviewable,
+            omittedReason: file.omittedReason,
+            included: file.included,
+          })),
+          includedFiles: snapshot.includedFiles,
+          remainingFiles: snapshot.remainingFiles,
+          coverageComplete: snapshot.complete,
         },
       };
     },
@@ -198,10 +207,19 @@ export const makePostCrReview = (agentInstanceId: string, pin: CrPin) =>
       number: v.number(),
       body: v.pipe(v.string(), v.minLength(1)),
       findings: v.optional(v.array(findingSchema), []),
+      reviewedFiles: v.optional(v.array(v.string()), []),
     }),
     async run({ data }) {
       assertCrPinned(pin, data.owner, data.repo);
       const { cr, repo } = await pinnedCr(pin);
+      const liveDiff = await getCrDiffPatch(cr);
+      const manifest = buildReviewDiffSnapshot(liveDiff, 0).files;
+      const missingFiles = missingReviewFiles(manifest, data.reviewedFiles);
+      const reviewableFileCount = manifest.filter((file) => file.reviewable).length;
+      const hasP1 = data.findings.map(findingSeverity).includes('P1');
+      const hasP2 = data.findings.map(findingSeverity).includes('P2');
+      const coverageComplete = missingFiles.length === 0;
+      const conclusion = reviewConclusion(hasP1, hasP2, coverageComplete);
       for (const finding of data.findings) {
         await addCrComment({
           changeRequestId: cr.id,
@@ -213,6 +231,9 @@ export const makePostCrReview = (agentInstanceId: string, pin: CrPin) =>
           body: finding.body,
         });
       }
+      const coverageNote = coverageComplete
+        ? ''
+        : `\n\n_Coverage incomplete: ${missingFiles.length} reviewable file(s) were not inspected; this review is inconclusive._`;
       await addCrComment({
         changeRequestId: cr.id,
         file: null,
@@ -220,18 +241,19 @@ export const makePostCrReview = (agentInstanceId: string, pin: CrPin) =>
         author: CR_BOT_AUTHOR,
         kind: 'summary',
         severity: null,
-        body: data.body,
+        body: `${data.body}${coverageNote}`,
       });
       // Same verdict mapping as the GitHub tool: a P1 requests changes in
       // blocking mode; otherwise the review approves.
-      const hasP1 = data.findings.map(findingSeverity).includes('P1');
       const blocking = repo.blocking_reviews && hasP1;
       await setChangeRequestReviewStatus(cr.id, blocking ? 'changes_requested' : 'approved');
       await upsertCrCheck(
         cr.id,
         'review',
-        blocking ? 'failed' : 'passed',
-        `${data.findings.length} finding(s)` + (blocking ? ' — P1 blocks merge' : ''),
+        blocking || conclusion === 'inconclusive' ? 'failed' : 'passed',
+        conclusion === 'inconclusive'
+          ? `inconclusive — ${missingFiles.length} reviewable file(s) missing`
+          : `${data.findings.length} finding(s)` + (blocking ? ' — P1 blocks merge' : ''),
       );
       const url = cr.feature_id ? cockpitFeatureUrl(cr.feature_id) : null;
       await completeLifecycleReview(
@@ -242,6 +264,16 @@ export const makePostCrReview = (agentInstanceId: string, pin: CrPin) =>
           ? 'request_changes'
           : 'approve',
         [...new Set(data.findings.map((finding) => finding.path))],
+        undefined,
+        {
+          conclusion,
+          coverageStatus: coverageComplete ? 'complete' : 'incomplete',
+          reviewableFileCount,
+          coveredFileCount: reviewableFileCount - missingFiles.length,
+          missingPaths: missingFiles,
+          coverageHeadSha: cr.source_head,
+          publishedHeadSha: cr.source_head,
+        },
       );
       if (blocking && repo.auto_fix && repo.process_profile === 'legacy_factory') {
         // Native verdicts fire no webhook, so the blocking-review fix
@@ -253,7 +285,7 @@ export const makePostCrReview = (agentInstanceId: string, pin: CrPin) =>
           trigger: 'blocking_review',
         });
       }
-      if (!blocking) await maybeAutoMergeCr(repo, cr.id);
+      if (!blocking && conclusion !== 'inconclusive') await maybeAutoMergeCr(repo, cr.id);
       return { output: { posted: true, inline: data.findings.length, url, fallback: null } };
     },
   });

--- a/src/ai/tools/github.ts
+++ b/src/ai/tools/github.ts
@@ -13,6 +13,7 @@ import {
 import {
   buildReviewDiffSnapshot,
   missingReviewFiles,
+  reviewConclusion,
   reviewPublicationEvent,
 } from '../../domain/review-context.ts';
 import { splitDiffSegments } from '../../domain/review-diff.ts';
@@ -483,11 +484,19 @@ ${JSON.stringify(candidates)}
         latencyMs: verificationLatencyMs,
         experimentKey,
       });
-      const liveDiff = await pullRequestDiff(token, data.owner, data.repo, data.number);
+      const [liveDiff, livePr] = await Promise.all([
+        pullRequestDiff(token, data.owner, data.repo, data.number),
+        gh(token, `/repos/${data.owner}/${data.repo}/pulls/${data.number}`).then((response) =>
+          response.json<{ head: { sha: string } }>(),
+        ),
+      ]);
       const manifest = buildReviewDiffSnapshot(liveDiff, 0).files;
       const missingFiles = missingReviewFiles(manifest, data.reviewedFiles);
       const hasP1 = verifiedFindings.map(findingSeverity).includes('P1');
+      const hasP2 = verifiedFindings.map(findingSeverity).includes('P2');
       const coverageComplete = missingFiles.length === 0;
+      const reviewableFileCount = manifest.filter((file) => file.reviewable).length;
+      const conclusion = reviewConclusion(hasP1, hasP2, coverageComplete, verificationComplete);
       // Verdict mapping (repo blocking mode, default off): a P1 requests
       // changes, and a fully-covered clean or P2-only review approves. A
       // partial review can comment, but absence of a finding is not approval
@@ -577,9 +586,23 @@ ${JSON.stringify(candidates)}
             : intended === 'APPROVE'
               ? 'approve'
               : 'comment';
-      await completeLifecycleReview(agentInstanceId, output.url, verifiedFindings.length, verdict, [
-        ...new Set(verifiedFindings.map((finding) => finding.path)),
-      ]);
+      await completeLifecycleReview(
+        agentInstanceId,
+        output.url,
+        verifiedFindings.length,
+        verdict,
+        [...new Set(verifiedFindings.map((finding) => finding.path))],
+        undefined,
+        {
+          conclusion,
+          coverageStatus: coverageComplete ? 'complete' : 'incomplete',
+          reviewableFileCount,
+          coveredFileCount: reviewableFileCount - missingFiles.length,
+          missingPaths: missingFiles,
+          coverageHeadSha: livePr.head.sha,
+          publishedHeadSha: livePr.head.sha,
+        },
+      );
       // Factory-PR gate: a blocking verdict on a self-authored PR never fires
       // the pull_request_review webhook trigger (the posted state is COMMENT),
       // so enqueue the fix directly. The consumer re-validates toggle and cap.

--- a/src/data/db.worker.test.ts
+++ b/src/data/db.worker.test.ts
@@ -512,13 +512,62 @@ describe('review dispatch invariants', () => {
         verdict: 'request_changes',
         head_sha: null,
         finding_paths: ['src/x.ts'],
+        conclusion: null,
       },
-      { agent_slug: 'review', verdict: 'approve', head_sha: headB, finding_paths: [] },
+      {
+        agent_slug: 'review',
+        verdict: 'approve',
+        head_sha: headB,
+        finding_paths: [],
+        conclusion: null,
+      },
     ]);
     await expect(lastReviewedHead(101, 13)).resolves.toBe(headB);
     await expect(lastReviewedHead(101, 14)).resolves.toBeNull();
     await expect(headHasCompletedReview(101, 13, headA)).resolves.toBe(true);
     await expect(headHasCompletedReview(101, 13, 'c'.repeat(40))).resolves.toBe(false);
+  });
+
+  it('persists the evidence behind a conclusive review outcome', async () => {
+    const head = 'd'.repeat(40);
+    const id = await tryRecordReview(
+      101,
+      1001,
+      14,
+      'opened',
+      'review',
+      'review--acme--api--14',
+      'full',
+      null,
+      head,
+    );
+    await completeReview('review--acme--api--14', 'https://example.test/review', 0, 'comment', [], {
+      conclusion: 'inconclusive',
+      coverageStatus: 'incomplete',
+      reviewableFileCount: 3,
+      coveredFileCount: 2,
+      missingPaths: ['src/missed.ts'],
+      coverageHeadSha: head,
+      publishedHeadSha: head,
+    });
+
+    const row = await testDatabase()
+      .prepare(
+        `SELECT conclusion, coverage_status, reviewable_file_count, covered_file_count,
+                missing_paths, coverage_head_sha, published_head_sha
+         FROM reviews WHERE id = ?1`,
+      )
+      .bind(id)
+      .first();
+    expect(row).toEqual({
+      conclusion: 'inconclusive',
+      coverage_status: 'incomplete',
+      reviewable_file_count: 3,
+      covered_file_count: 2,
+      missing_paths: ['src/missed.ts'],
+      coverage_head_sha: head,
+      published_head_sha: head,
+    });
   });
 
   it('fails a stale running claim before admitting its replacement', async () => {

--- a/src/data/factory.ts
+++ b/src/data/factory.ts
@@ -3,6 +3,7 @@ import type { CriterionResult } from '../domain/verification.ts';
 import type { ApiPlanQuestion } from '../shared/api-types.ts';
 import { STALL_AFTER_MINUTES, VERIFY_STALL_AFTER_MINUTES } from '../shared/time.ts';
 import type { CliUsage } from '../shared/usage.ts';
+import type { ReviewConclusion } from '../domain/review-context.ts';
 import { execute, queryOne, queryRows, withTransaction } from './database.ts';
 import { resolveRunnerModel } from './models.ts';
 import type { RepositoryRow } from './repositories.ts';
@@ -1122,11 +1123,27 @@ export async function completeReview(
   findingsCount: number | null = null,
   verdict: 'approve' | 'comment' | 'request_changes' = 'comment',
   findingPaths: string[] | null = null,
+  readiness?: {
+    conclusion: ReviewConclusion;
+    coverageStatus: 'complete' | 'incomplete' | 'stale';
+    reviewableFileCount: number;
+    coveredFileCount: number;
+    missingPaths: string[];
+    coverageHeadSha: string | null;
+    publishedHeadSha: string | null;
+  },
 ): Promise<{ stage_run_id: number | null } | null> {
   return queryOne<{ stage_run_id: number | null }>(sql`
     UPDATE app.reviews SET status = 'completed', completed_at = CURRENT_TIMESTAMP,
       review_url = ${reviewUrl}, findings_count = ${findingsCount}, verdict = ${verdict},
-      finding_paths = ${findingPaths === null ? null : JSON.stringify(findingPaths)}::jsonb
+      finding_paths = ${findingPaths === null ? null : JSON.stringify(findingPaths)}::jsonb,
+      conclusion = ${readiness?.conclusion ?? null},
+      coverage_status = ${readiness?.coverageStatus ?? null},
+      reviewable_file_count = ${readiness?.reviewableFileCount ?? null},
+      covered_file_count = ${readiness?.coveredFileCount ?? null},
+      missing_paths = ${readiness ? JSON.stringify(readiness.missingPaths) : null}::jsonb,
+      coverage_head_sha = ${readiness?.coverageHeadSha ?? null},
+      published_head_sha = ${readiness?.publishedHeadSha ?? null}
     WHERE id = (
       SELECT id FROM app.reviews
       WHERE agent_instance_id = ${agentInstanceId} AND status = 'running'

--- a/src/data/reviews.ts
+++ b/src/data/reviews.ts
@@ -1,6 +1,7 @@
 import { sql } from 'drizzle-orm';
 import { STALL_AFTER_MINUTES } from '../shared/time.ts';
 import type { CandidateFinding, FindingDecision } from '../domain/review-verification.ts';
+import type { ReviewConclusion } from '../domain/review-context.ts';
 import { queryOne, queryRows, withTransaction } from './database.ts';
 import { bigintArray, minutesAgo } from './sql.ts';
 
@@ -49,6 +50,13 @@ export interface ReviewActivityRow {
   findings_count: number | null; // null until post_review completes the row
   stage_run_id: number | null;
   verdict: string | null;
+  conclusion: ReviewConclusion | null;
+  coverage_status: 'complete' | 'incomplete' | 'stale' | null;
+  reviewable_file_count: number | null;
+  covered_file_count: number | null;
+  missing_paths: string[] | null;
+  coverage_head_sha: string | null;
+  published_head_sha: string | null;
   error: string | null; // why a failed row failed
   repo_owner: string | null; // null if the repo was since removed
   repo_name: string | null;
@@ -385,6 +393,7 @@ export interface ReviewStageProgress {
   completed: number;
   failed: number;
   blocking: boolean;
+  inconclusive: number;
   // Recorded reasons of the failed reviews, oldest first.
   errors: string[];
 }
@@ -395,14 +404,24 @@ export async function reviewStageProgress(stageRunId: number): Promise<ReviewSta
       COUNT(*) FILTER (WHERE status = 'running') AS running,
       COUNT(*) FILTER (WHERE status = 'completed') AS completed,
       COUNT(*) FILTER (WHERE status = 'failed') AS failed,
-      COALESCE(BOOL_OR(verdict = 'request_changes'), FALSE) AS blocking,
+      COALESCE(BOOL_OR(conclusion = 'not_ready' OR verdict = 'request_changes'), FALSE) AS blocking,
+      COUNT(*) FILTER (WHERE status = 'completed' AND conclusion = 'inconclusive') AS inconclusive,
       COALESCE(
         ARRAY_REMOVE(ARRAY_AGG(error ORDER BY id) FILTER (WHERE status = 'failed'), NULL),
         '{}'
       ) AS errors
     FROM app.reviews WHERE stage_run_id = ${stageRunId}
   `);
-  return row ?? { running: 0, completed: 0, failed: 0, blocking: false, errors: [] };
+  return (
+    row ?? {
+      running: 0,
+      completed: 0,
+      failed: 0,
+      blocking: false,
+      inconclusive: 0,
+      errors: [],
+    }
+  );
 }
 
 // True when this agent's review of this PR is running and young enough to
@@ -428,6 +447,7 @@ export interface PriorAgentReview {
   verdict: 'approve' | 'comment' | 'request_changes';
   head_sha: string | null;
   finding_paths: string[] | null; // null on rows recorded before the column existed
+  conclusion: ReviewConclusion | null;
 }
 
 // Each agent's most recent completed review of this PR — what a push
@@ -438,7 +458,7 @@ export async function latestCompletedReviewsByAgent(
   prNumber: number,
 ): Promise<PriorAgentReview[]> {
   return queryRows<PriorAgentReview>(sql`
-    SELECT DISTINCT ON (agent_slug) agent_slug, verdict, head_sha, finding_paths
+    SELECT DISTINCT ON (agent_slug) agent_slug, verdict, head_sha, finding_paths, conclusion
     FROM app.reviews
     WHERE repository_id = ${repositoryId} AND pr_number = ${prNumber}
       AND status = 'completed' AND agent_slug IS NOT NULL AND verdict IS NOT NULL

--- a/src/data/schema.ts
+++ b/src/data/schema.ts
@@ -742,6 +742,15 @@ export const reviews = appSchema.table(
       { onDelete: 'set null' },
     ),
     verdict: text(),
+    // Durable trust result. GitHub's review event is presentation; lifecycle
+    // and merge gates consume this fail-closed conclusion instead.
+    conclusion: text(),
+    coverageStatus: text('coverage_status'),
+    reviewableFileCount: integer('reviewable_file_count'),
+    coveredFileCount: integer('covered_file_count'),
+    missingPaths: jsonb('missing_paths').$type<string[]>(),
+    coverageHeadSha: text('coverage_head_sha'),
+    publishedHeadSha: text('published_head_sha'),
     // Why a failed row failed: the dispatch error or the agent's settlement
     // error. Null on completed rows.
     error: text(),
@@ -821,6 +830,23 @@ export const reviews = appSchema.table(
     check(
       'reviews_verdict_check',
       sql`(verdict IS NULL) OR (verdict = ANY (ARRAY['approve'::text, 'comment'::text, 'request_changes'::text]))`,
+    ),
+    check(
+      'reviews_conclusion_check',
+      sql`(conclusion IS NULL) OR (conclusion = ANY (ARRAY['ready'::text, 'ready_with_warnings'::text, 'not_ready'::text, 'inconclusive'::text]))`,
+    ),
+    check(
+      'reviews_coverage_status_check',
+      sql`(coverage_status IS NULL) OR (coverage_status = ANY (ARRAY['complete'::text, 'incomplete'::text, 'stale'::text]))`,
+    ),
+    check(
+      'reviews_coverage_counts_check',
+      sql`(reviewable_file_count IS NULL AND covered_file_count IS NULL) OR
+        (reviewable_file_count >= 0 AND covered_file_count >= 0 AND covered_file_count <= reviewable_file_count)`,
+    ),
+    check(
+      'reviews_missing_paths_array_check',
+      sql`(missing_paths IS NULL) OR (jsonb_typeof(missing_paths) = 'array'::text)`,
     ),
     check(
       'reviews_completion_shape',

--- a/src/domain/merge-policy.test.ts
+++ b/src/domain/merge-policy.test.ts
@@ -7,6 +7,7 @@ const GREEN: AutoMergeFacts = {
   hasAcceptanceCriteria: true,
   verificationPassed: true,
   reviewed: true,
+  reviewEvidenceConclusive: true,
   anyBlockingReview: false,
   checksGreen: true,
   hasConflict: false,
@@ -23,6 +24,7 @@ describe('autoMergeDecline', () => {
     expect(autoMergeDecline({ ...GREEN, hasAcceptanceCriteria: false })).toContain('acceptance');
     expect(autoMergeDecline({ ...GREEN, verificationPassed: false })).toContain('verification');
     expect(autoMergeDecline({ ...GREEN, reviewed: false })).toContain('review');
+    expect(autoMergeDecline({ ...GREEN, reviewEvidenceConclusive: false })).toContain('incomplete');
     expect(autoMergeDecline({ ...GREEN, anyBlockingReview: true })).toContain('requested changes');
     expect(autoMergeDecline({ ...GREEN, checksGreen: false })).toContain('checks');
     expect(autoMergeDecline({ ...GREEN, hasConflict: true })).toContain('conflict');

--- a/src/domain/merge-policy.ts
+++ b/src/domain/merge-policy.ts
@@ -19,6 +19,9 @@ export interface AutoMergeFacts {
   // At least one turbodiff review exists (another bot's approval never
   // stands in for ours having run).
   reviewed: boolean;
+  // Every required review carries current, complete evidence. A posted bot
+  // comment alone is not proof that the change was fully reviewed.
+  reviewEvidenceConclusive: boolean;
   // ANY blocking-intent review — even one superseded by a clean re-review —
   // declines in favor of a human look.
   anyBlockingReview: boolean;
@@ -33,6 +36,7 @@ export function autoMergeDecline(facts: AutoMergeFacts): string | null {
   if (!facts.hasAcceptanceCriteria) return 'no acceptance criteria to verify';
   if (!facts.verificationPassed) return 'verification not passed';
   if (!facts.reviewed) return 'no turbodiff review yet';
+  if (!facts.reviewEvidenceConclusive) return 'review evidence is incomplete or stale';
   if (facts.anyBlockingReview) return 'a review requested changes';
   if (!facts.checksGreen) return 'checks not green';
   if (facts.hasConflict) return 'merge conflict';

--- a/src/domain/review-context.test.ts
+++ b/src/domain/review-context.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vite-plus/test';
 import {
   buildReviewDiffSnapshot,
   missingReviewFiles,
+  reviewConclusion,
   reviewPublicationEvent,
 } from './review-context.ts';
 
@@ -56,5 +57,13 @@ describe('review context', () => {
     expect(reviewPublicationEvent(true, true, false)).toBe('REQUEST_CHANGES');
     expect(reviewPublicationEvent(false, true, true)).toBe('COMMENT');
     expect(reviewPublicationEvent(true, false, true, false)).toBe('COMMENT');
+  });
+
+  it('keeps uncertainty distinct from a clean or blocking conclusion', () => {
+    expect(reviewConclusion(false, false, true)).toBe('ready');
+    expect(reviewConclusion(false, true, true)).toBe('ready_with_warnings');
+    expect(reviewConclusion(true, true, true)).toBe('not_ready');
+    expect(reviewConclusion(false, false, false)).toBe('inconclusive');
+    expect(reviewConclusion(true, false, true, false)).toBe('inconclusive');
   });
 });

--- a/src/domain/review-context.ts
+++ b/src/domain/review-context.ts
@@ -101,6 +101,28 @@ export function missingReviewFiles(
 
 export type ReviewPublicationEvent = 'COMMENT' | 'REQUEST_CHANGES' | 'APPROVE';
 
+export const REVIEW_CONCLUSIONS = [
+  'ready',
+  'ready_with_warnings',
+  'not_ready',
+  'inconclusive',
+] as const;
+export type ReviewConclusion = (typeof REVIEW_CONCLUSIONS)[number];
+
+// A GitHub review event is only presentation. This is the durable trust
+// conclusion consumed by lifecycle and merge policy: uncertainty never
+// becomes a clean result merely because no blocking finding was published.
+export function reviewConclusion(
+  hasP1: boolean,
+  hasP2: boolean,
+  coverageComplete: boolean,
+  verificationComplete = true,
+): ReviewConclusion {
+  if (!coverageComplete || !verificationComplete) return 'inconclusive';
+  if (hasP1) return 'not_ready';
+  return hasP2 ? 'ready_with_warnings' : 'ready';
+}
+
 export function reviewPublicationEvent(
   blockingReviews: boolean,
   hasP1: boolean,

--- a/src/http/webhooks.worker.test.ts
+++ b/src/http/webhooks.worker.test.ts
@@ -1600,6 +1600,40 @@ describe('push re-reviews', () => {
     h.calls.length = 0;
   }
 
+  it('fails the review stage when any required review is inconclusive', async () => {
+    await seedReviewedRepo();
+    const h = harness();
+    await postWebhook(h.app, 'pull_request', pullRequest('opened', headA));
+    const stage = h.lastCommand();
+    await runLifecycleStage(stage, h.dispatch, {
+      computeRisk: async () => 'full',
+      enqueue: h.enqueue,
+    });
+
+    for (const [index, call] of h.calls.entries()) {
+      const missingPaths = index === 0 ? ['src/unread.ts'] : [];
+      await completeLifecycleReview(instance(call.slug), null, 0, 'comment', [], h.enqueue, {
+        conclusion: missingPaths.length > 0 ? 'inconclusive' : 'ready',
+        coverageStatus: missingPaths.length > 0 ? 'incomplete' : 'complete',
+        reviewableFileCount: 2,
+        coveredFileCount: 2 - missingPaths.length,
+        missingPaths,
+        coverageHeadSha: headA,
+        publishedHeadSha: headA,
+      });
+    }
+
+    await expect(getStageRun(stage.stageRunId)).resolves.toMatchObject({
+      status: 'failed',
+      output: { inconclusive: 1 },
+      error: expect.stringContaining('inconclusive'),
+    });
+    await expect(getFactoryRun(stage.factoryRunId)).resolves.toMatchObject({
+      status: 'awaiting_human',
+      handoff_reason: 'review stage failed',
+    });
+  });
+
   it('delays a push review by the repository window and records the scheduled head', async () => {
     await seedReviewedRepo();
     const h = harness();

--- a/src/http/webhooks.worker.test.ts
+++ b/src/http/webhooks.worker.test.ts
@@ -1630,7 +1630,7 @@ describe('push re-reviews', () => {
     });
     await expect(getFactoryRun(stage.factoryRunId)).resolves.toMatchObject({
       status: 'awaiting_human',
-      handoff_reason: 'review stage failed',
+      handoff_reason: 'stage failure requires retry policy evaluation',
     });
   });
 

--- a/src/services/auto-merge.ts
+++ b/src/services/auto-merge.ts
@@ -2,6 +2,7 @@ import { env } from 'cloudflare:workers';
 import { githubRequest as gh } from '../integrations/github/client.ts';
 import {
   getFeatureByRepoPr,
+  latestCompletedReviewsByAgent,
   latestVerificationForFeature,
   type RepositoryRow,
 } from '../data/db.ts';
@@ -66,19 +67,28 @@ export async function maybeAutoMerge(repo: RepositoryRow, prNumber: number): Pro
     const mergeability = await checkMergeability(token, repo.owner, repo.name, prNumber, {
       retryOnUnknown: true,
     });
+    const recordedReviews = (await latestCompletedReviewsByAgent(repo.id, prNumber)).filter(
+      (review) => review.head_sha === mergeability.headSha,
+    );
+    const reviewEvidenceConclusive =
+      recordedReviews.length > 0 &&
+      recordedReviews.every(
+        (review) => review.conclusion === 'ready' || review.conclusion === 'ready_with_warnings',
+      );
 
     const decline = autoMergeDecline({
       optedIn: repo.auto_merge,
       blockingReviews: repo.blocking_reviews,
       hasAcceptanceCriteria: Boolean(feature.acceptance),
       verificationPassed: verification?.status === 'passed',
-      reviewed: botReviews.length > 0,
+      reviewed: botReviews.length > 0 && recordedReviews.length > 0,
+      reviewEvidenceConclusive,
       anyBlockingReview: botReviews.some(
         (r) =>
           r.state === 'CHANGES_REQUESTED' ||
           (r.state === 'COMMENTED' && r.body.startsWith('**Verdict: REQUEST_CHANGES**')),
       ),
-      checksGreen: true, // GitHub CI signals arrive via the fix loop, not this gate
+      checksGreen: mergeability.mergeableState === 'clean',
       hasConflict: mergeability.hasConflict,
     });
     if (decline) {

--- a/src/services/change-requests.ts
+++ b/src/services/change-requests.ts
@@ -8,6 +8,7 @@ import {
   getOpenChangeRequest,
   getRepoById,
   latestVerificationForFeature,
+  latestCompletedReviewsByAgent,
   listChangeRequestsForRepo,
   listCrChecks,
   listCrComments,
@@ -184,6 +185,14 @@ export async function maybeAutoMergeCr(
   const feature = cr.feature_id ? await getFeature(cr.feature_id) : null;
   const verification = feature?.acceptance ? await latestVerificationForFeature(feature.id) : null;
   const checks = await listCrChecks(cr.id);
+  const recordedReviews = (await latestCompletedReviewsByAgent(repo.id, cr.number)).filter(
+    (review) => review.head_sha === cr.source_head,
+  );
+  const reviewEvidenceConclusive =
+    recordedReviews.length > 0 &&
+    recordedReviews.every(
+      (review) => review.conclusion === 'ready' || review.conclusion === 'ready_with_warnings',
+    );
 
   const decline = autoMergeDecline({
     optedIn: repo.auto_merge,
@@ -191,6 +200,7 @@ export async function maybeAutoMergeCr(
     hasAcceptanceCriteria: Boolean(feature?.acceptance),
     verificationPassed: verification?.status === 'passed',
     reviewed: cr.review_status !== null,
+    reviewEvidenceConclusive,
     anyBlockingReview: cr.review_status === 'changes_requested',
     checksGreen: checks.length > 0 && checks.every((check) => check.status === 'passed'),
     hasConflict: cr.mergeable !== true,

--- a/src/services/lifecycle.ts
+++ b/src/services/lifecycle.ts
@@ -28,6 +28,7 @@ import {
   type StageRunRow,
 } from '../data/db.ts';
 import { decideLifecycle, type LifecycleContext } from '../domain/lifecycle-coordinator.ts';
+import type { ReviewConclusion } from '../domain/review-context.ts';
 import { canResumeLifecycleRun, resumeTargetStage } from '../domain/lifecycle-resume.ts';
 import { formatUnmetCriteriaFindings } from '../domain/verification.ts';
 import { isDeliveryProcessProfile, processProfile } from '../domain/process-profiles.ts';
@@ -451,6 +452,7 @@ type ReviewStageOutput = {
   completed: number;
   failed: number;
   blocking: boolean;
+  inconclusive: number;
   errors?: string[];
 };
 
@@ -467,6 +469,7 @@ async function settleReviewStage(
     completed: progress.completed,
     failed: progress.failed,
     blocking: progress.blocking,
+    inconclusive: progress.inconclusive,
   };
   if (progress.errors.length > 0) output.errors = progress.errors;
   const command: RunStageCommand = {
@@ -493,6 +496,21 @@ async function settleReviewStage(
     await coordinateStageOutcome(command, false, enqueue);
     return;
   }
+  if (progress.failed > 0 || progress.inconclusive > 0) {
+    const reasons = [...new Set(progress.errors.filter(Boolean))];
+    if (progress.inconclusive > 0) {
+      reasons.push(`${progress.inconclusive} review(s) completed without conclusive evidence`);
+    }
+    const why = reasons.length > 0 ? `: ${reasons.join(' · ')}` : '';
+    await finishStageRun(
+      stageRun.id,
+      'failed',
+      output,
+      `review stage is inconclusive${why}`.slice(0, 1_000),
+    );
+    await coordinateStageOutcome(command, false, enqueue);
+    return;
+  }
   await finishStageRun(stageRun.id, 'completed', output);
   await coordinateStageOutcome(command, true, enqueue, {
     blockingFindings: progress.blocking,
@@ -508,6 +526,15 @@ export async function completeLifecycleReview(
   // before this agent is asked to look again.
   findingPaths: string[] = [],
   enqueue: typeof enqueueFactoryMessage = enqueueFactoryMessage,
+  readiness?: {
+    conclusion: ReviewConclusion;
+    coverageStatus: 'complete' | 'incomplete' | 'stale';
+    reviewableFileCount: number;
+    coveredFileCount: number;
+    missingPaths: string[];
+    coverageHeadSha: string | null;
+    publishedHeadSha: string | null;
+  },
 ): Promise<void> {
   const completed = await completeReview(
     agentInstanceId,
@@ -515,6 +542,7 @@ export async function completeLifecycleReview(
     findingsCount,
     verdict,
     findingPaths,
+    readiness,
   );
   if (completed?.stage_run_id) await settleReviewStage(completed.stage_run_id, enqueue);
 }

--- a/src/services/merge-conflicts.ts
+++ b/src/services/merge-conflicts.ts
@@ -18,9 +18,15 @@ export interface PrMergeability {
   mergeableState: string; // GitHub's mergeable_state: dirty | clean | unstable | blocked | behind | unknown | draft
   hasConflict: boolean; // mergeableState === 'dirty'
   baseRef: string; // the branch this PR would merge into — needed to notify/resolve
+  headSha: string;
 }
 
-type PrPayload = { mergeable: boolean | null; mergeable_state: string; base: { ref: string } };
+type PrPayload = {
+  mergeable: boolean | null;
+  mergeable_state: string;
+  base: { ref: string };
+  head: { sha: string };
+};
 
 function toMergeability(pr: PrPayload): PrMergeability {
   return {
@@ -28,6 +34,7 @@ function toMergeability(pr: PrPayload): PrMergeability {
     mergeableState: pr.mergeable_state,
     hasConflict: pr.mergeable_state === 'dirty',
     baseRef: pr.base.ref,
+    headSha: pr.head.sha,
   };
 }
 


### PR DESCRIPTION
## Summary
- persist durable review conclusions and coverage evidence
- fail review stages when any required review is incomplete or failed
- require current conclusive review evidence and green mergeability before auto-merge
- preserve GitHub review events as presentation separate from readiness

Stack 1 of 6 for trustworthy merge readiness.

## Verification
- vp test (297 tests)
- vp run check:types
- vp run test:schema (21 migrations, 50 tables)
- vp run db:check
- vp lint (pre-existing warnings only)

Worker integration tests compile, but local execution requires PostgreSQL; Docker access is unavailable in this environment.