### PR TITLE
Publish fail-closed GitHub review readiness checks

### DIFF
--- a/docs/review-quality.md
+++ b/docs/review-quality.md
@@ -72,6 +72,16 @@ withheld and the review is forced to `COMMENT`; it cannot accidentally approve
 or request changes from unverified output. The publisher then emits one
 consolidated GitHub review with the retained inline comments.
 
+When every required reviewer in the lifecycle stage settles, Turbodiff also
+publishes a head-SHA-bound `Turbodiff / Review readiness` Check Run. Its
+conclusion is successful only when every dispatched reviewer completed with
+full evidence and no P1 conclusion. Missing evidence, a failed reviewer, a
+stale head, or a blocking finding produces a failing check with per-reviewer
+coverage and diagnostic detail. Re-runs on the same head update the same
+logical check. Both lifecycle merges and legacy factory auto-merge consult the
+persisted stage result directly, so an absent or delayed GitHub check cannot
+accidentally weaken the internal gate.
+
 ```mermaid
 flowchart LR
   SCOUT["Persona scout"] -->|"candidates + causal evidence"| BOUNDARY["post_review boundary"]

--- a/src/data/lifecycle.ts
+++ b/src/data/lifecycle.ts
@@ -212,13 +212,15 @@ export async function finishStageRun(
   status: 'completed' | 'failed',
   output?: JsonValue,
   error?: string,
-): Promise<void> {
-  await execute(sql`
+): Promise<boolean> {
+  const finished = await queryOne<{ id: number }>(sql`
     UPDATE app.stage_runs SET status = ${status},
       output = ${output === undefined ? null : JSON.stringify(output)}::jsonb,
       error = ${error ?? null}, completed_at = CURRENT_TIMESTAMP
     WHERE id = ${id} AND status = 'running'
+    RETURNING id
   `);
+  return finished !== null;
 }
 
 // A claimed stage whose work was overtaken before it ran (a push review

--- a/src/data/reviews.ts
+++ b/src/data/reviews.ts
@@ -579,6 +579,66 @@ export interface ReviewStageProgress {
   errors: string[];
 }
 
