### PR TITLE
Surface review readiness evidence in the Quality UI

### DIFF
--- a/src/client/lib/queries.ts
+++ b/src/client/lib/queries.ts
@@ -23,6 +23,7 @@ import type {
   ApiRepoFile,
   ApiRepoTree,
   ApiReviewQuality,
+  ApiReviewsPage,
   ApiSettings,
   ApiSkillCatalog,
   ApiSkillDetail,
@@ -117,6 +118,13 @@ export const usageQuery = queryOptions({
 export const reviewQualityQuery = queryOptions({
   queryKey: ['review-quality'],
   queryFn: () => api.get<ApiReviewQuality>('/api/review-quality'),
+});
+
+export const reviewsQuery = queryOptions({
+  queryKey: ['reviews', 1],
+  queryFn: () => api.get<ApiReviewsPage>('/api/reviews?page=1'),
+  refetchInterval: (query) =>
+    query.state.data?.reviews.some((review) => review.state === 'running') ? LIVE_POLL_MS : false,
 });
 
 // Terminal fix-run outcomes for a cockpit comment's linked batch — anything

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -39,6 +39,7 @@ import {
   queryClient,
   repoCodeQuery,
   reviewQualityQuery,
+  reviewsQuery,
   settingsQuery,
   skillCatalogQuery,
   skillQuery,
@@ -168,7 +169,11 @@ const usageRoute = createRoute({
 const reviewQualityRoute = createRoute({
   getParentRoute: () => shellRoute,
   path: '/review-quality',
-  loader: () => queryClient.ensureQueryData(reviewQualityQuery),
+  loader: () =>
+    Promise.all([
+      queryClient.ensureQueryData(reviewQualityQuery),
+      queryClient.ensureQueryData(reviewsQuery),
+    ]),
   component: lazyRouteComponent(() => import('./pages/review-quality.tsx'), 'ReviewQualityPage'),
 });
 

--- a/src/client/pages/review-quality.tsx
+++ b/src/client/pages/review-quality.tsx
@@ -1,6 +1,16 @@
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
-import { Check, CircleX, Clock3, GitPullRequest, Wrench } from 'lucide-react';
-import type { ApiReviewFindingFeedback, ApiReviewQuality } from '../../shared/api-types.ts';
+import { Check, CircleX, Clock3, ExternalLink, GitPullRequest, Wrench } from 'lucide-react';
+import type {
+  ApiReview,
+  ApiReviewFindingFeedback,
+  ApiReviewQuality,
+} from '../../shared/api-types.ts';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '../components/ui/accordion.tsx';
 import { Markdown } from '../components/markdown.tsx';
 import { EmptyState, Muted, PageTitle, SectionHeading } from '../components/section.tsx';
 import { StatTile } from '../components/stat-tile.tsx';
@@ -9,7 +19,7 @@ import { Card } from '../components/ui/card.tsx';
 import { Pill } from '../components/ui/pill.tsx';
 import { api } from '../lib/api.ts';
 import { ago, fmtDuration, fmtUsd } from '../lib/format.ts';
-import { queryClient, reviewQualityQuery } from '../lib/queries.ts';
+import { queryClient, reviewQualityQuery, reviewsQuery } from '../lib/queries.ts';
 
 const feedbackOptions = [
   { value: 'useful', label: 'Useful', icon: Check },
@@ -22,8 +32,179 @@ function percentage(numerator: number, denominator: number): string {
   return denominator > 0 ? `${Math.round((numerator / denominator) * 100)}%` : '—';
 }
 
+interface ReviewSignal {
+  label: string;
+  tone: 'neutral' | 'on' | 'running' | 'red' | 'warn';
+}
+
+function reviewSignal(review: ApiReview): ReviewSignal {
+  if (review.state === 'running') return { label: 'Reviewing', tone: 'running' };
+  if (review.state === 'stalled') return { label: 'Inconclusive · stalled', tone: 'red' };
+  if (review.state === 'failed') return { label: 'Inconclusive · failed', tone: 'red' };
+  switch (review.conclusion) {
+    case 'ready':
+      return { label: 'Ready', tone: 'on' };
+    case 'ready_with_warnings':
+      return { label: 'Ready · warnings', tone: 'warn' };
+    case 'not_ready':
+      return { label: 'Not ready', tone: 'red' };
+    case 'inconclusive':
+      return { label: 'Inconclusive', tone: 'red' };
+    default:
+      return { label: 'Legacy · no evidence', tone: 'neutral' };
+  }
+}
+
+function ReviewReadinessCard({ review }: { review: ApiReview }) {
+  const signal = reviewSignal(review);
+  const covered = review.covered_file_count ?? 0;
+  const total = review.reviewable_file_count ?? 0;
+  const coverage = total > 0 ? Math.round((covered / total) * 100) : null;
+  const coverageComplete = review.coverage_status === 'complete' && coverage === 100;
+  const blocked = review.file_evidence.filter((item) => item.disposition === 'blocked');
+  return (
+    <AccordionItem value={String(review.id)}>
+      <AccordionTrigger aside={<Pill tone={signal.tone}>{signal.label}</Pill>} className="gap-3">
+        <span className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-left">
+          <span className="font-mono text-xs text-ink">
+            {review.repo ? `${review.repo}#${review.pr_number}` : `PR #${review.pr_number}`}
+          </span>
+          <span className="text-xs text-mute">{review.agent_slug ?? 'review'}</span>
+          <span className="text-xs text-mute">{ago(review.created_at)}</span>
+        </span>
+      </AccordionTrigger>
+      <AccordionContent>
+        <div className="space-y-4 pt-1 text-[0.82rem] text-ink-dim">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div>
+              <div className="font-mono text-[10px] tracking-[0.12em] text-mute uppercase">
+                Coverage
+              </div>
+              <div className="mt-1 font-mono text-sm text-ink">
+                {review.reviewable_file_count === null
+                  ? 'Not recorded'
+                  : `${covered}/${total} files · ${review.coverage_status ?? 'unknown'}`}
+              </div>
+              {coverage !== null ? (
+                <div
+                  className="mt-2 h-1.5 overflow-hidden rounded-full bg-raised"
+                  role="progressbar"
+                  aria-label="Review coverage"
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={coverage}
+                >
+                  <div
+                    className={coverageComplete ? 'h-full bg-go' : 'h-full bg-danger'}
+                    style={{ width: `${coverage}%` }}
+                  />
+                </div>
+              ) : null}
+            </div>
+            <div>
+              <div className="font-mono text-[10px] tracking-[0.12em] text-mute uppercase">
+                Verification
+              </div>
+              <div className="mt-1 font-mono text-sm text-ink">
+                {review.verification_status?.replaceAll('_', ' ') ?? 'Not recorded'}
+              </div>
+            </div>
+            <div>
+              <div className="font-mono text-[10px] tracking-[0.12em] text-mute uppercase">
+                Evidence head
+              </div>
+              <div className="mt-1 font-mono text-sm text-ink">
+                {review.coverage_head_sha?.slice(0, 12) ?? 'Not recorded'}
+              </div>
+            </div>
+          </div>
+
+          {review.error ? (
+            <p className="rounded-lg border border-danger/30 bg-danger/5 px-3 py-2 text-danger">
+              {review.error}
+            </p>
+          ) : null}
+          {review.missing_paths.length > 0 ? (
+            <div>
+              <div className="font-mono text-[10px] tracking-[0.12em] text-danger uppercase">
+                Missing review evidence
+              </div>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {review.missing_paths.map((path) => (
+                  <code
+                    key={path}
+                    className="rounded bg-danger/8 px-2 py-1 text-[11px] text-danger"
+                  >
+                    {path}
+                  </code>
+                ))}
+              </div>
+            </div>
+          ) : null}
+          {review.file_evidence.length > 0 ? (
+            <div>
+              <div className="font-mono text-[10px] tracking-[0.12em] text-mute uppercase">
+                Per-file audit trail
+              </div>
+              <ul className="mt-2 space-y-1.5">
+                {review.file_evidence.map((item) => (
+                  <li key={item.path} className="rounded-lg border border-line/70 px-3 py-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <code className="text-[11px] text-ink">{item.path}</code>
+                      <Pill
+                        tone={
+                          item.patch_delivered && item.disposition === 'reviewed' ? 'on' : 'red'
+                        }
+                      >
+                        {item.patch_delivered
+                          ? (item.disposition ?? 'unacknowledged')
+                          : 'not delivered'}
+                      </Pill>
+                    </div>
+                    {item.evidence ? (
+                      <p className="mt-1 text-xs text-mute">{item.evidence}</p>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          {blocked.length > 0 ? (
+            <p className="text-xs text-danger">
+              {blocked.length} file{blocked.length === 1 ? '' : 's'} explicitly blocked review.
+            </p>
+          ) : null}
+          <div className="flex flex-wrap gap-3 text-xs">
+            {review.pr_url ? (
+              <a
+                href={review.pr_url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-accent-bright hover:underline"
+              >
+                Open pull request <ExternalLink className="ml-1 inline size-3" aria-hidden />
+              </a>
+            ) : null}
+            {review.review_url ? (
+              <a
+                href={review.review_url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-accent-bright hover:underline"
+              >
+                Open published review <ExternalLink className="ml-1 inline size-3" aria-hidden />
+              </a>
+            ) : null}
+          </div>
+        </div>
+      </AccordionContent>
+    </AccordionItem>
+  );
+}
+
 export function ReviewQualityPage() {
   const { data } = useSuspenseQuery(reviewQualityQuery);
+  const { data: activity } = useSuspenseQuery(reviewsQuery);
   const precisionLabels = data.stats.true_positives + data.stats.false_positives;
   const feedback = useMutation({
     mutationFn: ({ id, value }: { id: number; value: ApiReviewFindingFeedback }) =>
@@ -86,6 +267,22 @@ export function ReviewQualityPage() {
           sub="Verification only"
         />
       </div>
+
+      <SectionHeading aside={<Muted>Latest {activity.reviews.length} review runs</Muted>}>
+        Readiness history
+      </SectionHeading>
+      {activity.reviews.length === 0 ? (
+        <EmptyState>Review readiness evidence will appear after the next review.</EmptyState>
+      ) : (
+        <Accordion
+          type="multiple"
+          className="rounded-xl border border-line bg-surface px-4 shadow-edge"
+        >
+          {activity.reviews.map((review) => (
+            <ReviewReadinessCard key={review.id} review={review} />
+          ))}
+        </Accordion>
+      )}
 
       <SectionHeading
         aside={

--- a/src/data/reviews.ts
+++ b/src/data/reviews.ts
@@ -58,6 +58,7 @@ export interface ReviewActivityRow {
   missing_paths: string[] | null;
   coverage_head_sha: string | null;
   published_head_sha: string | null;
+  verification_status: ReviewVerificationStatus | null;
   error: string | null; // why a failed row failed
   repo_owner: string | null; // null if the repo was since removed
   repo_name: string | null;
@@ -93,6 +94,10 @@ export interface ReviewFileEvidenceRow {
   patch_delivered: boolean;
   disposition: 'reviewed' | 'blocked' | null;
   evidence: string | null;
+}
+
+export interface ReviewFileEvidenceDetail extends ReviewFileEvidenceRow {
+  review_id: number;
 }
 
 export interface ReviewFileAcknowledgement {
@@ -178,6 +183,30 @@ export async function listReviewFileEvidence(reviewId: number): Promise<ReviewFi
     FROM app.review_file_evidence e
     WHERE e.review_id = ${reviewId}
     ORDER BY e.path
+  `);
+}
+
+export async function listReviewFileEvidenceForReviews(
+  reviewIds: number[],
+): Promise<ReviewFileEvidenceDetail[]> {
+  if (reviewIds.length === 0) return [];
+  return queryRows<ReviewFileEvidenceDetail>(sql`
+    SELECT e.review_id, e.path,
+      (
+        e.patch_delivered OR EXISTS (
+          SELECT 1 FROM app.review_patch_deliveries d
+          WHERE d.review_id = e.review_id AND d.path = e.path
+          GROUP BY d.review_id, d.path
+          HAVING COUNT(*) = MAX(d.chunk_count)
+            AND MIN(d.chunk_count) = MAX(d.chunk_count)
+            AND MIN(d.chunk_index) = 0
+            AND MAX(d.chunk_index) = MAX(d.chunk_count) - 1
+        )
+      ) AS patch_delivered,
+      e.disposition, e.evidence
+    FROM app.review_file_evidence e
+    WHERE e.review_id = ANY(${bigintArray(reviewIds)})
+    ORDER BY e.review_id, e.path
   `);
 }
 

--- a/src/http/api-support.ts
+++ b/src/http/api-support.ts
@@ -17,6 +17,7 @@ import {
   type PlanWithRepo,
   type RepositoryRow,
   type ReviewActivityRow,
+  type ReviewFileEvidenceDetail,
   type SkillRow,
   type TaskRepoStatusRow,
   type VerificationRow,
@@ -59,7 +60,10 @@ export function totalTokens(row: {
   return row.input_tokens + row.output_tokens + row.cache_read_tokens + row.cache_write_tokens;
 }
 
-export function serializeReview(r: ReviewActivityRow): ApiReview {
+export function serializeReview(
+  r: ReviewActivityRow,
+  fileEvidence: ReviewFileEvidenceDetail[] = [],
+): ApiReview {
   const repo = r.repo_owner && r.repo_name ? `${r.repo_owner}/${r.repo_name}` : null;
   return {
     id: r.id,
@@ -70,6 +74,26 @@ export function serializeReview(r: ReviewActivityRow): ApiReview {
     trigger_event: r.trigger_event,
     risk_tier: r.risk_tier,
     findings_count: r.findings_count,
+    verdict:
+      r.verdict === 'approve' || r.verdict === 'comment' || r.verdict === 'request_changes'
+        ? r.verdict
+        : null,
+    conclusion: r.conclusion,
+    coverage_status: r.coverage_status,
+    reviewable_file_count: r.reviewable_file_count,
+    covered_file_count: r.covered_file_count,
+    missing_paths: r.missing_paths ?? [],
+    coverage_head_sha: r.coverage_head_sha,
+    published_head_sha: r.published_head_sha,
+    verification_status: r.verification_status,
+    file_evidence: fileEvidence
+      .filter((item) => item.review_id === r.id)
+      .map(({ path, patch_delivered, disposition, evidence }) => ({
+        path,
+        patch_delivered,
+        disposition,
+        evidence,
+      })),
     state: reviewState(r),
     error: r.error,
     review_url: r.review_url,

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -73,6 +73,7 @@ import {
   listPlansForInstallations,
   listRecentFeaturesForUsage,
   listRecentReviews,
+  listReviewFileEvidenceForReviews,
   reviewQualityDashboard,
   listRepoAgentOverrides,
   listRepoSkillOverrides,
@@ -867,7 +868,13 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
     const pages = Math.max(1, Math.ceil(total / PER_PAGE));
     const page = Math.min(pages, Math.max(1, Number(c.req.query('page')) || 1));
     const reviews = await listRecentReviews(installationIds, PER_PAGE, (page - 1) * PER_PAGE);
-    return c.json<ApiReviewsPage>({ total, page, pages, reviews: reviews.map(serializeReview) });
+    const evidence = await listReviewFileEvidenceForReviews(reviews.map((review) => review.id));
+    return c.json<ApiReviewsPage>({
+      total,
+      page,
+      pages,
+      reviews: reviews.map((review) => serializeReview(review, evidence)),
+    });
   });
 
   app.get('/review-quality', async (c) => {

--- a/src/http/api.worker.test.ts
+++ b/src/http/api.worker.test.ts
@@ -13,6 +13,7 @@ import type {
   ApiFeatureDetail,
   ApiFeatureExplanation,
   ApiModels,
+  ApiReviewsPage,
   ApiSettings,
   ApiUsage,
   ExplanationDocument,
@@ -281,6 +282,59 @@ describe('review quality feedback', () => {
         )
         .first(),
     ).resolves.toMatchObject({ feedback: 'useful', feedback_by_github_id: 3001, stamped: true });
+  });
+
+  it('returns tenant-scoped readiness and complete per-file delivery evidence', async () => {
+    await testDatabase().batch([
+      testDatabase().prepare(
+        `INSERT INTO reviews
+          (id, repository_id, installation_id, pr_number, trigger_event, status, conclusion,
+           coverage_status, reviewable_file_count, covered_file_count, missing_paths,
+           coverage_head_sha, published_head_sha, verification_status)
+         VALUES
+          (9201, 101, 1001, 27, 'opened', 'completed', 'ready_with_warnings',
+           'complete', 2, 2, '[]', 'abc123', 'abc123', 'completed'),
+          (9202, 202, 2002, 28, 'opened', 'completed', 'ready',
+           'complete', 1, 1, '[]', 'private-sha', 'private-sha', 'completed')`,
+      ),
+      testDatabase().prepare(
+        `INSERT INTO review_file_evidence
+          (review_id, path, patch_delivered, disposition, evidence, delivered_at, acknowledged_at)
+         VALUES
+          (9201, 'src/complete.ts', true, 'reviewed', 'Checked the authorization branch.',
+           CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+          (9201, 'src/chunked.ts', false, 'reviewed', 'Checked all paged diff chunks.',
+           NULL, CURRENT_TIMESTAMP),
+          (9202, 'src/private.ts', true, 'reviewed', 'Must not cross the tenant boundary.',
+           CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      ),
+      testDatabase().prepare(
+        `INSERT INTO review_patch_deliveries (review_id, path, chunk_index, chunk_count)
+         VALUES (9201, 'src/chunked.ts', 0, 2), (9201, 'src/chunked.ts', 1, 2)`,
+      ),
+    ]);
+
+    const response = await authenticatedApi().request('https://turbodiff.test/api/reviews?page=1');
+    expect(response.status).toBe(200);
+    const payload = await response.json<ApiReviewsPage>();
+
+    expect(payload.reviews).toHaveLength(1);
+    expect(payload.reviews[0]).toMatchObject({
+      id: 9201,
+      repo: 'acme/api',
+      conclusion: 'ready_with_warnings',
+      coverage_status: 'complete',
+      reviewable_file_count: 2,
+      covered_file_count: 2,
+      coverage_head_sha: 'abc123',
+      published_head_sha: 'abc123',
+      verification_status: 'completed',
+      file_evidence: [
+        { path: 'src/chunked.ts', patch_delivered: true, disposition: 'reviewed' },
+        { path: 'src/complete.ts', patch_delivered: true, disposition: 'reviewed' },
+      ],
+    });
+    expect(JSON.stringify(payload)).not.toContain('private-sha');
   });
 });
 

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -3,6 +3,7 @@
 // both the worker and client TypeScript programs.
 
 export type ReviewState = 'running' | 'completed' | 'stalled' | 'failed';
+export type ApiReviewConclusion = 'ready' | 'ready_with_warnings' | 'not_ready' | 'inconclusive';
 
 export type ApiProcessProfile =
   | 'review_on_demand'
@@ -25,6 +26,21 @@ export interface ApiReview {
   trigger_event: string;
   risk_tier: string | null;
   findings_count: number | null;
+  verdict: 'approve' | 'comment' | 'request_changes' | null;
+  conclusion: ApiReviewConclusion | null;
+  coverage_status: 'complete' | 'incomplete' | 'stale' | null;
+  reviewable_file_count: number | null;
+  covered_file_count: number | null;
+  missing_paths: string[];
+  coverage_head_sha: string | null;
+  published_head_sha: string | null;
+  verification_status: 'skipped' | 'completed' | 'failed' | 'incomplete' | null;
+  file_evidence: {
+    path: string;
+    patch_delivered: boolean;
+    disposition: 'reviewed' | 'blocked' | null;
+    evidence: string | null;
+  }[];
   state: ReviewState;
   error: string | null; // why a failed review failed
   review_url: string | null;


### PR DESCRIPTION
## Summary

- expose review conclusion, coverage state, exact evidence SHA, verification outcome, and per-file acknowledgements through the review-history API
- add a fail-closed readiness history to the Quality page with explicit ready, not-ready, inconclusive, stalled, and legacy states
- show missing paths and distinguish fully delivered/reviewed files from blocked, partial, or unacknowledged files
- preserve tenant isolation while deriving complete delivery for paged diff chunks

## Stack

6 of 6. Depends on #169.

## Verification

- `vp test` (43 files, 302 tests)
- `vp run check:types`
- `vp lint` (passes; existing warnings remain)
- `vp run build`
- `git diff --check`

The Worker integration suite compiles through `check:types`; runtime execution requires the repository's PostgreSQL/Docker test environment, which is unavailable in this workspace.
