### PR TITLE
Pin review lifecycle to exact runs and head SHAs

### DIFF
--- a/db/migrations/0021_review_run_identity.sql
+++ b/db/migrations/0021_review_run_identity.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "app"."reviews" ADD COLUMN "submission_id" text;--> statement-breakpoint
+CREATE UNIQUE INDEX "reviews_submission_id_idx" ON "app"."reviews" USING btree ("submission_id") WHERE (submission_id IS NOT NULL);

--- a/db/migrations/meta/0021_snapshot.json
+++ b/db/migrations/meta/0021_snapshot.json
@@ -1,0 +1,7640 @@
+{
+  "id": "3fca0e7a-b661-4958-bb3d-ea7a871fbb5f",
+  "prevId": "105d308f-3ee2-4143-8bb8-fd594e3adfd1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app.acceptance_contracts": {
+      "name": "acceptance_contracts",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "acceptance_contracts_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria": {
+          "name": "criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "acceptance_contracts_work_item_idx": {
+          "name": "acceptance_contracts_work_item_idx",
+          "columns": [
+            {
+              "expression": "work_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acceptance_contracts_change_idx": {
+          "name": "acceptance_contracts_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acceptance_contracts_work_item_id_fkey": {
+          "name": "acceptance_contracts_work_item_id_fkey",
+          "tableFrom": "acceptance_contracts",
+          "tableTo": "work_items",
+          "schemaTo": "app",
+          "columnsFrom": ["work_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acceptance_contracts_change_id_fkey": {
+          "name": "acceptance_contracts_change_id_fkey",
+          "tableFrom": "acceptance_contracts",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": ["change_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "acceptance_contracts_version_check": {
+          "name": "acceptance_contracts_version_check",
+          "value": "version > 0"
+        },
+        "acceptance_contracts_owner_check": {
+          "name": "acceptance_contracts_owner_check",
+          "value": "(work_item_id IS NOT NULL) OR (change_id IS NOT NULL)"
+        },
+        "acceptance_contracts_criteria_array_check": {
+          "name": "acceptance_contracts_criteria_array_check",
+          "value": "jsonb_typeof(criteria) = 'array'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.account": {
+      "name": "account",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_fkey": {
+          "name": "account_userId_fkey",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_provider_identity_unique": {
+          "name": "account_provider_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": ["accountId", "providerId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.agent_runs": {
+      "name": "agent_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "agent_runs_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fix_attempt_id": {
+          "name": "fix_attempt_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_run_id": {
+          "name": "automation_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_key": {
+          "name": "log_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "agent_runs_automation_idx": {
+          "name": "agent_runs_automation_idx",
+          "columns": [
+            {
+              "expression": "automation_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(automation_run_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_feature_idx": {
+          "name": "agent_runs_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(feature_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_fix_attempt_idx": {
+          "name": "agent_runs_fix_attempt_idx",
+          "columns": [
+            {
+              "expression": "fix_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(fix_attempt_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runs_plan_idx": {
+          "name": "agent_runs_plan_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(plan_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_plan_id_fkey": {
+          "name": "agent_runs_plan_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_feature_id_fkey": {
+          "name": "agent_runs_feature_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_fix_attempt_id_fkey": {
+          "name": "agent_runs_fix_attempt_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "fix_attempts",
+          "schemaTo": "app",
+          "columnsFrom": ["fix_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_automation_run_id_fkey": {
+          "name": "agent_runs_automation_run_id_fkey",
+          "tableFrom": "agent_runs",
+          "tableTo": "automation_runs",
+          "schemaTo": "app",
+          "columnsFrom": ["automation_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_runs_kind_check": {
+          "name": "agent_runs_kind_check",
+          "value": "kind = ANY (ARRAY['plan_analyze'::text, 'plan_refine'::text, 'generate'::text, 'verify'::text, 'fix'::text, 'automation'::text, 'chat'::text, 'resolve_conflict'::text])"
+        },
+        "agent_runs_owner": {
+          "name": "agent_runs_owner",
+          "value": "num_nonnulls(plan_id, feature_id, fix_attempt_id, automation_run_id) >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.agents": {
+      "name": "agents",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "agents_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloudflare/anthropic/claude-sonnet-5'"
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_installation_id_fkey": {
+          "name": "agents_installation_id_fkey",
+          "tableFrom": "agents",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_id_installation_unique": {
+          "name": "agents_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "installation_id"]
+        },
+        "agents_installation_slug_unique": {
+          "name": "agents_installation_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id", "slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "agents_slug_format": {
+          "name": "agents_slug_format",
+          "value": "slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.automation_runs": {
+      "name": "automation_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "automation_runs_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "automation_runs_automation_idx": {
+          "name": "automation_runs_automation_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_one_running_idx": {
+          "name": "automation_runs_one_running_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_id_fkey": {
+          "name": "automation_runs_automation_id_fkey",
+          "tableFrom": "automation_runs",
+          "tableTo": "automations",
+          "schemaTo": "app",
+          "columnsFrom": ["automation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "automation_runs_status_check": {
+          "name": "automation_runs_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'pr_opened'::text, 'no_changes'::text, 'checks_failed'::text, 'failed'::text])"
+        },
+        "automation_runs_pr_number_check": {
+          "name": "automation_runs_pr_number_check",
+          "value": "(pr_number IS NULL) OR (pr_number > 0)"
+        },
+        "automation_runs_input_tokens_check": {
+          "name": "automation_runs_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "automation_runs_output_tokens_check": {
+          "name": "automation_runs_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "automation_runs_cache_read_tokens_check": {
+          "name": "automation_runs_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "automation_runs_cache_write_tokens_check": {
+          "name": "automation_runs_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "automation_runs_cost_usd_check": {
+          "name": "automation_runs_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.automations": {
+      "name": "automations",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "automations_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_kind": {
+          "name": "schedule_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_of_day": {
+          "name": "time_of_day",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "runner_model": {
+          "name": "runner_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "automations_due_idx": {
+          "name": "automations_due_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automations_repository_idx": {
+          "name": "automations_repository_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automations_repository_id_fkey": {
+          "name": "automations_repository_id_fkey",
+          "tableFrom": "automations",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "automations_schedule_kind_check": {
+          "name": "automations_schedule_kind_check",
+          "value": "schedule_kind = ANY (ARRAY['hourly'::text, 'daily'::text, 'weekly'::text])"
+        },
+        "automations_day_of_week_check": {
+          "name": "automations_day_of_week_check",
+          "value": "(day_of_week >= 0) AND (day_of_week <= 6)"
+        },
+        "automations_schedule_shape": {
+          "name": "automations_schedule_shape",
+          "value": "((schedule_kind = 'hourly'::text) AND (time_of_day IS NULL) AND (day_of_week IS NULL)) OR ((schedule_kind = 'daily'::text) AND (time_of_day IS NOT NULL) AND (day_of_week IS NULL)) OR ((schedule_kind = 'weekly'::text) AND (time_of_day IS NOT NULL) AND (day_of_week IS NOT NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.change_request_counters": {
+      "name": "change_request_counters",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_number": {
+          "name": "last_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "change_request_counters_repository_id_fkey": {
+          "name": "change_request_counters_repository_id_fkey",
+          "tableFrom": "change_request_counters",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "change_request_counters_last_number_check": {
+          "name": "change_request_counters_last_number_check",
+          "value": "last_number > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.change_requests": {
+      "name": "change_requests",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "change_requests_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_branch": {
+          "name": "source_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "source_head": {
+          "name": "source_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_head": {
+          "name": "target_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_base": {
+          "name": "merge_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mergeable": {
+          "name": "mergeable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_files": {
+          "name": "conflict_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff_key": {
+          "name": "diff_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patch_truncated": {
+          "name": "patch_truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_head": {
+          "name": "merged_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_by": {
+          "name": "opened_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'factory'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "change_requests_feature_idx": {
+          "name": "change_requests_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(feature_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_requests_change_unique": {
+          "name": "change_requests_change_unique",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_requests_open_branches_unique": {
+          "name": "change_requests_open_branches_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'open'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_requests_repo_status_idx": {
+          "name": "change_requests_repo_status_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_requests_feature_id_features_id_fk": {
+          "name": "change_requests_feature_id_features_id_fk",
+          "tableFrom": "change_requests",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "change_requests_change_id_changes_id_fk": {
+          "name": "change_requests_change_id_changes_id_fk",
+          "tableFrom": "change_requests",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": ["change_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_requests_repository_id_fkey": {
+          "name": "change_requests_repository_id_fkey",
+          "tableFrom": "change_requests",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "change_requests_repo_number_unique": {
+          "name": "change_requests_repo_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["repository_id", "number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "change_requests_number_check": {
+          "name": "change_requests_number_check",
+          "value": "number > 0"
+        },
+        "change_requests_status_check": {
+          "name": "change_requests_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'merged'::text, 'closed'::text])"
+        },
+        "change_requests_review_status_check": {
+          "name": "change_requests_review_status_check",
+          "value": "(review_status IS NULL) OR (review_status = ANY (ARRAY['approved'::text, 'changes_requested'::text]))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.changes": {
+      "name": "changes",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "changes_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_key": {
+          "name": "provider_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_branch": {
+          "name": "source_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "source_head": {
+          "name": "source_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_head": {
+          "name": "target_head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "changes_repo_status_idx": {
+          "name": "changes_repo_status_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "changes_repository_id_fkey": {
+          "name": "changes_repository_id_fkey",
+          "tableFrom": "changes",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "changes_repo_provider_key_unique": {
+          "name": "changes_repo_provider_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["repository_id", "provider_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "changes_number_check": {
+          "name": "changes_number_check",
+          "value": "number > 0"
+        },
+        "changes_origin_check": {
+          "name": "changes_origin_check",
+          "value": "origin = ANY (ARRAY['human'::text, 'factory'::text, 'automation'::text, 'imported'::text])"
+        },
+        "changes_status_check": {
+          "name": "changes_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'merged'::text, 'closed'::text])"
+        },
+        "changes_capabilities_array_check": {
+          "name": "changes_capabilities_array_check",
+          "value": "jsonb_typeof(capabilities) = 'array'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.chat_messages": {
+      "name": "chat_messages",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "chat_messages_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'done'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "chat_messages_feature_idx": {
+          "name": "chat_messages_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_one_pending_user_idx": {
+          "name": "chat_messages_one_pending_user_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((role = 'user'::text) AND (status = ANY (ARRAY['queued'::text, 'running'::text])))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_feature_id_fkey": {
+          "name": "chat_messages_feature_id_fkey",
+          "tableFrom": "chat_messages",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_messages_role_check": {
+          "name": "chat_messages_role_check",
+          "value": "role = ANY (ARRAY['user'::text, 'assistant'::text])"
+        },
+        "chat_messages_status_check": {
+          "name": "chat_messages_status_check",
+          "value": "status = ANY (ARRAY['queued'::text, 'running'::text, 'done'::text, 'failed'::text])"
+        },
+        "chat_messages_outcome_check": {
+          "name": "chat_messages_outcome_check",
+          "value": "(outcome IS NULL) OR (outcome = ANY (ARRAY['changed'::text, 'no_changes'::text, 'tests_failed'::text]))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.cockpit_comments": {
+      "name": "cockpit_comments",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cockpit_comments_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'additions'"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "fix_attempt_id": {
+          "name": "fix_attempt_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "cockpit_comments_feature_idx": {
+          "name": "cockpit_comments_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cockpit_comments_fix_attempt_idx": {
+          "name": "cockpit_comments_fix_attempt_idx",
+          "columns": [
+            {
+              "expression": "fix_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(fix_attempt_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cockpit_comments_feature_id_fkey": {
+          "name": "cockpit_comments_feature_id_fkey",
+          "tableFrom": "cockpit_comments",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cockpit_comments_fix_attempt_id_fkey": {
+          "name": "cockpit_comments_fix_attempt_id_fkey",
+          "tableFrom": "cockpit_comments",
+          "tableTo": "fix_attempts",
+          "schemaTo": "app",
+          "columnsFrom": ["fix_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cockpit_comments_line_check": {
+          "name": "cockpit_comments_line_check",
+          "value": "line > 0"
+        },
+        "cockpit_comments_side_check": {
+          "name": "cockpit_comments_side_check",
+          "value": "side = ANY (ARRAY['additions'::text, 'deletions'::text])"
+        },
+        "cockpit_comments_status_check": {
+          "name": "cockpit_comments_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'dispatched'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.connections": {
+      "name": "connections",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "connections_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mcp'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_allowlist": {
+          "name": "tool_allowlist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_ciphertext": {
+          "name": "auth_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optional": {
+          "name": "optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "auth_config_ciphertext": {
+          "name": "auth_config_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_expires_at": {
+          "name": "oauth_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_needs_reauth": {
+          "name": "oauth_needs_reauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "oauth_has_refresh_token": {
+          "name": "oauth_has_refresh_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connections_installation_id_fkey": {
+          "name": "connections_installation_id_fkey",
+          "tableFrom": "connections",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_id_installation_unique": {
+          "name": "connections_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "installation_id"]
+        },
+        "connections_installation_name_unique": {
+          "name": "connections_installation_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "connections_kind_check": {
+          "name": "connections_kind_check",
+          "value": "kind = ANY (ARRAY['mcp'::text, 'api'::text])"
+        },
+        "connections_auth_type_check": {
+          "name": "connections_auth_type_check",
+          "value": "auth_type = ANY (ARRAY['none'::text, 'bearer'::text, 'api_key'::text, 'client_credentials'::text, 'oauth'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.cr_checks": {
+      "name": "cr_checks",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cr_checks_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cr_checks_change_request_id_fkey": {
+          "name": "cr_checks_change_request_id_fkey",
+          "tableFrom": "cr_checks",
+          "tableTo": "change_requests",
+          "schemaTo": "app",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cr_checks_name_unique": {
+          "name": "cr_checks_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["change_request_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cr_checks_status_check": {
+          "name": "cr_checks_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'passed'::text, 'failed'::text, 'error'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.cr_comments": {
+      "name": "cr_comments",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cr_comments_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'comment'"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "cr_comments_change_request_idx": {
+          "name": "cr_comments_change_request_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cr_comments_change_request_id_fkey": {
+          "name": "cr_comments_change_request_id_fkey",
+          "tableFrom": "cr_comments",
+          "tableTo": "change_requests",
+          "schemaTo": "app",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cr_comments_line_check": {
+          "name": "cr_comments_line_check",
+          "value": "(line IS NULL) OR (line > 0)"
+        },
+        "cr_comments_kind_check": {
+          "name": "cr_comments_kind_check",
+          "value": "kind = ANY (ARRAY['comment'::text, 'finding'::text, 'summary'::text])"
+        },
+        "cr_comments_severity_check": {
+          "name": "cr_comments_severity_check",
+          "value": "(severity IS NULL) OR (severity = ANY (ARRAY['P1'::text, 'P2'::text, 'P3'::text]))"
+        },
+        "cr_comments_location": {
+          "name": "cr_comments_location",
+          "value": "((file IS NULL) AND (line IS NULL)) OR (file IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.factory_runs": {
+      "name": "factory_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "factory_runs_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_item_id": {
+          "name": "work_item_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_key": {
+          "name": "profile_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_stage": {
+          "name": "start_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stop_after_stage": {
+          "name": "stop_after_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_snapshot": {
+          "name": "policy_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "handoff_reason": {
+          "name": "handoff_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "factory_runs_repo_created_idx": {
+          "name": "factory_runs_repo_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "factory_runs_change_idx": {
+          "name": "factory_runs_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "factory_runs_work_item_idx": {
+          "name": "factory_runs_work_item_idx",
+          "columns": [
+            {
+              "expression": "work_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(work_item_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "factory_runs_repository_id_fkey": {
+          "name": "factory_runs_repository_id_fkey",
+          "tableFrom": "factory_runs",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "factory_runs_work_item_id_fkey": {
+          "name": "factory_runs_work_item_id_fkey",
+          "tableFrom": "factory_runs",
+          "tableTo": "work_items",
+          "schemaTo": "app",
+          "columnsFrom": ["work_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "factory_runs_change_id_fkey": {
+          "name": "factory_runs_change_id_fkey",
+          "tableFrom": "factory_runs",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": ["change_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "factory_runs_idempotency_key_unique": {
+          "name": "factory_runs_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["idempotency_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "factory_runs_status_check": {
+          "name": "factory_runs_status_check",
+          "value": "status = ANY (ARRAY['active'::text, 'awaiting_human'::text, 'handed_off'::text, 'completed'::text, 'failed'::text, 'cancelled'::text])"
+        },
+        "factory_runs_profile_check": {
+          "name": "factory_runs_profile_check",
+          "value": "profile_key = ANY (ARRAY['review_on_demand'::text, 'automatic_review'::text, 'review_and_repair'::text, 'idea_to_pr'::text, 'assisted_delivery'::text, 'full_delivery'::text, 'native_turnkey'::text, 'legacy_factory'::text])"
+        },
+        "factory_runs_stage_check": {
+          "name": "factory_runs_stage_check",
+          "value": "start_stage = ANY (ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text]) AND stop_after_stage = ANY (ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text])"
+        },
+        "factory_runs_stage_order_check": {
+          "name": "factory_runs_stage_order_check",
+          "value": "array_position(ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text], start_stage) <= array_position(ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text], stop_after_stage)"
+        },
+        "factory_runs_policy_object_check": {
+          "name": "factory_runs_policy_object_check",
+          "value": "jsonb_typeof(policy_snapshot) = 'object'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.factory_version": {
+      "name": "factory_version",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "factory_version_singleton_check": {
+          "name": "factory_version_singleton_check",
+          "value": "id = 1"
+        },
+        "factory_version_positive_check": {
+          "name": "factory_version_positive_check",
+          "value": "version > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.feature_explanations": {
+      "name": "feature_explanations",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "feature_explanations_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "agent_instance_id": {
+          "name": "agent_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feature_explanations_feature_head_idx": {
+          "name": "feature_explanations_feature_head_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feature_explanations_instance_idx": {
+          "name": "feature_explanations_instance_idx",
+          "columns": [
+            {
+              "expression": "agent_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feature_explanations_one_running_idx": {
+          "name": "feature_explanations_one_running_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feature_explanations_feature_id_fkey": {
+          "name": "feature_explanations_feature_id_fkey",
+          "tableFrom": "feature_explanations",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feature_explanations_status_check": {
+          "name": "feature_explanations_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'ready'::text, 'failed'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.features": {
+      "name": "features",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "features_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptance": {
+          "name": "acceptance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_login": {
+          "name": "coauthor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_id": {
+          "name": "coauthor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_started_at": {
+          "name": "run_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_model": {
+          "name": "runner_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criteria_conflict": {
+          "name": "criteria_conflict",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "acceptance_updated_at": {
+          "name": "acceptance_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_acceptance": {
+          "name": "proposed_acceptance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_session_id": {
+          "name": "chat_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "features_change_request_idx": {
+          "name": "features_change_request_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_request_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_change_idx": {
+          "name": "features_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_generating_created_idx": {
+          "name": "features_generating_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(status = 'generating'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_open_pr_idx": {
+          "name": "features_open_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((status = 'pr_opened'::text) AND (pr_number IS NOT NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_plan_idx": {
+          "name": "features_plan_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(plan_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_repository_created_idx": {
+          "name": "features_repository_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "features_repository_pr_idx": {
+          "name": "features_repository_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(pr_number IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "features_plan_id_plans_id_fk": {
+          "name": "features_plan_id_plans_id_fk",
+          "tableFrom": "features",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "features_change_request_id_change_requests_id_fk": {
+          "name": "features_change_request_id_change_requests_id_fk",
+          "tableFrom": "features",
+          "tableTo": "change_requests",
+          "schemaTo": "app",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "features_change_id_changes_id_fk": {
+          "name": "features_change_id_changes_id_fk",
+          "tableFrom": "features",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": ["change_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "features_repository_id_fkey": {
+          "name": "features_repository_id_fkey",
+          "tableFrom": "features",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "features_plan_repository_unique": {
+          "name": "features_plan_repository_unique",
+          "nullsNotDistinct": false,
+          "columns": ["plan_id", "repository_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "features_pr_number_check": {
+          "name": "features_pr_number_check",
+          "value": "pr_number > 0"
+        },
+        "features_status_check": {
+          "name": "features_status_check",
+          "value": "status = ANY (ARRAY['queued'::text, 'generating'::text, 'pr_opened'::text, 'no_changes'::text, 'checks_failed'::text, 'failed'::text, 'merged'::text, 'pr_closed'::text, 'abandoned'::text])"
+        },
+        "features_input_tokens_check": {
+          "name": "features_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "features_output_tokens_check": {
+          "name": "features_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "features_cache_read_tokens_check": {
+          "name": "features_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "features_cache_write_tokens_check": {
+          "name": "features_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "features_cost_usd_check": {
+          "name": "features_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.fix_attempts": {
+      "name": "fix_attempts",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "fix_attempts_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage_run_id": {
+          "name": "stage_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "fix_attempts_one_running_idx": {
+          "name": "fix_attempts_one_running_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fix_attempts_pr_idx": {
+          "name": "fix_attempts_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fix_attempts_stage_run_idx": {
+          "name": "fix_attempts_stage_run_idx",
+          "columns": [
+            {
+              "expression": "stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(stage_run_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fix_attempts_stage_run_id_stage_runs_id_fk": {
+          "name": "fix_attempts_stage_run_id_stage_runs_id_fk",
+          "tableFrom": "fix_attempts",
+          "tableTo": "stage_runs",
+          "schemaTo": "app",
+          "columnsFrom": ["stage_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fix_attempts_repository_id_fkey": {
+          "name": "fix_attempts_repository_id_fkey",
+          "tableFrom": "fix_attempts",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "fix_attempts_pr_number_check": {
+          "name": "fix_attempts_pr_number_check",
+          "value": "pr_number > 0"
+        },
+        "fix_attempts_status_check": {
+          "name": "fix_attempts_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'fixed'::text, 'no_changes'::text, 'tests_failed'::text, 'failed'::text])"
+        },
+        "fix_attempts_input_tokens_check": {
+          "name": "fix_attempts_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "fix_attempts_output_tokens_check": {
+          "name": "fix_attempts_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "fix_attempts_cache_read_tokens_check": {
+          "name": "fix_attempts_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "fix_attempts_cache_write_tokens_check": {
+          "name": "fix_attempts_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "fix_attempts_cost_usd_check": {
+          "name": "fix_attempts_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.installation_repo_sync": {
+      "name": "installation_repo_sync",
+      "schema": "app",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncing_until": {
+          "name": "syncing_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "installation_repo_sync_installation_id_fkey": {
+          "name": "installation_repo_sync_installation_id_fkey",
+          "tableFrom": "installation_repo_sync",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.installations": {
+      "name": "installations",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval('app.native_entity_id_seq'::regclass)"
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended": {
+          "name": "suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "installer_github_id": {
+          "name": "installer_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "installations_installer_idx": {
+          "name": "installations_installer_idx",
+          "columns": [
+            {
+              "expression": "installer_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(installer_github_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "installations_id_provider_unique": {
+          "name": "installations_id_provider_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "provider"]
+        },
+        "installations_provider_login_unique": {
+          "name": "installations_provider_login_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider", "account_login"]
+        },
+        "installations_provider_account_unique": {
+          "name": "installations_provider_account_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider", "account_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "installations_account_type_check": {
+          "name": "installations_account_type_check",
+          "value": "account_type = ANY (ARRAY['Organization'::text, 'User'::text])"
+        },
+        "installations_provider_check": {
+          "name": "installations_provider_check",
+          "value": "provider = ANY (ARRAY['github'::text, 'artifacts'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.invitation": {
+      "name": "invitation",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviterId": {
+          "name": "inviterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_email_status_idx": {
+          "name": "invitation_email_status_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_idx": {
+          "name": "invitation_inviter_idx",
+          "columns": [
+            {
+              "expression": "inviterId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_organization_idx": {
+          "name": "invitation_organization_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_pending_email_unique": {
+          "name": "invitation_pending_email_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'pending'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organizationId_fkey": {
+          "name": "invitation_organizationId_fkey",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "schemaTo": "auth",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviterId_fkey": {
+          "name": "invitation_inviterId_fkey",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["inviterId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "role = ANY (ARRAY['owner'::text, 'admin'::text, 'member'::text])"
+        },
+        "invitation_status_check": {
+          "name": "invitation_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'accepted'::text, 'rejected'::text, 'canceled'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.lifecycle_events": {
+      "name": "lifecycle_events",
+      "schema": "app",
+      "columns": {
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "factory_run_id": {
+          "name": "factory_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "lifecycle_events_factory_run_idx": {
+          "name": "lifecycle_events_factory_run_idx",
+          "columns": [
+            {
+              "expression": "factory_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lifecycle_events_change_idx": {
+          "name": "lifecycle_events_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lifecycle_events_factory_run_id_fkey": {
+          "name": "lifecycle_events_factory_run_id_fkey",
+          "tableFrom": "lifecycle_events",
+          "tableTo": "factory_runs",
+          "schemaTo": "app",
+          "columnsFrom": ["factory_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lifecycle_events_change_id_fkey": {
+          "name": "lifecycle_events_change_id_fkey",
+          "tableFrom": "lifecycle_events",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": ["change_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lifecycle_events_kind_check": {
+          "name": "lifecycle_events_kind_check",
+          "value": "kind = ANY (ARRAY['work.requested'::text, 'plan.ready'::text, 'human.approved'::text, 'change.opened'::text, 'change.updated'::text, 'change.closed'::text, 'stage.completed'::text, 'stage.failed'::text, 'external.checks_updated'::text, 'human.resume_requested'::text, 'human.handoff_requested'::text, 'run.cancelled'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.member": {
+      "name": "member",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organizationId_fkey": {
+          "name": "member_organizationId_fkey",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "schemaTo": "auth",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_userId_fkey": {
+          "name": "member_userId_fkey",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "member_organization_user_unique": {
+          "name": "member_organization_user_unique",
+          "nullsNotDistinct": false,
+          "columns": ["organizationId", "userId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "role = ANY (ARRAY['owner'::text, 'admin'::text, 'member'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.models": {
+      "name": "models",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "models_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'anthropic'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "for_runner": {
+          "name": "for_runner",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "for_reviewer": {
+          "name": "for_reviewer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "runner_default": {
+          "name": "runner_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "runner_fast_default": {
+          "name": "runner_fast_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reviewer_default": {
+          "name": "reviewer_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reviewer_experiment_weight": {
+          "name": "reviewer_experiment_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verifier_experiment_weight": {
+          "name": "verifier_experiment_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "models_runner_default_unique": {
+          "name": "models_runner_default_unique",
+          "columns": [
+            {
+              "expression": "runner_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "runner_default",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "models_runner_fast_default_unique": {
+          "name": "models_runner_fast_default_unique",
+          "columns": [
+            {
+              "expression": "runner_fast_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "runner_fast_default",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "models_reviewer_default_unique": {
+          "name": "models_reviewer_default_unique",
+          "columns": [
+            {
+              "expression": "reviewer_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "reviewer_default",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "models_provider_model_unique": {
+          "name": "models_provider_model_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider", "model_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "models_reviewer_experiment_weight_check": {
+          "name": "models_reviewer_experiment_weight_check",
+          "value": "reviewer_experiment_weight >= 0 AND reviewer_experiment_weight <= 10000"
+        },
+        "models_verifier_experiment_weight_check": {
+          "name": "models_verifier_experiment_weight_check",
+          "value": "verifier_experiment_weight >= 0 AND verifier_experiment_weight <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.oauthAccessToken": {
+      "name": "oauthAccessToken",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_expiry_idx": {
+          "name": "oauth_access_token_expiry_idx",
+          "columns": [
+            {
+              "expression": "accessTokenExpiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauthAccessToken_clientId_fkey": {
+          "name": "oauthAccessToken_clientId_fkey",
+          "tableFrom": "oauthAccessToken",
+          "tableTo": "oauthApplication",
+          "schemaTo": "auth",
+          "columnsFrom": ["clientId"],
+          "columnsTo": ["clientId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauthAccessToken_userId_fkey": {
+          "name": "oauthAccessToken_userId_fkey",
+          "tableFrom": "oauthAccessToken",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthAccessToken_accessToken_key": {
+          "name": "oauthAccessToken_accessToken_key",
+          "nullsNotDistinct": false,
+          "columns": ["accessToken"]
+        },
+        "oauthAccessToken_refreshToken_key": {
+          "name": "oauthAccessToken_refreshToken_key",
+          "nullsNotDistinct": false,
+          "columns": ["refreshToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.oauthApplication": {
+      "name": "oauthApplication",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientSecret": {
+          "name": "clientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectUrls": {
+          "name": "redirectUrls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_application_user_id_idx": {
+          "name": "oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauthApplication_userId_fkey": {
+          "name": "oauthApplication_userId_fkey",
+          "tableFrom": "oauthApplication",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthApplication_clientId_key": {
+          "name": "oauthApplication_clientId_key",
+          "nullsNotDistinct": false,
+          "columns": ["clientId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.oauthConsent": {
+      "name": "oauthConsent",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentGiven": {
+          "name": "consentGiven",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauthConsent_clientId_fkey": {
+          "name": "oauthConsent_clientId_fkey",
+          "tableFrom": "oauthConsent",
+          "tableTo": "oauthApplication",
+          "schemaTo": "auth",
+          "columnsFrom": ["clientId"],
+          "columnsTo": ["clientId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauthConsent_userId_fkey": {
+          "name": "oauthConsent_userId_fkey",
+          "tableFrom": "oauthConsent",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_consent_client_user_unique": {
+          "name": "oauth_consent_client_user_unique",
+          "nullsNotDistinct": false,
+          "columns": ["clientId", "userId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.organization": {
+      "name": "organization",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installationId": {
+          "name": "installationId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_installationId_fkey": {
+          "name": "organization_installationId_fkey",
+          "tableFrom": "organization",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_key": {
+          "name": "organization_slug_key",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "organization_installationId_key": {
+          "name": "organization_installationId_key",
+          "nullsNotDistinct": false,
+          "columns": ["installationId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.plan_repositories": {
+      "name": "plan_repositories",
+      "schema": "app",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "plan_repositories_repository_idx": {
+          "name": "plan_repositories_repository_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plan_repositories_plan_id_fkey": {
+          "name": "plan_repositories_plan_id_fkey",
+          "tableFrom": "plan_repositories",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_repositories_repository_id_fkey": {
+          "name": "plan_repositories_repository_id_fkey",
+          "tableFrom": "plan_repositories",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "plan_repositories_pkey": {
+          "name": "plan_repositories_pkey",
+          "columns": ["plan_id", "repository_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "plan_repositories_position_unique": {
+          "name": "plan_repositories_position_unique",
+          "nullsNotDistinct": false,
+          "columns": ["plan_id", "position"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plan_repositories_position_check": {
+          "name": "plan_repositories_position_check",
+          "value": "(\"position\" >= 0) AND (\"position\" <= 2)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.plans": {
+      "name": "plans",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "plans_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "todo_id": {
+          "name": "todo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptance": {
+          "name": "acceptance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'analyzing'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_login": {
+          "name": "created_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_model": {
+          "name": "runner_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "plans_active_idx": {
+          "name": "plans_active_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(NOT archived)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plans_feature_idx": {
+          "name": "plans_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(feature_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plans_repository_created_idx": {
+          "name": "plans_repository_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plans_todo_id_todos_id_fk": {
+          "name": "plans_todo_id_todos_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "todos",
+          "schemaTo": "app",
+          "columnsFrom": ["todo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plans_feature_id_features_id_fk": {
+          "name": "plans_feature_id_features_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "plans_repository_id_fkey": {
+          "name": "plans_repository_id_fkey",
+          "tableFrom": "plans",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plans_todo_unique": {
+          "name": "plans_todo_unique",
+          "nullsNotDistinct": false,
+          "columns": ["todo_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "plans_status_check": {
+          "name": "plans_status_check",
+          "value": "status = ANY (ARRAY['analyzing'::text, 'awaiting_answers'::text, 'refining'::text, 'plan_ready'::text, 'approving'::text, 'approved'::text, 'failed'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "push_subscriptions_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_github_id": {
+          "name": "user_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_idx": {
+          "name": "push_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_github_id_fkey": {
+          "name": "push_subscriptions_user_github_id_fkey",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_github_id"],
+          "columnsTo": ["githubId"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_key": {
+          "name": "push_subscriptions_endpoint_key",
+          "nullsNotDistinct": false,
+          "columns": ["endpoint"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repo_agents": {
+      "name": "repo_agents",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_agents_agent_tenant_idx": {
+          "name": "repo_agents_agent_tenant_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_agents_repository_tenant_idx": {
+          "name": "repo_agents_repository_tenant_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_agents_repository_tenant_fk": {
+          "name": "repo_agents_repository_tenant_fk",
+          "tableFrom": "repo_agents",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_agents_agent_tenant_fk": {
+          "name": "repo_agents_agent_tenant_fk",
+          "tableFrom": "repo_agents",
+          "tableTo": "agents",
+          "schemaTo": "app",
+          "columnsFrom": ["agent_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repo_agents_pkey": {
+          "name": "repo_agents_pkey",
+          "columns": ["repository_id", "agent_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repo_connections": {
+      "name": "repo_connections",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviews": {
+          "name": "reviews",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "automations": {
+          "name": "automations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_connections_connection_tenant_idx": {
+          "name": "repo_connections_connection_tenant_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_connections_repository_tenant_idx": {
+          "name": "repo_connections_repository_tenant_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_connections_repository_tenant_fk": {
+          "name": "repo_connections_repository_tenant_fk",
+          "tableFrom": "repo_connections",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_connections_connection_tenant_fk": {
+          "name": "repo_connections_connection_tenant_fk",
+          "tableFrom": "repo_connections",
+          "tableTo": "connections",
+          "schemaTo": "app",
+          "columnsFrom": ["connection_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repo_connections_pkey": {
+          "name": "repo_connections_pkey",
+          "columns": ["repository_id", "connection_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repo_skills": {
+      "name": "repo_skills",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "repo_skills_repository_tenant_idx": {
+          "name": "repo_skills_repository_tenant_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_skills_skill_tenant_idx": {
+          "name": "repo_skills_skill_tenant_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_skills_repository_tenant_fk": {
+          "name": "repo_skills_repository_tenant_fk",
+          "tableFrom": "repo_skills",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_skills_skill_tenant_fk": {
+          "name": "repo_skills_skill_tenant_fk",
+          "tableFrom": "repo_skills",
+          "tableTo": "skills",
+          "schemaTo": "app",
+          "columnsFrom": ["skill_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repo_skills_pkey": {
+          "name": "repo_skills_pkey",
+          "columns": ["repository_id", "skill_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.repositories": {
+      "name": "repositories",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval('app.native_entity_id_seq'::regclass)"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "artifacts_repo": {
+          "name": "artifacts_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_push_at": {
+          "name": "last_push_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_on_push": {
+          "name": "review_on_push",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_push_debounce_minutes": {
+          "name": "review_push_debounce_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "review_intake": {
+          "name": "review_intake",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'factory_only'"
+        },
+        "process_profile": {
+          "name": "process_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy_factory'"
+        },
+        "blocking_reviews": {
+          "name": "blocking_reviews",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_fix": {
+          "name": "auto_fix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "check_command": {
+          "name": "check_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_command": {
+          "name": "run_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_port": {
+          "name": "app_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_merge": {
+          "name": "auto_merge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "demo_videos": {
+          "name": "demo_videos",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "launchable": {
+          "name": "launchable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_resolve_conflicts": {
+          "name": "auto_resolve_conflicts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "repositories_artifacts_repo_unique": {
+          "name": "repositories_artifacts_repo_unique",
+          "columns": [
+            {
+              "expression": "artifacts_repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(artifacts_repo IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_enabled_idx": {
+          "name": "repositories_enabled_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repositories_installation_idx": {
+          "name": "repositories_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_installation_provider_fk": {
+          "name": "repositories_installation_provider_fk",
+          "tableFrom": "repositories",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id", "provider"],
+          "columnsTo": ["id", "provider"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repositories_id_installation_unique": {
+          "name": "repositories_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "installation_id"]
+        },
+        "repositories_owner_name_unique": {
+          "name": "repositories_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["owner", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "repositories_review_push_debounce_check": {
+          "name": "repositories_review_push_debounce_check",
+          "value": "(review_push_debounce_minutes >= 0) AND (review_push_debounce_minutes <= 720)"
+        },
+        "repositories_provider_check": {
+          "name": "repositories_provider_check",
+          "value": "provider = ANY (ARRAY['github'::text, 'artifacts'::text])"
+        },
+        "repositories_app_port_check": {
+          "name": "repositories_app_port_check",
+          "value": "(app_port >= 1) AND (app_port <= 65535)"
+        },
+        "repositories_review_intake_check": {
+          "name": "repositories_review_intake_check",
+          "value": "review_intake = ANY (ARRAY['factory_only'::text, 'on_demand'::text, 'all_changes'::text])"
+        },
+        "repositories_process_profile_check": {
+          "name": "repositories_process_profile_check",
+          "value": "process_profile = ANY (ARRAY['review_on_demand'::text, 'automatic_review'::text, 'review_and_repair'::text, 'idea_to_pr'::text, 'assisted_delivery'::text, 'full_delivery'::text, 'native_turnkey'::text, 'legacy_factory'::text])"
+        },
+        "repositories_artifacts_shape": {
+          "name": "repositories_artifacts_shape",
+          "value": "((provider = 'artifacts'::text) AND (artifacts_repo IS NOT NULL) AND (default_branch IS NOT NULL)) OR ((provider = 'github'::text) AND (artifacts_repo IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.repository_refs": {
+      "name": "repository_refs",
+      "schema": "app",
+      "columns": {
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pushed_at": {
+          "name": "pushed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "repository_refs_head_idx": {
+          "name": "repository_refs_head_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repository_refs_repository_id_fkey": {
+          "name": "repository_refs_repository_id_fkey",
+          "tableFrom": "repository_refs",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "repository_refs_pkey": {
+          "name": "repository_refs_pkey",
+          "columns": ["repository_id", "ref"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.review_findings": {
+      "name": "review_findings",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "review_findings_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_index": {
+          "name": "candidate_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_path": {
+          "name": "failure_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verifier_confidence": {
+          "name": "verifier_confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifier_severity": {
+          "name": "verifier_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_reason": {
+          "name": "verification_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_by_github_id": {
+          "name": "feedback_by_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_at": {
+          "name": "feedback_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "review_findings_review_idx": {
+          "name": "review_findings_review_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_findings_feedback_idx": {
+          "name": "review_findings_feedback_idx",
+          "columns": [
+            {
+              "expression": "feedback",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "published",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_findings_review_id_reviews_id_fk": {
+          "name": "review_findings_review_id_reviews_id_fk",
+          "tableFrom": "review_findings",
+          "tableTo": "reviews",
+          "schemaTo": "app",
+          "columnsFrom": ["review_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "review_findings_review_candidate_unique": {
+          "name": "review_findings_review_candidate_unique",
+          "nullsNotDistinct": false,
+          "columns": ["review_id", "candidate_index"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "review_findings_candidate_index_check": {
+          "name": "review_findings_candidate_index_check",
+          "value": "candidate_index >= 0"
+        },
+        "review_findings_line_check": {
+          "name": "review_findings_line_check",
+          "value": "line > 0"
+        },
+        "review_findings_side_check": {
+          "name": "review_findings_side_check",
+          "value": "side = ANY (ARRAY['LEFT'::text, 'RIGHT'::text])"
+        },
+        "review_findings_severity_check": {
+          "name": "review_findings_severity_check",
+          "value": "severity = ANY (ARRAY['P1'::text, 'P2'::text])"
+        },
+        "review_findings_verifier_confidence_check": {
+          "name": "review_findings_verifier_confidence_check",
+          "value": "(verifier_confidence IS NULL) OR (verifier_confidence = ANY (ARRAY['low'::text, 'medium'::text, 'high'::text]))"
+        },
+        "review_findings_verifier_severity_check": {
+          "name": "review_findings_verifier_severity_check",
+          "value": "(verifier_severity IS NULL) OR (verifier_severity = ANY (ARRAY['P1'::text, 'P2'::text]))"
+        },
+        "review_findings_feedback_check": {
+          "name": "review_findings_feedback_check",
+          "value": "(feedback IS NULL) OR (feedback = ANY (ARRAY['useful'::text, 'false_positive'::text, 'fixed'::text, 'dismissed'::text]))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.reviews": {
+      "name": "reviews",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "reviews_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event": {
+          "name": "trigger_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_url": {
+          "name": "review_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_instance_id": {
+          "name": "agent_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_tier": {
+          "name": "risk_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings_count": {
+          "name": "findings_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_count": {
+          "name": "candidate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_model": {
+          "name": "verification_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_input_tokens": {
+          "name": "verification_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verification_output_tokens": {
+          "name": "verification_output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verification_cost_usd": {
+          "name": "verification_cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verification_latency_ms": {
+          "name": "verification_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiment_key": {
+          "name": "experiment_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage_run_id": {
+          "name": "stage_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_status": {
+          "name": "coverage_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewable_file_count": {
+          "name": "reviewable_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered_file_count": {
+          "name": "covered_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "missing_paths": {
+          "name": "missing_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_head_sha": {
+          "name": "coverage_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_head_sha": {
+          "name": "published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_paths": {
+          "name": "finding_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "reviews_agent_instance_idx": {
+          "name": "reviews_agent_instance_idx",
+          "columns": [
+            {
+              "expression": "agent_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_submission_id_idx": {
+          "name": "reviews_submission_id_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(submission_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_installation_time_idx": {
+          "name": "reviews_installation_time_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_one_running_instance_idx": {
+          "name": "reviews_one_running_instance_idx",
+          "columns": [
+            {
+              "expression": "agent_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((status = 'running'::text) AND (agent_instance_id IS NOT NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_repo_pr_idx": {
+          "name": "reviews_repo_pr_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_repository_installation_idx": {
+          "name": "reviews_repository_installation_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_running_installation_idx": {
+          "name": "reviews_running_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_stage_run_idx": {
+          "name": "reviews_stage_run_idx",
+          "columns": [
+            {
+              "expression": "stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(stage_run_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_stage_run_id_stage_runs_id_fk": {
+          "name": "reviews_stage_run_id_stage_runs_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "stage_runs",
+          "schemaTo": "app",
+          "columnsFrom": ["stage_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reviews_repository_tenant_fk": {
+          "name": "reviews_repository_tenant_fk",
+          "tableFrom": "reviews",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id", "installation_id"],
+          "columnsTo": ["id", "installation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reviews_output_tokens_check": {
+          "name": "reviews_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "reviews_cache_read_tokens_check": {
+          "name": "reviews_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "reviews_cache_write_tokens_check": {
+          "name": "reviews_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "reviews_pr_number_check": {
+          "name": "reviews_pr_number_check",
+          "value": "pr_number > 0"
+        },
+        "reviews_status_check": {
+          "name": "reviews_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'completed'::text, 'failed'::text])"
+        },
+        "reviews_input_tokens_check": {
+          "name": "reviews_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "reviews_cost_usd_check": {
+          "name": "reviews_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        },
+        "reviews_risk_tier_check": {
+          "name": "reviews_risk_tier_check",
+          "value": "(risk_tier IS NULL) OR (risk_tier = ANY (ARRAY['trivial'::text, 'lite'::text, 'full'::text]))"
+        },
+        "reviews_findings_count_check": {
+          "name": "reviews_findings_count_check",
+          "value": "(findings_count IS NULL) OR (findings_count >= 0)"
+        },
+        "reviews_candidate_count_check": {
+          "name": "reviews_candidate_count_check",
+          "value": "(candidate_count IS NULL) OR (candidate_count >= 0)"
+        },
+        "reviews_verification_status_check": {
+          "name": "reviews_verification_status_check",
+          "value": "(verification_status IS NULL) OR (verification_status = ANY (ARRAY['skipped'::text, 'completed'::text, 'failed'::text, 'incomplete'::text]))"
+        },
+        "reviews_verification_input_tokens_check": {
+          "name": "reviews_verification_input_tokens_check",
+          "value": "verification_input_tokens >= 0"
+        },
+        "reviews_verification_output_tokens_check": {
+          "name": "reviews_verification_output_tokens_check",
+          "value": "verification_output_tokens >= 0"
+        },
+        "reviews_verification_cost_usd_check": {
+          "name": "reviews_verification_cost_usd_check",
+          "value": "verification_cost_usd >= (0)::numeric"
+        },
+        "reviews_verification_latency_ms_check": {
+          "name": "reviews_verification_latency_ms_check",
+          "value": "(verification_latency_ms IS NULL) OR (verification_latency_ms >= 0)"
+        },
+        "reviews_verdict_check": {
+          "name": "reviews_verdict_check",
+          "value": "(verdict IS NULL) OR (verdict = ANY (ARRAY['approve'::text, 'comment'::text, 'request_changes'::text]))"
+        },
+        "reviews_conclusion_check": {
+          "name": "reviews_conclusion_check",
+          "value": "(conclusion IS NULL) OR (conclusion = ANY (ARRAY['ready'::text, 'ready_with_warnings'::text, 'not_ready'::text, 'inconclusive'::text]))"
+        },
+        "reviews_coverage_status_check": {
+          "name": "reviews_coverage_status_check",
+          "value": "(coverage_status IS NULL) OR (coverage_status = ANY (ARRAY['complete'::text, 'incomplete'::text, 'stale'::text]))"
+        },
+        "reviews_coverage_counts_check": {
+          "name": "reviews_coverage_counts_check",
+          "value": "(reviewable_file_count IS NULL AND covered_file_count IS NULL) OR\n        (reviewable_file_count >= 0 AND covered_file_count >= 0 AND covered_file_count <= reviewable_file_count)"
+        },
+        "reviews_missing_paths_array_check": {
+          "name": "reviews_missing_paths_array_check",
+          "value": "(missing_paths IS NULL) OR (jsonb_typeof(missing_paths) = 'array'::text)"
+        },
+        "reviews_completion_shape": {
+          "name": "reviews_completion_shape",
+          "value": "((status = 'running'::text) AND (completed_at IS NULL)) OR (status <> 'running'::text)"
+        },
+        "reviews_finding_paths_array_check": {
+          "name": "reviews_finding_paths_array_check",
+          "value": "(finding_paths IS NULL) OR (jsonb_typeof(finding_paths) = 'array'::text)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "auth.session": {
+      "name": "session",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeOrganizationId": {
+          "name": "activeOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_active_organization_idx": {
+          "name": "session_active_organization_idx",
+          "columns": [
+            {
+              "expression": "activeOrganizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"activeOrganizationId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_expires_at_idx": {
+          "name": "session_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_fkey": {
+          "name": "session_userId_fkey",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_fk": {
+          "name": "session_active_organization_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "schemaTo": "auth",
+          "columnsFrom": ["activeOrganizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_key": {
+          "name": "session_token_key",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.skills": {
+      "name": "skills",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "skills_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skills_installation_id_fkey": {
+          "name": "skills_installation_id_fkey",
+          "tableFrom": "skills",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_id_installation_unique": {
+          "name": "skills_id_installation_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "installation_id"]
+        },
+        "skills_installation_slug_unique": {
+          "name": "skills_installation_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id", "slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "skills_slug_format": {
+          "name": "skills_slug_format",
+          "value": "slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.stage_runs": {
+      "name": "stage_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "stage_runs_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "factory_run_id": {
+          "name": "factory_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_instance": {
+          "name": "workflow_instance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "stage_runs_factory_run_idx": {
+          "name": "stage_runs_factory_run_idx",
+          "columns": [
+            {
+              "expression": "factory_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stage_runs_change_idx": {
+          "name": "stage_runs_change_idx",
+          "columns": [
+            {
+              "expression": "change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(change_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stage_runs_factory_run_id_fkey": {
+          "name": "stage_runs_factory_run_id_fkey",
+          "tableFrom": "stage_runs",
+          "tableTo": "factory_runs",
+          "schemaTo": "app",
+          "columnsFrom": ["factory_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stage_runs_change_id_fkey": {
+          "name": "stage_runs_change_id_fkey",
+          "tableFrom": "stage_runs",
+          "tableTo": "changes",
+          "schemaTo": "app",
+          "columnsFrom": ["change_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stage_runs_idempotency_key_unique": {
+          "name": "stage_runs_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["idempotency_key"]
+        },
+        "stage_runs_attempt_unique": {
+          "name": "stage_runs_attempt_unique",
+          "nullsNotDistinct": false,
+          "columns": ["factory_run_id", "stage", "attempt"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "stage_runs_attempt_check": {
+          "name": "stage_runs_attempt_check",
+          "value": "attempt > 0"
+        },
+        "stage_runs_status_check": {
+          "name": "stage_runs_status_check",
+          "value": "status = ANY (ARRAY['queued'::text, 'running'::text, 'completed'::text, 'failed'::text, 'cancelled'::text])"
+        },
+        "stage_runs_stage_check": {
+          "name": "stage_runs_stage_check",
+          "value": "stage = ANY (ARRAY['plan'::text, 'implement'::text, 'publish'::text, 'review'::text, 'repair'::text, 'verify'::text, 'merge'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.todo_repositories": {
+      "name": "todo_repositories",
+      "schema": "app",
+      "columns": {
+        "todo_id": {
+          "name": "todo_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "todo_repositories_repository_idx": {
+          "name": "todo_repositories_repository_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "todo_repositories_todo_id_fkey": {
+          "name": "todo_repositories_todo_id_fkey",
+          "tableFrom": "todo_repositories",
+          "tableTo": "todos",
+          "schemaTo": "app",
+          "columnsFrom": ["todo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "todo_repositories_repository_id_fkey": {
+          "name": "todo_repositories_repository_id_fkey",
+          "tableFrom": "todo_repositories",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "todo_repositories_pkey": {
+          "name": "todo_repositories_pkey",
+          "columns": ["todo_id", "repository_id"]
+        }
+      },
+      "uniqueConstraints": {
+        "todo_repositories_position_unique": {
+          "name": "todo_repositories_position_unique",
+          "nullsNotDistinct": false,
+          "columns": ["todo_id", "position"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "todo_repositories_position_check": {
+          "name": "todo_repositories_position_check",
+          "value": "(\"position\" >= 0) AND (\"position\" <= 2)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.todos": {
+      "name": "todos",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "todos_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_login": {
+          "name": "created_by_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "todos_installation_unplanned_idx": {
+          "name": "todos_installation_unplanned_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(plan_id IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "todos_plan_unique": {
+          "name": "todos_plan_unique",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(plan_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "todos_plan_id_plans_id_fk": {
+          "name": "todos_plan_id_plans_id_fk",
+          "tableFrom": "todos",
+          "tableTo": "plans",
+          "schemaTo": "app",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "todos_installation_id_fkey": {
+          "name": "todos_installation_id_fkey",
+          "tableFrom": "todos",
+          "tableTo": "installations",
+          "schemaTo": "app",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.user": {
+      "name": "user",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubId": {
+          "name": "githubId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_github_id_unique": {
+          "name": "user_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["githubId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user_installation_access": {
+      "name": "user_installation_access",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_ids": {
+          "name": "installation_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_installation_access_user_id_fkey": {
+          "name": "user_installation_access_user_id_fkey",
+          "tableFrom": "user_installation_access",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_installation_access_no_null_ids": {
+          "name": "user_installation_access_no_null_ids",
+          "value": "array_position(installation_ids, NULL::bigint) IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.user_tokens": {
+      "name": "user_tokens",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_ciphertext": {
+          "name": "refresh_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.verification": {
+      "name": "verification",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_expires_at_idx": {
+          "name": "verification_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.verifications": {
+      "name": "verifications",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "verifications_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo": {
+          "name": "demo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "verifications_feature_idx": {
+          "name": "verifications_feature_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verifications_one_running_idx": {
+          "name": "verifications_one_running_idx",
+          "columns": [
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verifications_running_created_idx": {
+          "name": "verifications_running_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(status = 'running'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verifications_feature_id_fkey": {
+          "name": "verifications_feature_id_fkey",
+          "tableFrom": "verifications",
+          "tableTo": "features",
+          "schemaTo": "app",
+          "columnsFrom": ["feature_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verifications_status_check": {
+          "name": "verifications_status_check",
+          "value": "status = ANY (ARRAY['running'::text, 'passed'::text, 'failed'::text, 'error'::text, 'skipped'::text])"
+        },
+        "verifications_input_tokens_check": {
+          "name": "verifications_input_tokens_check",
+          "value": "input_tokens >= 0"
+        },
+        "verifications_output_tokens_check": {
+          "name": "verifications_output_tokens_check",
+          "value": "output_tokens >= 0"
+        },
+        "verifications_cache_read_tokens_check": {
+          "name": "verifications_cache_read_tokens_check",
+          "value": "cache_read_tokens >= 0"
+        },
+        "verifications_cache_write_tokens_check": {
+          "name": "verifications_cache_write_tokens_check",
+          "value": "cache_write_tokens >= 0"
+        },
+        "verifications_cost_usd_check": {
+          "name": "verifications_cost_usd_check",
+          "value": "cost_usd >= (0)::numeric"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.work_items": {
+      "name": "work_items",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "work_items_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9007199254740991",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "work_items_repo_created_idx": {
+          "name": "work_items_repo_created_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_items_repository_id_fkey": {
+          "name": "work_items_repository_id_fkey",
+          "tableFrom": "work_items",
+          "tableTo": "repositories",
+          "schemaTo": "app",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "work_items_origin_check": {
+          "name": "work_items_origin_check",
+          "value": "origin = ANY (ARRAY['idea'::text, 'issue'::text, 'external_change'::text, 'automation'::text, 'api'::text])"
+        },
+        "work_items_status_check": {
+          "name": "work_items_status_check",
+          "value": "status = ANY (ARRAY['open'::text, 'closed'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "app": "app",
+    "auth": "auth"
+  },
+  "sequences": {
+    "app.native_entity_id_seq": {
+      "name": "native_entity_id_seq",
+      "schema": "app",
+      "increment": "1",
+      "startWith": "4000000000000000",
+      "minValue": "1",
+      "maxValue": "9007199254740991",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1789004826420,
       "tag": "0020_review-readiness-conclusions",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1789004826421,
+      "tag": "0021_review_run_identity",
+      "breakpoints": true
     }
   ]
 }

--- a/src/ai/agents/pr-reviewer.ts
+++ b/src/ai/agents/pr-reviewer.ts
@@ -62,18 +62,38 @@ function parseOwnerRepoNumber(
   return match ? { owner: match[1], repo: match[2], number: Number(match[3]) } : null;
 }
 
-function parsePin(raw: string | undefined): RepoPin {
+function parseReviewIdentity(
+  rawId: string | undefined,
+  expectedHeadSha: string | undefined,
+): { reviewId: number; expectedHeadSha: string } | null {
+  const reviewId = Number(rawId);
+  if (!Number.isSafeInteger(reviewId) || reviewId <= 0 || !expectedHeadSha) return null;
+  return { reviewId, expectedHeadSha };
+}
+
+function parsePin(
+  raw: string | undefined,
+  rawId: string | undefined,
+  expectedHeadSha: string | undefined,
+): RepoPin {
   const parsed = parseOwnerRepoNumber(raw);
-  return parsed ? { owner: parsed.owner, repo: parsed.repo } : null;
+  const identity = parseReviewIdentity(rawId, expectedHeadSha);
+  return parsed && identity ? { ...parsed, ...identity } : null;
 }
 
 // Native change-request dispatches ("owner/name#3" + a CR row id) swap the
 // GitHub tool set for the CR-backed one; the agent itself is identical.
-function parseCrPin(raw: string | undefined, rawId: string | undefined): CrPin | null {
+function parseCrPin(
+  raw: string | undefined,
+  rawCrId: string | undefined,
+  rawReviewId: string | undefined,
+  expectedHeadSha: string | undefined,
+): CrPin | null {
   const parsed = parseOwnerRepoNumber(raw);
-  const id = Number(rawId);
-  if (!parsed || !Number.isInteger(id) || id <= 0) return null;
-  return { ...parsed, changeRequestId: id };
+  const id = Number(rawCrId);
+  const identity = parseReviewIdentity(rawReviewId, expectedHeadSha);
+  if (!parsed || !identity || !Number.isInteger(id) || id <= 0) return null;
+  return { ...parsed, changeRequestId: id, ...identity };
 }
 
 function deliveryConfig() {
@@ -86,8 +106,17 @@ function deliveryConfig() {
       experimentKey: delivery.attributes.experiment_key || null,
       riskTier: delivery.attributes.risk_tier || 'full',
       connections: parseConnections(delivery.attributes.connections),
-      pin: parsePin(delivery.attributes.pull_request),
-      crPin: parseCrPin(delivery.attributes.change_request, delivery.attributes.change_request_id),
+      pin: parsePin(
+        delivery.attributes.pull_request,
+        delivery.attributes.review_id,
+        delivery.attributes.expected_head_sha,
+      ),
+      crPin: parseCrPin(
+        delivery.attributes.change_request,
+        delivery.attributes.change_request_id,
+        delivery.attributes.review_id,
+        delivery.attributes.expected_head_sha,
+      ),
     };
   }
   // Pre-multi-agent conversations and manual test prompts arrive as plain
@@ -145,7 +174,7 @@ export function PrReviewer(props: AgentProps) {
     useTool(makeFetchCr(cfg.crPin));
     useTool(makeFetchCrFile(cfg.crPin));
     useTool(makeFetchCrComments(cfg.crPin));
-    useTool(makePostCrReview(props.id, cfg.crPin));
+    useTool(makePostCrReview(cfg.crPin));
   } else {
     useTool(makeFetchPr(cfg.pin));
     useTool(makeFetchDiff(cfg.pin));

--- a/src/ai/review/dispatch.ts
+++ b/src/ai/review/dispatch.ts
@@ -1,7 +1,8 @@
 import { dispatch } from '@flue/runtime';
 import {
+  bindReviewSubmission,
   listRepoConnections,
-  markReviewFailed,
+  markReviewFailedById,
   tryRecordReview,
   type AgentRow,
   type RepositoryRow,
@@ -72,6 +73,8 @@ export async function dispatchReviewAgent(
   if (reviewId === null) return false;
   const connections = (await listRepoConnections(repo.id, 'reviews')).map(connectionSnapshot);
   const baseAttributes = {
+    review_id: String(reviewId),
+    expected_head_sha: opts.headSha ?? '',
     agent_slug: agent.slug,
     agent_name: agent.name,
     model: assignment.scout,
@@ -92,8 +95,9 @@ export async function dispatchReviewAgent(
       : baseAttributes;
 
   try {
-    await dispatch(PrReviewer, {
+    const receipt = await dispatch(PrReviewer, {
       id: instanceId,
+      idempotencyKey: `review-${reviewId}`,
       message: {
         kind: 'signal',
         type: 'review.request',
@@ -107,13 +111,14 @@ export async function dispatchReviewAgent(
           (opts.delta ? pushFocus(opts.delta) : ''),
       },
     });
+    await bindReviewSubmission(reviewId, receipt.submissionId);
   } catch (error) {
     console.error(
       `turbodiff: dispatch failed for ${instanceId} (${agent.slug} on ${repo.owner}/${repo.name}#${prNumber}):`,
       error,
     );
-    await markReviewFailed(
-      instanceId,
+    await markReviewFailedById(
+      reviewId,
       `dispatch failed: ${error instanceof Error ? error.message : String(error)}`.slice(0, 1_000),
     );
     return false;

--- a/src/ai/review/metering.ts
+++ b/src/ai/review/metering.ts
@@ -1,12 +1,12 @@
 import { observe } from '@flue/runtime';
-import { addReviewUsage } from '../../data/db.ts';
+import { addReviewUsageBySubmission } from '../../data/db.ts';
 import { isExplainInstanceId } from '../../domain/explain.ts';
-import { failLifecycleReview } from '../../services/lifecycle.ts';
+import { failLifecycleReviewBySubmission } from '../../services/lifecycle.ts';
 
 // Meters model usage per review. Every completed model call emits a `turn`
 // event carrying provider-reported tokens and catalog-priced cost; review
-// rows store their exact agent instance id (tryRecordReview), so attribution
-// is a direct match on event.instanceId — no id parsing.
+// rows store Flue's durable submission id, so attribution remains exact even
+// though one agent instance intentionally hosts a sequence of re-reviews.
 //
 // On Cloudflare each agent conversation runs in its own Durable Object
 // isolate; this subscriber registers in every isolate and sees only that
@@ -34,16 +34,16 @@ export function registerReviewMetering(): void {
     // (agent error, abort, or a run that ended without posting), flip it to
     // failed so it doesn't sit "running" until the stall cutoff.
     if (event.type === 'submission_settled') {
-      void failLifecycleReview(event.instanceId, settlementReason(event)).catch((err) =>
-        console.error('turbodiff: marking review failed errored', err),
+      void failLifecycleReviewBySubmission(event.submissionId, settlementReason(event)).catch(
+        (err) => console.error('turbodiff: marking review failed errored', err),
       );
       return;
     }
-    if (event.type !== 'turn' || !event.response.usage) return;
+    if (event.type !== 'turn' || !event.submissionId || !event.response.usage) return;
     const { usage } = event.response;
     // Subscribers run synchronously on the emission path — queue the PostgreSQL
     // write and contain failures; metering must never affect the agent.
-    void addReviewUsage(event.instanceId, {
+    void addReviewUsageBySubmission(event.submissionId, {
       inputTokens: usage.input,
       outputTokens: usage.output,
       cacheReadTokens: usage.cacheRead,

--- a/src/ai/tools/change-requests.ts
+++ b/src/ai/tools/change-requests.ts
@@ -4,13 +4,14 @@ import {
   addCrComment,
   getChangeRequest,
   getRepoByFullName,
+  getReviewRunGuard,
   listCrComments,
   setChangeRequestReviewStatus,
   upsertCrCheck,
   type ChangeRequestRow,
   type RepositoryRow,
 } from '../../data/db.ts';
-import { completeLifecycleReview } from '../../services/lifecycle.ts';
+import { completeLifecycleReviewById } from '../../services/lifecycle.ts';
 import {
   CR_BOT_AUTHOR,
   getCrDiffPatch,
@@ -45,19 +46,32 @@ export interface CrPin {
   repo: string;
   number: number;
   changeRequestId: number;
+  reviewId: number;
+  expectedHeadSha: string;
 }
 
-function assertCrPinned(pin: CrPin, owner: string, repo: string): void {
+function assertCrPinned(pin: CrPin, owner: string, repo: string, number?: number): void {
   assertPinned({ owner: pin.owner, repo: pin.repo }, owner, repo);
+  if (number !== undefined && number !== pin.number) {
+    throw new Error(`this review is scoped to change request #${pin.number}`);
+  }
 }
 
-async function pinnedCr(pin: CrPin): Promise<{ cr: ChangeRequestRow; repo: RepositoryRow }> {
+async function pinnedCr(
+  pin: CrPin,
+  allowStale = false,
+): Promise<{ cr: ChangeRequestRow; repo: RepositoryRow }> {
   const cr = await getChangeRequest(pin.changeRequestId);
   if (!cr) throw new Error(`change request ${pin.changeRequestId} no longer exists`);
   const repo = await getRepoByFullName(pin.owner, pin.repo);
   if (!repo || repo.id !== cr.repository_id) {
     throw new Error(
       `change request ${pin.changeRequestId} does not belong to ${pin.owner}/${pin.repo}`,
+    );
+  }
+  if (!allowStale && cr.source_head !== pin.expectedHeadSha) {
+    throw new Error(
+      `change request head changed from ${pin.expectedHeadSha} to ${cr.source_head ?? 'unknown'}; this review is stale`,
     );
   }
   return { cr, repo };
@@ -77,7 +91,7 @@ export const makeFetchCr = (pin: CrPin) =>
       number: v.number(),
     }),
     async run({ data }) {
-      assertCrPinned(pin, data.owner, data.repo);
+      assertCrPinned(pin, data.owner, data.repo, data.number);
       const { cr } = await pinnedCr(pin);
       const comments = await listCrComments(cr.id);
       const summary = comments.find((c) => c.kind === 'summary' && c.author === CR_BOT_AUTHOR);
@@ -161,7 +175,7 @@ export const makeFetchCrComments = (pin: CrPin) =>
       number: v.number(),
     }),
     async run({ data }) {
-      assertCrPinned(pin, data.owner, data.repo);
+      assertCrPinned(pin, data.owner, data.repo, data.number);
       const { cr } = await pinnedCr(pin);
       const comments = await listCrComments(cr.id);
       return {
@@ -193,7 +207,7 @@ export const makeFetchCrComments = (pin: CrPin) =>
 // The native post_review: findings land as cr_comments, the verdict on the
 // CR row and its 'review' check, and the PostgreSQL review row completes — then the
 // auto-merge gate gets its chance, exactly like the GitHub tool's tail.
-export const makePostCrReview = (agentInstanceId: string, pin: CrPin) =>
+export const makePostCrReview = (pin: CrPin) =>
   defineTool({
     name: 'post_review',
     description:
@@ -210,10 +224,51 @@ export const makePostCrReview = (agentInstanceId: string, pin: CrPin) =>
       reviewedFiles: v.optional(v.array(v.string()), []),
     }),
     async run({ data }) {
-      assertCrPinned(pin, data.owner, data.repo);
-      const { cr, repo } = await pinnedCr(pin);
+      assertCrPinned(pin, data.owner, data.repo, data.number);
+      const { cr, repo } = await pinnedCr(pin, true);
+      const guard = await getReviewRunGuard(pin.reviewId);
+      if (
+        !guard ||
+        guard.status !== 'running' ||
+        guard.repository_id !== repo.id ||
+        guard.pr_number !== pin.number ||
+        guard.head_sha !== pin.expectedHeadSha
+      ) {
+        return {
+          output: {
+            posted: false,
+            stale: true,
+            reason: 'the exact review run is no longer active',
+            inline: 0,
+            url: null,
+            fallback: null,
+          },
+        };
+      }
       const liveDiff = await getCrDiffPatch(cr);
       const manifest = buildReviewDiffSnapshot(liveDiff, 0).files;
+      if (cr.source_head !== pin.expectedHeadSha) {
+        const reviewablePaths = manifest.filter((file) => file.reviewable).map((file) => file.path);
+        await completeLifecycleReviewById(pin.reviewId, null, 0, 'comment', [], undefined, {
+          conclusion: 'inconclusive',
+          coverageStatus: 'stale',
+          reviewableFileCount: reviewablePaths.length,
+          coveredFileCount: 0,
+          missingPaths: reviewablePaths,
+          coverageHeadSha: pin.expectedHeadSha,
+          publishedHeadSha: null,
+        });
+        return {
+          output: {
+            posted: false,
+            stale: true,
+            reason: `change request head changed to ${cr.source_head ?? 'unknown'}`,
+            inline: 0,
+            url: null,
+            fallback: null,
+          },
+        };
+      }
       const missingFiles = missingReviewFiles(manifest, data.reviewedFiles);
       const reviewableFileCount = manifest.filter((file) => file.reviewable).length;
       const hasP1 = data.findings.map(findingSeverity).includes('P1');
@@ -256,8 +311,8 @@ export const makePostCrReview = (agentInstanceId: string, pin: CrPin) =>
           : `${data.findings.length} finding(s)` + (blocking ? ' — P1 blocks merge' : ''),
       );
       const url = cr.feature_id ? cockpitFeatureUrl(cr.feature_id) : null;
-      await completeLifecycleReview(
-        agentInstanceId,
+      await completeLifecycleReviewById(
+        pin.reviewId,
         url,
         data.findings.length,
         (hasP1 && repo.process_profile !== 'legacy_factory') || blocking
@@ -286,6 +341,15 @@ export const makePostCrReview = (agentInstanceId: string, pin: CrPin) =>
         });
       }
       if (!blocking && conclusion !== 'inconclusive') await maybeAutoMergeCr(repo, cr.id);
-      return { output: { posted: true, inline: data.findings.length, url, fallback: null } };
+      return {
+        output: {
+          posted: true,
+          stale: false,
+          reason: null,
+          inline: data.findings.length,
+          url,
+          fallback: null,
+        },
+      };
     },
   });

--- a/src/ai/tools/github.ts
+++ b/src/ai/tools/github.ts
@@ -3,8 +3,13 @@ import * as v from 'valibot';
 import { maybeAutoMerge } from '../../services/auto-merge.ts';
 import { maybeResolveConflict } from '../../services/merge-conflicts.ts';
 import { enqueueFactoryMessage } from '../../services/factory-queue.ts';
-import { getRepoByFullName, recordReviewQuality } from '../../data/db.ts';
-import { completeLifecycleReview } from '../../services/lifecycle.ts';
+import {
+  getRepoByFullName,
+  getReviewRunGuard,
+  recordReviewQuality,
+  recordReviewQualityById,
+} from '../../data/db.ts';
+import { completeLifecycleReview, completeLifecycleReviewById } from '../../services/lifecycle.ts';
 import { installationToken } from '../../integrations/github/app.ts';
 import {
   githubGraphql as ghGraphql,
@@ -31,9 +36,19 @@ import {
 // (or post reviews to) any other repo in the same installation. Null only on
 // the operator-driven plain-message path (REVIEW_SECRET-authed /internal),
 // which has no dispatch attributes to pin from.
-export type RepoPin = { owner: string; repo: string } | null;
+export type RepoPin = {
+  owner: string;
+  repo: string;
+  number: number;
+  reviewId: number;
+  expectedHeadSha: string;
+} | null;
 
-export function assertPinned(pin: RepoPin, owner: string, repo: string): void {
+export function assertPinned(
+  pin: Pick<NonNullable<RepoPin>, 'owner' | 'repo'> | null,
+  owner: string,
+  repo: string,
+): void {
   if (!pin) return;
   if (
     owner.toLowerCase() !== pin.owner.toLowerCase() ||
@@ -41,6 +56,23 @@ export function assertPinned(pin: RepoPin, owner: string, repo: string): void {
   ) {
     throw new Error(
       `this review is scoped to ${pin.owner}/${pin.repo} — refusing to access ${owner}/${repo}`,
+    );
+  }
+}
+
+export function assertPrPinned(pin: RepoPin, owner: string, repo: string, number: number): void {
+  assertPinned(pin, owner, repo);
+  if (pin && number !== pin.number) {
+    throw new Error(
+      `this review is scoped to ${pin.owner}/${pin.repo}#${pin.number} — refusing to access #${number}`,
+    );
+  }
+}
+
+export function assertHeadPinned(pin: RepoPin, headSha: string): void {
+  if (pin && headSha !== pin.expectedHeadSha) {
+    throw new Error(
+      `pull request head changed from ${pin.expectedHeadSha} to ${headSha}; this review is stale`,
     );
   }
 }
@@ -95,7 +127,7 @@ export const makeFetchPr = (pin: RepoPin, name = 'fetch_pr') =>
       number: v.number(),
     }),
     async run({ data }) {
-      assertPinned(pin, data.owner, data.repo);
+      assertPrPinned(pin, data.owner, data.repo, data.number);
       interface PrMeta {
         title: string;
         body: string | null;
@@ -114,6 +146,7 @@ export const makeFetchPr = (pin: RepoPin, name = 'fetch_pr') =>
         pullRequestDiff(token, data.owner, data.repo, data.number),
       ]);
       const snapshot = buildReviewDiffSnapshot(diff, MAX_DIFF_CHARS);
+      assertHeadPinned(pin, meta.head.sha);
       return {
         output: {
           title: meta.title,
@@ -156,9 +189,15 @@ export const makeFetchDiff = (pin: RepoPin, name = 'fetch_diff') =>
       paths: v.pipe(v.array(v.string()), v.minLength(1), v.maxLength(50)),
     }),
     async run({ data }) {
-      assertPinned(pin, data.owner, data.repo);
+      assertPrPinned(pin, data.owner, data.repo, data.number);
       const token = await tokenFor(data.owner, data.repo);
-      const diff = await pullRequestDiff(token, data.owner, data.repo, data.number);
+      const [diff, meta] = await Promise.all([
+        pullRequestDiff(token, data.owner, data.repo, data.number),
+        gh(token, `/repos/${data.owner}/${data.repo}/pulls/${data.number}`).then((response) =>
+          response.json<{ head: { sha: string } }>(),
+        ),
+      ]);
+      assertHeadPinned(pin, meta.head.sha);
       const requested = new Set(data.paths);
       const selected = splitDiffSegments(diff)
         .filter((entry) => requested.has(entry.path))
@@ -275,7 +314,7 @@ export const makeFetchReviewThreads = (pin: RepoPin) =>
       number: v.number(),
     }),
     async run({ data }) {
-      assertPinned(pin, data.owner, data.repo);
+      assertPrPinned(pin, data.owner, data.repo, data.number);
       const token = await tokenFor(data.owner, data.repo);
       const result = await ghGraphql<ThreadsQueryResult>(token, THREADS_QUERY, {
         owner: data.owner,
@@ -354,9 +393,9 @@ interface ReviewComment {
   start_side?: 'LEFT' | 'RIGHT';
 }
 
-// A per-render factory rather than a shared definition: the tool closes over
-// the agent instance id so completing the PostgreSQL review row targets exactly the
-// dispatch that ran it — concurrent agents on the same PR never collide.
+// A per-render factory rather than a shared definition: dispatched reviews
+// carry an exact review id and expected head SHA. The instance id is retained
+// only for the operator-only, unpinned compatibility path.
 export const makePostReview = (
   agentInstanceId: string,
   pin: RepoPin = null,
@@ -384,7 +423,7 @@ export const makePostReview = (
       reviewedFiles: v.optional(v.array(v.string()), []),
     }),
     async run({ data, harness }) {
-      assertPinned(pin, data.owner, data.repo);
+      assertPrPinned(pin, data.owner, data.repo, data.number);
       const row = await getRepoByFullName(data.owner, data.repo);
       if (!row) {
         throw new Error(
@@ -393,6 +432,50 @@ export const makePostReview = (
         );
       }
       const token = await installationToken(row.installation_id);
+      if (pin) {
+        const guard = await getReviewRunGuard(pin.reviewId);
+        if (
+          !guard ||
+          guard.status !== 'running' ||
+          guard.repository_id !== row.id ||
+          guard.pr_number !== pin.number ||
+          guard.head_sha !== pin.expectedHeadSha
+        ) {
+          return {
+            output: {
+              posted: false,
+              stale: true,
+              reason: 'the exact review run is no longer active',
+            },
+          };
+        }
+      }
+      const [liveDiff, livePr] = await Promise.all([
+        pullRequestDiff(token, data.owner, data.repo, data.number),
+        gh(token, `/repos/${data.owner}/${data.repo}/pulls/${data.number}`).then((response) =>
+          response.json<{ head: { sha: string } }>(),
+        ),
+      ]);
+      const manifest = buildReviewDiffSnapshot(liveDiff, 0).files;
+      if (pin && livePr.head.sha !== pin.expectedHeadSha) {
+        const reviewablePaths = manifest.filter((file) => file.reviewable).map((file) => file.path);
+        await completeLifecycleReviewById(pin.reviewId, null, 0, 'comment', [], undefined, {
+          conclusion: 'inconclusive',
+          coverageStatus: 'stale',
+          reviewableFileCount: reviewablePaths.length,
+          coveredFileCount: 0,
+          missingPaths: reviewablePaths,
+          coverageHeadSha: pin.expectedHeadSha,
+          publishedHeadSha: null,
+        });
+        return {
+          output: {
+            posted: false,
+            stale: true,
+            reason: `pull request head changed to ${livePr.head.sha}`,
+          },
+        };
+      }
       const candidates = consolidateCandidates(data.findings);
       let verificationComplete = true;
       let verifiedFindings = candidates;
@@ -472,7 +555,7 @@ ${JSON.stringify(candidates)}
             .filter((decision) => decision.accepted && decision.confidence === 'high')
             .map((decision) => decision.candidate)
         : [];
-      await recordReviewQuality(agentInstanceId, {
+      const quality = {
         candidates,
         decisions,
         publishedCandidateIndexes,
@@ -483,14 +566,9 @@ ${JSON.stringify(candidates)}
         costUsd: verificationCostUsd,
         latencyMs: verificationLatencyMs,
         experimentKey,
-      });
-      const [liveDiff, livePr] = await Promise.all([
-        pullRequestDiff(token, data.owner, data.repo, data.number),
-        gh(token, `/repos/${data.owner}/${data.repo}/pulls/${data.number}`).then((response) =>
-          response.json<{ head: { sha: string } }>(),
-        ),
-      ]);
-      const manifest = buildReviewDiffSnapshot(liveDiff, 0).files;
+      };
+      if (pin) await recordReviewQualityById(pin.reviewId, quality);
+      else await recordReviewQuality(agentInstanceId, quality);
       const missingFiles = missingReviewFiles(manifest, data.reviewedFiles);
       const hasP1 = verifiedFindings.map(findingSeverity).includes('P1');
       const hasP2 = verifiedFindings.map(findingSeverity).includes('P2');
@@ -586,23 +664,37 @@ ${JSON.stringify(candidates)}
             : intended === 'APPROVE'
               ? 'approve'
               : 'comment';
-      await completeLifecycleReview(
-        agentInstanceId,
-        output.url,
-        verifiedFindings.length,
-        verdict,
-        [...new Set(verifiedFindings.map((finding) => finding.path))],
-        undefined,
-        {
-          conclusion,
-          coverageStatus: coverageComplete ? 'complete' : 'incomplete',
-          reviewableFileCount,
-          coveredFileCount: reviewableFileCount - missingFiles.length,
-          missingPaths: missingFiles,
-          coverageHeadSha: livePr.head.sha,
-          publishedHeadSha: livePr.head.sha,
-        },
-      );
+      const readiness = {
+        conclusion,
+        coverageStatus: coverageComplete ? 'complete' : 'incomplete',
+        reviewableFileCount,
+        coveredFileCount: reviewableFileCount - missingFiles.length,
+        missingPaths: missingFiles,
+        coverageHeadSha: livePr.head.sha,
+        publishedHeadSha: livePr.head.sha,
+      } as const;
+      const findingPaths = [...new Set(verifiedFindings.map((finding) => finding.path))];
+      if (pin) {
+        await completeLifecycleReviewById(
+          pin.reviewId,
+          output.url,
+          verifiedFindings.length,
+          verdict,
+          findingPaths,
+          undefined,
+          readiness,
+        );
+      } else {
+        await completeLifecycleReview(
+          agentInstanceId,
+          output.url,
+          verifiedFindings.length,
+          verdict,
+          findingPaths,
+          undefined,
+          readiness,
+        );
+      }
       // Factory-PR gate: a blocking verdict on a self-authored PR never fires
       // the pull_request_review webhook trigger (the posted state is COMMENT),
       // so enqueue the fix directly. The consumer re-validates toggle and cap.

--- a/src/ai/tools/repository-workspace.ts
+++ b/src/ai/tools/repository-workspace.ts
@@ -5,7 +5,7 @@ import { runCheckCommand } from '../runtime/check-command.ts';
 import { installDependencies } from '../runtime/sandbox-deps.ts';
 import { assertRepositorySearchPath } from '../runtime/review-workspace-policy.ts';
 import { prepareReviewWorkspace, type ReviewWorkspace } from '../runtime/review-workspace.ts';
-import { assertPinned, type RepoPin } from './github.ts';
+import { assertHeadPinned, assertPrPinned, type RepoPin } from './github.ts';
 
 const MAX_TOOL_OUTPUT = 20_000;
 
@@ -24,7 +24,7 @@ async function resetWorkspace(workspace: ReviewWorkspace): Promise<void> {
 }
 
 async function pinnedRepo(pin: RepoPin, owner: string, repo: string) {
-  assertPinned(pin, owner, repo);
+  if (pin) assertPrPinned(pin, owner, repo, pin.number);
   const row = await getRepoByFullName(owner, repo);
   if (!row) throw new Error(`Turbodiff is not installed on ${owner}/${repo}`);
   return row;
@@ -46,6 +46,8 @@ export const makeSearchRepository = (agentInstanceId: string, pin: RepoPin) =>
       path: v.optional(v.pipe(v.string(), v.minLength(1), v.maxLength(500)), '.'),
     }),
     async run({ data }) {
+      assertPrPinned(pin, data.owner, data.repo, data.number);
+      assertHeadPinned(pin, data.headSha);
       const repo = await pinnedRepo(pin, data.owner, data.repo);
       const path = assertRepositorySearchPath(data.path);
       const workspace = await prepareReviewWorkspace(
@@ -80,6 +82,8 @@ export const makeRunRepositoryCheck = (agentInstanceId: string, pin: RepoPin) =>
       headSha: v.pipe(v.string(), v.length(40)),
     }),
     async run({ data }) {
+      assertPrPinned(pin, data.owner, data.repo, data.number);
+      assertHeadPinned(pin, data.headSha);
       const repo = await pinnedRepo(pin, data.owner, data.repo);
       if (!repo.check_command) {
         return { output: { configured: false, ran: false, passed: null, output: '' } };

--- a/src/data/db.worker.test.ts
+++ b/src/data/db.worker.test.ts
@@ -32,6 +32,7 @@ import {
   pipelineCostByMonth,
   recentChatHistory,
   recordReviewQuality,
+  recordReviewQualityById,
   reviewQualityDashboard,
   recordRepositoryRef,
   repositoryRef,
@@ -42,8 +43,13 @@ import {
   tryRecordAutomationRun,
   tryRecordFixAttempt,
   markReviewFailed,
+  markReviewFailedById,
+  markReviewFailedBySubmission,
+  bindReviewSubmission,
   tryRecordReview,
   completeReview,
+  completeReviewById,
+  addReviewUsageBySubmission,
   headHasCompletedReview,
   lastReviewedHead,
   latestCompletedReviewsByAgent,
@@ -334,6 +340,98 @@ describe('cockpit chat messages', () => {
 });
 
 describe('review dispatch invariants', () => {
+  it('never lets an older submission mutate its replacement review', async () => {
+    const instanceId = 'review--acme--api--16';
+    const oldId = await tryRecordReview(
+      101,
+      1001,
+      16,
+      'opened',
+      'review',
+      instanceId,
+      'full',
+      null,
+      'a'.repeat(40),
+    );
+    expect(oldId).not.toBeNull();
+    await bindReviewSubmission(oldId!, 'submission-old');
+    await markReviewFailedById(oldId!, 'replaced');
+
+    const currentId = await tryRecordReview(
+      101,
+      1001,
+      16,
+      'synchronize',
+      'review',
+      instanceId,
+      'full',
+      null,
+      'b'.repeat(40),
+    );
+    expect(currentId).not.toBeNull();
+    await bindReviewSubmission(currentId!, 'submission-current');
+
+    await expect(
+      completeReviewById(oldId!, 'https://example.test/stale', 3, 'approve'),
+    ).resolves.toBeNull();
+    await recordReviewQualityById(oldId!, {
+      candidates: [],
+      decisions: [],
+      publishedCandidateIndexes: [],
+      status: 'completed',
+      model: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+      latencyMs: null,
+      experimentKey: null,
+    });
+    await expect(
+      markReviewFailedBySubmission('submission-old', 'late failure'),
+    ).resolves.toBeNull();
+    await addReviewUsageBySubmission('submission-old', {
+      inputTokens: 7,
+      outputTokens: 2,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      costUsd: 0.01,
+      model: 'cloudflare/openai/gpt-5.6-sol',
+    });
+
+    const rows = await testDatabase()
+      .prepare(
+        `SELECT id, status, findings_count, candidate_count, input_tokens, submission_id
+         FROM reviews WHERE agent_instance_id = ?1 ORDER BY id`,
+      )
+      .bind(instanceId)
+      .all<{
+        id: number;
+        status: string;
+        findings_count: number | null;
+        candidate_count: number | null;
+        input_tokens: number;
+        submission_id: string;
+      }>();
+    expect(rows.results).toEqual([
+      {
+        id: oldId,
+        status: 'failed',
+        findings_count: null,
+        candidate_count: null,
+        input_tokens: 7,
+        submission_id: 'submission-old',
+      },
+      {
+        id: currentId,
+        status: 'running',
+        findings_count: null,
+        candidate_count: null,
+        input_tokens: 0,
+        submission_id: 'submission-current',
+      },
+    ]);
+  });
+
   it('records verifier evidence and tenant-scoped finding feedback', async () => {
     await tryRecordReview(101, 1001, 15, 'opened', 'review', 'review--acme--api--15');
     const candidate = {

--- a/src/data/factory.ts
+++ b/src/data/factory.ts
@@ -1153,6 +1153,38 @@ export async function completeReview(
   `);
 }
 
+export async function completeReviewById(
+  reviewId: number,
+  reviewUrl: string | null,
+  findingsCount: number | null = null,
+  verdict: 'approve' | 'comment' | 'request_changes' = 'comment',
+  findingPaths: string[] | null = null,
+  readiness?: {
+    conclusion: ReviewConclusion;
+    coverageStatus: 'complete' | 'incomplete' | 'stale';
+    reviewableFileCount: number;
+    coveredFileCount: number;
+    missingPaths: string[];
+    coverageHeadSha: string | null;
+    publishedHeadSha: string | null;
+  },
+): Promise<{ stage_run_id: number | null } | null> {
+  return queryOne<{ stage_run_id: number | null }>(sql`
+    UPDATE app.reviews SET status = 'completed', completed_at = CURRENT_TIMESTAMP,
+      review_url = ${reviewUrl}, findings_count = ${findingsCount}, verdict = ${verdict},
+      finding_paths = ${findingPaths === null ? null : JSON.stringify(findingPaths)}::jsonb,
+      conclusion = ${readiness?.conclusion ?? null},
+      coverage_status = ${readiness?.coverageStatus ?? null},
+      reviewable_file_count = ${readiness?.reviewableFileCount ?? null},
+      covered_file_count = ${readiness?.coveredFileCount ?? null},
+      missing_paths = ${readiness ? JSON.stringify(readiness.missingPaths) : null}::jsonb,
+      coverage_head_sha = ${readiness?.coverageHeadSha ?? null},
+      published_head_sha = ${readiness?.publishedHeadSha ?? null}
+    WHERE id = ${reviewId} AND status = 'running'
+    RETURNING stage_run_id
+  `);
+}
+
 // Accumulates one model turn's usage onto the latest review row for an agent
 // instance. Fired from the observe() metering subscriber.
 export async function addReviewUsage(
@@ -1177,5 +1209,27 @@ export async function addReviewUsage(
       SELECT id FROM app.reviews WHERE agent_instance_id = ${agentInstanceId}
       ORDER BY id DESC LIMIT 1
     )
+  `);
+}
+
+export async function addReviewUsageBySubmission(
+  submissionId: string,
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+    costUsd: number;
+    model: string;
+  },
+): Promise<void> {
+  await execute(sql`
+    UPDATE app.reviews SET
+      input_tokens = input_tokens + ${usage.inputTokens},
+      output_tokens = output_tokens + ${usage.outputTokens},
+      cache_read_tokens = cache_read_tokens + ${usage.cacheReadTokens},
+      cache_write_tokens = cache_write_tokens + ${usage.cacheWriteTokens},
+      cost_usd = cost_usd + ${usage.costUsd}, model = ${usage.model}
+    WHERE submission_id = ${submissionId}
   `);
 }

--- a/src/data/reviews.ts
+++ b/src/data/reviews.ts
@@ -2,7 +2,7 @@ import { sql } from 'drizzle-orm';
 import { STALL_AFTER_MINUTES } from '../shared/time.ts';
 import type { CandidateFinding, FindingDecision } from '../domain/review-verification.ts';
 import type { ReviewConclusion } from '../domain/review-context.ts';
-import { queryOne, queryRows, withTransaction } from './database.ts';
+import { execute, queryOne, queryRows, withTransaction } from './database.ts';
 import { bigintArray, minutesAgo } from './sql.ts';
 
 export interface AgentUsageRow {
@@ -46,6 +46,7 @@ export interface ReviewActivityRow {
   model: string | null;
   agent_slug: string | null; // null on rows predating multi-agent support
   agent_instance_id: string | null;
+  submission_id: string | null;
   risk_tier: string | null; // null before tiering, and on mention/manual dispatch
   findings_count: number | null; // null until post_review completes the row
   stage_run_id: number | null;
@@ -78,6 +79,22 @@ export interface ReviewQualityRecord {
   experimentKey: string | null;
 }
 
+export interface ReviewRunGuard {
+  id: number;
+  repository_id: number;
+  pr_number: number;
+  status: string;
+  head_sha: string | null;
+  submission_id: string | null;
+}
+
+export async function getReviewRunGuard(reviewId: number): Promise<ReviewRunGuard | null> {
+  return queryOne<ReviewRunGuard>(sql`
+    SELECT id, repository_id, pr_number, status, head_sha, submission_id
+    FROM app.reviews WHERE id = ${reviewId}
+  `);
+}
+
 export async function recordReviewQuality(
   agentInstanceId: string,
   quality: ReviewQualityRecord,
@@ -101,6 +118,53 @@ export async function recordReviewQuality(
         verification_latency_ms = ${quality.latencyMs},
         experiment_key = ${quality.experimentKey}
       WHERE id = ${reviewId}
+    `);
+    await transaction.execute(sql`DELETE FROM app.review_findings WHERE review_id = ${reviewId}`);
+    if (quality.candidates.length === 0) return;
+    const published = new Set(quality.publishedCandidateIndexes);
+    const decisions = new Map(quality.decisions.map((decision) => [decision.candidate, decision]));
+    const values = quality.candidates.map((candidate, index) => {
+      const decision = decisions.get(index);
+      return sql`(
+        ${reviewId}, ${index}, ${candidate.path}, ${candidate.line}, ${candidate.side},
+        ${candidate.severity}, ${candidate.body}, ${candidate.evidence}, ${candidate.failurePath},
+        ${published.has(index)}, ${decision?.confidence ?? null}, ${decision?.severity ?? null},
+        ${decision?.reason ?? null}
+      )`;
+    });
+    await transaction.execute(sql`
+      INSERT INTO app.review_findings
+        (review_id, candidate_index, path, line, side, severity, body, evidence, failure_path,
+         published, verifier_confidence, verifier_severity, verification_reason)
+      VALUES ${sql.join(values, sql`, `)}
+    `);
+  });
+}
+
+// Exact-run variant used by dispatched reviews. Re-review conversations reuse
+// their agent instance id, so production writes must never select "latest".
+export async function recordReviewQualityById(
+  reviewId: number,
+  quality: ReviewQualityRecord,
+): Promise<void> {
+  await withTransaction(async (transaction) => {
+    const found = await transaction.execute<{ id: number }>(sql`
+      SELECT id FROM app.reviews
+      WHERE id = ${reviewId} AND status = 'running'
+      FOR UPDATE
+    `);
+    if (!found.rows[0]) return;
+    await transaction.execute(sql`
+      UPDATE app.reviews SET
+        candidate_count = ${quality.candidates.length},
+        verification_status = ${quality.status},
+        verification_model = ${quality.model},
+        verification_input_tokens = ${quality.inputTokens},
+        verification_output_tokens = ${quality.outputTokens},
+        verification_cost_usd = ${quality.costUsd},
+        verification_latency_ms = ${quality.latencyMs},
+        experiment_key = ${quality.experimentKey}
+      WHERE id = ${reviewId} AND status = 'running'
     `);
     await transaction.execute(sql`DELETE FROM app.review_findings WHERE review_id = ${reviewId}`);
     if (quality.candidates.length === 0) return;
@@ -385,6 +449,37 @@ export async function markReviewFailed(
       ORDER BY id DESC LIMIT 1
     )
     RETURNING stage_run_id
+  `);
+}
+
+export async function markReviewFailedById(
+  reviewId: number,
+  error: string | null = null,
+): Promise<{ stage_run_id: number | null } | null> {
+  return queryOne<{ stage_run_id: number | null }>(sql`
+    UPDATE app.reviews SET status = 'failed', completed_at = CURRENT_TIMESTAMP,
+      error = COALESCE(${error}::text, error)
+    WHERE id = ${reviewId} AND status = 'running'
+    RETURNING stage_run_id
+  `);
+}
+
+export async function markReviewFailedBySubmission(
+  submissionId: string,
+  error: string | null = null,
+): Promise<{ stage_run_id: number | null } | null> {
+  return queryOne<{ stage_run_id: number | null }>(sql`
+    UPDATE app.reviews SET status = 'failed', completed_at = CURRENT_TIMESTAMP,
+      error = COALESCE(${error}::text, error)
+    WHERE submission_id = ${submissionId} AND status = 'running'
+    RETURNING stage_run_id
+  `);
+}
+
+export async function bindReviewSubmission(reviewId: number, submissionId: string): Promise<void> {
+  await execute(sql`
+    UPDATE app.reviews SET submission_id = ${submissionId}
+    WHERE id = ${reviewId} AND status = 'running' AND submission_id IS NULL
   `);
 }
 

--- a/src/data/schema.ts
+++ b/src/data/schema.ts
@@ -717,6 +717,9 @@ export const reviews = appSchema.table(
     model: text(),
     agentSlug: text('agent_slug'),
     agentInstanceId: text('agent_instance_id'),
+    // Durable Flue delivery identity. The instance id is intentionally reused
+    // across re-reviews; this id binds metering and settlement to one run.
+    submissionId: text('submission_id'),
     riskTier: text('risk_tier'),
     findingsCount: integer('findings_count'),
     candidateCount: integer('candidate_count'),
@@ -767,6 +770,9 @@ export const reviews = appSchema.table(
   },
   (table) => [
     index('reviews_agent_instance_idx').using('btree', table.agentInstanceId),
+    uniqueIndex('reviews_submission_id_idx')
+      .using('btree', table.submissionId)
+      .where(sql`(submission_id IS NOT NULL)`),
     index('reviews_installation_time_idx').using(
       'btree',
       table.installationId,

--- a/src/services/lifecycle.ts
+++ b/src/services/lifecycle.ts
@@ -4,6 +4,7 @@ import {
   cancelStageRun,
   claimStageRun,
   completeReview,
+  completeReviewById,
   countBudgetedFixAttempts,
   createAcceptanceContract,
   createFactoryRunWithStage,
@@ -20,6 +21,8 @@ import {
   listCrChecks,
   listStageRuns,
   markReviewFailed,
+  markReviewFailedById,
+  markReviewFailedBySubmission,
   recordLifecycleDecision,
   recordStageRunOutput,
   resumeFactoryRun,
@@ -547,12 +550,58 @@ export async function completeLifecycleReview(
   if (completed?.stage_run_id) await settleReviewStage(completed.stage_run_id, enqueue);
 }
 
+export async function completeLifecycleReviewById(
+  reviewId: number,
+  reviewUrl: string | null,
+  findingsCount: number,
+  verdict: 'approve' | 'comment' | 'request_changes',
+  findingPaths: string[] = [],
+  enqueue: typeof enqueueFactoryMessage = enqueueFactoryMessage,
+  readiness?: {
+    conclusion: ReviewConclusion;
+    coverageStatus: 'complete' | 'incomplete' | 'stale';
+    reviewableFileCount: number;
+    coveredFileCount: number;
+    missingPaths: string[];
+    coverageHeadSha: string | null;
+    publishedHeadSha: string | null;
+  },
+): Promise<void> {
+  const completed = await completeReviewById(
+    reviewId,
+    reviewUrl,
+    findingsCount,
+    verdict,
+    findingPaths,
+    readiness,
+  );
+  if (completed?.stage_run_id) await settleReviewStage(completed.stage_run_id, enqueue);
+}
+
 export async function failLifecycleReview(
   agentInstanceId: string,
   reason: string | null = null,
   enqueue: typeof enqueueFactoryMessage = enqueueFactoryMessage,
 ): Promise<void> {
   const failed = await markReviewFailed(agentInstanceId, reason);
+  if (failed?.stage_run_id) await settleReviewStage(failed.stage_run_id, enqueue);
+}
+
+export async function failLifecycleReviewById(
+  reviewId: number,
+  reason: string | null = null,
+  enqueue: typeof enqueueFactoryMessage = enqueueFactoryMessage,
+): Promise<void> {
+  const failed = await markReviewFailedById(reviewId, reason);
+  if (failed?.stage_run_id) await settleReviewStage(failed.stage_run_id, enqueue);
+}
+
+export async function failLifecycleReviewBySubmission(
+  submissionId: string,
+  reason: string | null = null,
+  enqueue: typeof enqueueFactoryMessage = enqueueFactoryMessage,
+): Promise<void> {
+  const failed = await markReviewFailedBySubmission(submissionId, reason);
   if (failed?.stage_run_id) await settleReviewStage(failed.stage_run_id, enqueue);
 }
 


### PR DESCRIPTION
Stack 2/6. Builds on #164.

## What changed

- Persist Flue's durable submission ID on each review row.
- Bind tool access, metering, settlement, quality evidence, and completion to an exact review ID.
- Pin all PR/CR and repository-workspace tools to the dispatched change number and head SHA.
- Stop stale reviews before publication and record them as inconclusive instead.
- Add a regression test proving an older submission cannot mutate its replacement row.

## Verification

- `vp test` (41 files, 297 tests)
- `vp run check:types`
- `vp run test:schema` (22 migrations, 50 tables)
- `vp run db:check`
- `vp lint` (pre-existing warnings only)

Worker integration execution remains locally unavailable because this environment cannot access Docker/PostgreSQL; its test program typechecks.