+export interface ReviewStageEvidenceRow {
+  agent_slug: string | null;
+  status: string;
+  conclusion: ReviewConclusion | null;
+  covered_file_count: number | null;
+  reviewable_file_count: number | null;
+  missing_paths: string[] | null;
+  findings_count: number | null;
+  error: string | null;
+  review_url: string | null;
+  head_sha: string | null;
+}
+
+export async function reviewStageEvidence(stageRunId: number): Promise<ReviewStageEvidenceRow[]> {
+  return queryRows<ReviewStageEvidenceRow>(sql`
+    SELECT agent_slug, status, conclusion, covered_file_count, reviewable_file_count,
+      missing_paths, findings_count, error, review_url, head_sha
+    FROM app.reviews
+    WHERE stage_run_id = ${stageRunId}
+    ORDER BY agent_slug, id
+  `);
+}
+
+export interface ReviewHeadReadiness {
+  stage_status: string;
+  total: number;
+  running: number;
+  failed: number;
+  inconclusive: number;
+  not_ready: number;
+}
+
+export async function reviewHeadReadiness(
+  repositoryId: number,
+  prNumber: number,
+  headSha: string,
+): Promise<ReviewHeadReadiness | null> {
+  return queryOne<ReviewHeadReadiness>(sql`
+    WITH latest_stage AS (
+      SELECT stage_run_id
+      FROM app.reviews
+      WHERE repository_id = ${repositoryId} AND pr_number = ${prNumber}
+        AND head_sha = ${headSha} AND stage_run_id IS NOT NULL
+      ORDER BY id DESC LIMIT 1
+    )
+    SELECT s.status AS stage_status,
+      COUNT(r.id) AS total,
+      COUNT(r.id) FILTER (WHERE r.status = 'running') AS running,
+      COUNT(r.id) FILTER (WHERE r.status = 'failed') AS failed,
+      COUNT(r.id) FILTER (
+        WHERE r.conclusion = 'inconclusive' OR r.conclusion IS NULL
+      ) AS inconclusive,
+      COUNT(r.id) FILTER (WHERE r.conclusion = 'not_ready') AS not_ready
+    FROM latest_stage l
+    JOIN app.stage_runs s ON s.id = l.stage_run_id
+    JOIN app.reviews r ON r.stage_run_id = l.stage_run_id
+    GROUP BY s.status
+  `);
+}
+
 export async function reviewStageProgress(stageRunId: number): Promise<ReviewStageProgress> {
   const row = await queryOne<ReviewStageProgress>(sql`
     SELECT
@@ -586,7 +646,10 @@ export async function reviewStageProgress(stageRunId: number): Promise<ReviewSta
       COUNT(*) FILTER (WHERE status = 'completed') AS completed,
       COUNT(*) FILTER (WHERE status = 'failed') AS failed,
       COALESCE(BOOL_OR(conclusion = 'not_ready' OR verdict = 'request_changes'), FALSE) AS blocking,
-      COUNT(*) FILTER (WHERE status = 'completed' AND conclusion = 'inconclusive') AS inconclusive,
+      COUNT(*) FILTER (
+        WHERE status = 'completed'
+          AND (conclusion = 'inconclusive' OR (conclusion IS NULL AND submission_id IS NOT NULL))
+      ) AS inconclusive,
       COALESCE(
         ARRAY_REMOVE(ARRAY_AGG(error ORDER BY id) FILTER (WHERE status = 'failed'), NULL),
         '{}'

--- a/src/domain/review-readiness.test.ts
+++ b/src/domain/review-readiness.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { reviewReadinessReport, type ReviewReadinessEvidence } from './review-readiness.ts';
+
+const ready: ReviewReadinessEvidence = {
+  agentSlug: 'review',
+  status: 'completed',
+  conclusion: 'ready',
+  coveredFileCount: 4,
+  reviewableFileCount: 4,
+  missingPaths: [],
+  findingsCount: 0,
+  error: null,
+};
+
+describe('reviewReadinessReport', () => {
+  it('passes only when every required reviewer is conclusive', () => {
+    expect(reviewReadinessReport([ready])).toMatchObject({
+      conclusion: 'ready',
+      checkConclusion: 'success',
+    });
+    expect(
+      reviewReadinessReport([
+        ready,
+        { ...ready, agentSlug: 'security', conclusion: 'inconclusive', missingPaths: ['auth.ts'] },
+      ]),
+    ).toMatchObject({ conclusion: 'inconclusive', checkConclusion: 'failure' });
+  });
+
+  it('keeps verified blocking findings distinct from missing evidence', () => {
+    expect(
+      reviewReadinessReport([{ ...ready, conclusion: 'not_ready', findingsCount: 1 }]),
+    ).toMatchObject({
+      conclusion: 'not_ready',
+      checkConclusion: 'failure',
+      title: 'Review gate failed',
+    });
+    expect(reviewReadinessReport([])).toMatchObject({
+      conclusion: 'inconclusive',
+      checkConclusion: 'failure',
+    });
+  });
+});

--- a/src/domain/review-readiness.ts
+++ b/src/domain/review-readiness.ts
@@ -1,0 +1,70 @@
+import type { ReviewConclusion } from './review-context.ts';
+
+export interface ReviewReadinessEvidence {
+  agentSlug: string | null;
+  status: string;
+  conclusion: ReviewConclusion | null;
+  coveredFileCount: number | null;
+  reviewableFileCount: number | null;
+  missingPaths: string[] | null;
+  findingsCount: number | null;
+  error: string | null;
+}
+
+export interface ReviewReadinessReport {
+  conclusion: ReviewConclusion;
+  checkConclusion: 'success' | 'failure';
+  title: string;
+  summary: string;
+  text: string;
+}
+
+export function reviewReadinessReport(evidence: ReviewReadinessEvidence[]): ReviewReadinessReport {
+  const failed = evidence.filter((item) => item.status === 'failed');
+  const inconclusive = evidence.filter(
+    (item) => item.status !== 'completed' || item.conclusion === 'inconclusive' || !item.conclusion,
+  );
+  const notReady = evidence.filter((item) => item.conclusion === 'not_ready');
+  const warning = evidence.some((item) => item.conclusion === 'ready_with_warnings');
+  const conclusion: ReviewConclusion =
+    evidence.length === 0 || failed.length > 0 || inconclusive.length > 0
+      ? 'inconclusive'
+      : notReady.length > 0
+        ? 'not_ready'
+        : warning
+          ? 'ready_with_warnings'
+          : 'ready';
+  const covered = evidence.reduce((sum, item) => sum + (item.coveredFileCount ?? 0), 0);
+  const reviewable = evidence.reduce((sum, item) => sum + (item.reviewableFileCount ?? 0), 0);
+  const findings = evidence.reduce((sum, item) => sum + (item.findingsCount ?? 0), 0);
+  const title =
+    conclusion === 'ready'
+      ? 'Review gate passed'
+      : conclusion === 'ready_with_warnings'
+        ? 'Review gate passed with warnings'
+        : conclusion === 'not_ready'
+          ? 'Review gate failed'
+          : 'Review evidence is inconclusive';
+  const summary =
+    `Conclusion: ${conclusion.replaceAll('_', ' ')}. ` +
+    `${evidence.length} required reviewer(s); ${covered}/${reviewable} file assessment(s) covered; ` +
+    `${findings} verified finding(s).`;
+  const rows = evidence.map((item) => {
+    const missing = item.missingPaths?.length
+      ? `; missing ${item.missingPaths.slice(0, 10).join(', ')}${item.missingPaths.length > 10 ? ', …' : ''}`
+      : '';
+    const reason = item.error ? `; ${item.error}` : '';
+    return (
+      `- ${item.agentSlug ?? 'review'}: ${item.status}/${item.conclusion ?? 'no conclusion'}; ` +
+      `${item.coveredFileCount ?? 0}/${item.reviewableFileCount ?? 0} covered${missing}${reason}`
+    );
+  });
+  return {
+    conclusion,
+    checkConclusion:
+      conclusion === 'ready' || conclusion === 'ready_with_warnings' ? 'success' : 'failure',
+    title,
+    summary,
+    text: rows.join('\n').slice(0, 60_000),
+  };
+}

--- a/src/http/webhooks.worker.test.ts
+++ b/src/http/webhooks.worker.test.ts
@@ -22,6 +22,7 @@ import {
   latestAcceptanceContractForChange,
   listFactoryRunsForFeature,
   listStageRuns,
+  reviewHeadReadiness,
   tryRecordFixAttempt,
   tryRecordReview,
   updateFeature,
@@ -1631,6 +1632,12 @@ describe('push re-reviews', () => {
     await expect(getFactoryRun(stage.factoryRunId)).resolves.toMatchObject({
       status: 'awaiting_human',
       handoff_reason: 'stage failure requires retry policy evaluation',
+    });
+    await expect(reviewHeadReadiness(101, 77, headA)).resolves.toMatchObject({
+      stage_status: 'failed',
+      running: 0,
+      failed: 0,
+      inconclusive: 1,
     });
   });
 

--- a/src/services/auto-merge.ts
+++ b/src/services/auto-merge.ts
@@ -2,8 +2,8 @@ import { env } from 'cloudflare:workers';
 import { githubRequest as gh } from '../integrations/github/client.ts';
 import {
   getFeatureByRepoPr,
-  latestCompletedReviewsByAgent,
   latestVerificationForFeature,
+  reviewHeadReadiness,
   type RepositoryRow,
 } from '../data/db.ts';
 import { installationToken } from '../integrations/github/app.ts';
@@ -67,21 +67,23 @@ export async function maybeAutoMerge(repo: RepositoryRow, prNumber: number): Pro
     const mergeability = await checkMergeability(token, repo.owner, repo.name, prNumber, {
       retryOnUnknown: true,
     });
-    const recordedReviews = (await latestCompletedReviewsByAgent(repo.id, prNumber)).filter(
-      (review) => review.head_sha === mergeability.headSha,
+    const readiness = await reviewHeadReadiness(repo.id, prNumber, mergeability.headSha);
+    const reviewEvidenceConclusive = Boolean(
+      readiness &&
+      readiness.stage_status === 'completed' &&
+      readiness.total > 0 &&
+      readiness.running === 0 &&
+      readiness.failed === 0 &&
+      readiness.inconclusive === 0 &&
+      readiness.not_ready === 0,
     );
-    const reviewEvidenceConclusive =
-      recordedReviews.length > 0 &&
-      recordedReviews.every(
-        (review) => review.conclusion === 'ready' || review.conclusion === 'ready_with_warnings',
-      );
 
     const decline = autoMergeDecline({
       optedIn: repo.auto_merge,
       blockingReviews: repo.blocking_reviews,
       hasAcceptanceCriteria: Boolean(feature.acceptance),
       verificationPassed: verification?.status === 'passed',
-      reviewed: botReviews.length > 0 && recordedReviews.length > 0,
+      reviewed: botReviews.length > 0 && Boolean(readiness?.total),
       reviewEvidenceConclusive,
       anyBlockingReview: botReviews.some(
         (r) =>

--- a/src/services/lifecycle.ts
+++ b/src/services/lifecycle.ts
@@ -27,6 +27,7 @@ import {
   recordStageRunOutput,
   resumeFactoryRun,
   reviewStageProgress,
+  reviewHeadReadiness,
   type FactoryRunRow,
   type StageRunRow,
 } from '../data/db.ts';
@@ -35,6 +36,7 @@ import type { ReviewConclusion } from '../domain/review-context.ts';
 import { canResumeLifecycleRun, resumeTargetStage } from '../domain/lifecycle-resume.ts';
 import { formatUnmetCriteriaFindings } from '../domain/verification.ts';
 import { isDeliveryProcessProfile, processProfile } from '../domain/process-profiles.ts';
+import { publishReviewReadinessCheckForStage } from './review-readiness-check.ts';
 import type {
   LifecycleDecision,
   LifecycleEventKind,
@@ -352,10 +354,22 @@ function scheduledHeadFromInput(input: JsonValue | null): string | null {
 
 async function assertGithubMergeReady(
   token: string,
-  repo: { owner: string; name: string },
+  repo: { id: number; owner: string; name: string },
   change: { number: number; source_head: string | null },
 ): Promise<void> {
   if (!change.source_head) throw new Error('change head is unknown');
+  const readiness = await reviewHeadReadiness(repo.id, change.number, change.source_head);
+  if (
+    !readiness ||
+    readiness.stage_status !== 'completed' ||
+    readiness.total === 0 ||
+    readiness.running > 0 ||
+    readiness.failed > 0 ||
+    readiness.inconclusive > 0 ||
+    readiness.not_ready > 0
+  ) {
+    throw new Error('Turbodiff review evidence is not conclusively ready for this head');
+  }
   const mergeability = await checkMergeability(token, repo.owner, repo.name, change.number, {
     retryOnUnknown: true,
   });
@@ -459,6 +473,12 @@ type ReviewStageOutput = {
   errors?: string[];
 };
 
+async function publishReviewReadiness(stageRunId: number): Promise<void> {
+  await publishReviewReadinessCheckForStage(stageRunId).catch((error) =>
+    console.error('turbodiff: publishing review readiness check failed', error),
+  );
+}
+
 async function settleReviewStage(
   stageRunId: number,
   enqueue: typeof enqueueFactoryMessage,
@@ -490,12 +510,14 @@ async function settleReviewStage(
     // 413 that explained it came second.
     const reasons = [...new Set(progress.errors.filter(Boolean))];
     const why = reasons.length > 0 ? `: ${reasons.join(' · ')}` : '';
-    await finishStageRun(
+    const finished = await finishStageRun(
       stageRun.id,
       'failed',
       output,
       `all review dispatches failed${why}`.slice(0, 1_000),
     );
+    if (!finished) return;
+    await publishReviewReadiness(stageRun.id);
     await coordinateStageOutcome(command, false, enqueue);
     return;
   }
@@ -505,16 +527,20 @@ async function settleReviewStage(
       reasons.push(`${progress.inconclusive} review(s) completed without conclusive evidence`);
     }
     const why = reasons.length > 0 ? `: ${reasons.join(' · ')}` : '';
-    await finishStageRun(
+    const finished = await finishStageRun(
       stageRun.id,
       'failed',
       output,
       `review stage is inconclusive${why}`.slice(0, 1_000),
     );
+    if (!finished) return;
+    await publishReviewReadiness(stageRun.id);
     await coordinateStageOutcome(command, false, enqueue);
     return;
   }
-  await finishStageRun(stageRun.id, 'completed', output);
+  const finished = await finishStageRun(stageRun.id, 'completed', output);
+  if (!finished) return;
+  await publishReviewReadiness(stageRun.id);
   await coordinateStageOutcome(command, true, enqueue, {
     blockingFindings: progress.blocking,
   });

--- a/src/services/review-readiness-check.ts
+++ b/src/services/review-readiness-check.ts
@@ -1,0 +1,69 @@
+import { env } from 'cloudflare:workers';
+import {
+  getChange,
+  getFactoryRun,
+  getRepoById,
+  getStageRun,
+  reviewStageEvidence,
+} from '../data/db.ts';
+import { reviewReadinessReport } from '../domain/review-readiness.ts';
+import { installationToken } from '../integrations/github/app.ts';
+import { githubRequest as gh } from '../integrations/github/client.ts';
+
+export const REVIEW_READINESS_CHECK_NAME = 'Turbodiff / Review readiness';
+
+export async function publishReviewReadinessCheckForStage(stageRunId: number): Promise<void> {
+  const stage = await getStageRun(stageRunId);
+  if (!stage || stage.stage !== 'review' || !stage.change_id) return;
+  const [run, change, evidence] = await Promise.all([
+    getFactoryRun(stage.factory_run_id),
+    getChange(stage.change_id),
+    reviewStageEvidence(stageRunId),
+  ]);
+  if (!run || !change || !change.provider_key.startsWith('github:') || !change.source_head) return;
+  if (!change.capabilities.includes('publish_check')) return;
+  const repo = await getRepoById(run.repository_id);
+  if (!repo) return;
+
+  const heads = [...new Set(evidence.map((item) => item.head_sha).filter(Boolean))];
+  if (heads.length !== 1) throw new Error('review evidence does not resolve to one GitHub head');
+  const headSha = heads[0]!;
+  const report = reviewReadinessReport(
+    evidence.map((item) => ({
+      agentSlug: item.agent_slug,
+      status: item.status,
+      conclusion: item.conclusion,
+      coveredFileCount: item.covered_file_count,
+      reviewableFileCount: item.reviewable_file_count,
+      missingPaths: item.missing_paths,
+      findingsCount: item.findings_count,
+      error: item.error,
+    })),
+  );
+  const token = await installationToken(repo.installation_id);
+  const externalId = `review-readiness:${repo.id}:${change.number}:${headSha}`;
+  const base = `/repos/${repo.owner}/${repo.name}`;
+  const current = await gh(
+    token,
+    `${base}/commits/${headSha}/check-runs?check_name=${encodeURIComponent(REVIEW_READINESS_CHECK_NAME)}&per_page=100`,
+  ).then((response) =>
+    response.json<{
+      check_runs: { id: number; external_id: string | null; name: string }[];
+    }>(),
+  );
+  const existing = current.check_runs.find(
+    (check) => check.external_id === externalId && check.name === REVIEW_READINESS_CHECK_NAME,
+  );
+  const body = {
+    name: REVIEW_READINESS_CHECK_NAME,
+    external_id: externalId,
+    details_url: `${env.PUBLIC_BASE_URL}/reviews`,
+    status: 'completed',
+    conclusion: report.checkConclusion,
+    output: { title: report.title, summary: report.summary, text: report.text || undefined },
+  };
+  await gh(token, existing ? `${base}/check-runs/${existing.id}` : `${base}/check-runs`, {
+    method: existing ? 'PATCH' : 'POST',
+    body: JSON.stringify(existing ? body : { ...body, head_sha: headSha }),
+  });
+}


### PR DESCRIPTION
Stack 5/6. Builds on #168.

## What changed

- Aggregate every required review in a lifecycle stage into one fail-closed readiness report.
- Publish or update a head-SHA-bound `Turbodiff / Review readiness` GitHub Check Run.
- Return success only for fully conclusive `ready` / `ready with warnings` stages.
- Return failure for P1 blocks, stale heads, incomplete coverage, verifier failure, missing conclusions, or failed agents.
- Include reviewer-by-reviewer coverage and diagnostic evidence in the check output.
- Make stage settlement single-winner so concurrent completions cannot publish duplicate final checks.
- Require the persisted completed review stage in both lifecycle merge and legacy factory auto-merge paths.

## Verification

- `vp test` (43 files, 302 tests)
- `vp run check:types`
- `vp lint` (pre-existing warnings only)
- Existing 24-migration schema remains validated by the preceding stack PR.

Worker integration execution remains locally unavailable because this environment cannot access Docker/PostgreSQL; its test program typechecks.
