### PR TITLE
Simplify README and switch to MIT

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,105 +1,21 @@
-# Functional Source License, Version 1.1, ALv2 Future License
+MIT License
 
-## Abbreviation
+Copyright (c) 2026 Nico Botha
 
-FSL-1.1-ALv2
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-## Notice
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Copyright 2026 Nico Botha
-
-## Terms and Conditions
-
-### Licensor ("We")
-
-The party offering the Software under these Terms and Conditions.
-
-### The Software
-
-The "Software" is each version of the software that we make available under
-these Terms and Conditions, as indicated by our inclusion of these Terms and
-Conditions with the Software.
-
-### License Grant
-
-Subject to your compliance with this License Grant and the Patents,
-Redistribution and Trademark clauses below, we hereby grant you the right to
-use, copy, modify, create derivative works, publicly perform, publicly display
-and redistribute the Software for any Permitted Purpose identified below.
-
-### Permitted Purpose
-
-A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
-means making the Software available to others in a commercial product or
-service that:
-
-1. substitutes for the Software;
-
-2. substitutes for any other product or service we offer using the Software
-   that exists as of the date we make the Software available; or
-
-3. offers the same or substantially similar functionality as the Software.
-
-Permitted Purposes specifically include using the Software:
-
-1. for your internal use and access;
-
-2. for non-commercial education;
-
-3. for non-commercial research; and
-
-4. in connection with professional services that you provide to a licensee
-   using the Software in accordance with these Terms and Conditions.
-
-### Patents
-
-To the extent your use for a Permitted Purpose would necessarily infringe our
-patents, the license grant above includes a license under our patents. If you
-make a claim against any party that the Software infringes or contributes to
-the infringement of any patent, then your patent license to the Software ends
-immediately.
-
-### Redistribution
-
-The Terms and Conditions apply to all copies, modifications and derivatives of
-the Software.
-
-If you redistribute any copies, modifications or derivatives of the Software,
-you must include a copy of or a link to these Terms and Conditions and not
-remove any copyright notices provided in or with the Software.
-
-### Disclaimer
-
-THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
-PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
-
-IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
-SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
-EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
-
-### Trademarks
-
-Except for displaying the License Details and identifying us as the origin of
-the Software, you have no right under these Terms and Conditions to use our
-trademarks, trade names, service marks or product names.
-
-## Grant of Future License
-
-We hereby irrevocably grant you an additional license to use the Software under
-the Apache License, Version 2.0 that is effective on the second anniversary of
-the date we make the Software available. On or after that date, you may use the
-Software under the Apache License, Version 2.0, in which case the following
-will apply:
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-this file except in compliance with the License.
-
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed
-under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-CONDITIONS OF ANY KIND, either express or implied. See the License for the
-specific language governing permissions and limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,16 @@
 
 <img src="public/logo-small.png" alt="Turbodiff logo" width="64" align="center" />
 
-Turbodiff is an open-source software factory for GitHub. Give it a task and it
+Turbodiff is an open-source software factory. Give it a task and it
 can plan the work, write the code, open a pull request, review the change, fix
 problems, and check the result. You decide where automation starts and stops,
-and which steps need a person to approve them.
+and which steps need a human input.
 
 You can also use the pull request reviewer on its own. Turbodiff works with
 your existing repositories and GitHub workflow rather than asking you to move
 your code or replace your tools.
 
-The project is self-hosted and licensed under the [MIT License](LICENSE.md).
-You can use, change, and share it, including as part of a commercial product.
+This project can be self-hosted and is licensed under the [MIT License](LICENSE.md).
 
 > [!WARNING]
 > Turbodiff is under active development. If you find a problem, please
@@ -26,7 +25,7 @@ Turbodiff covers the path from an idea to a finished pull request:
    with clear success checks.
 2. **Build** — write the code in an isolated container, run the repository's
    checks, and open a pull request.
-3. **Review** — inspect the whole change and publish one clear GitHub review.
+3. **Review** — inspect the whole change and publish clear GitHub reviews.
 4. **Repair** — try to fix important review findings, failed checks, and merge
    conflicts.
 5. **Verify** — compare the finished work with the approved plan. Turbodiff can
@@ -48,36 +47,21 @@ The reviewer also works with pull requests created outside Turbodiff. It can:
 - Run custom review agents for different areas of a codebase.
 - Track whether findings were useful, fixed, or dismissed.
 
-## Open source and self-hosted
-
-The application code is in this repository. Self-hosting gives you control
-over:
-
-- Which repositories Turbodiff can access.
-- Which AI models it uses.
-- Where its database and files are stored.
-- Which features are enabled.
-- How much of the factory runs automatically.
-
-Your GitHub App keys and model credentials stay in services you manage. Code
-writing and verification run in isolated Cloudflare Containers, and permanent
-model credentials are not passed into those containers.
+## Open source and self-hostable
 
 Turbodiff uses:
 
 - **Cloudflare Workers** for the web app and API.
 - **Cloudflare Containers** for code-writing and verification jobs.
 - **Cloudflare AI Gateway** to connect to AI models.
-- **PostgreSQL** for users, repositories, tasks, reviews, and settings.
+- **PostgreSQL** on Planetscale for users, repositories, tasks, reviews, and settings - connected via Hyperdrive.
 - **Cloudflare R2** for logs, screenshots, and other files.
 - **Cloudflare Queues and Workflows** for jobs that take longer than a web
   request.
 
 More detail is available in the [architecture guide](docs/architecture.md).
 
-## Self-hosting
-
-Turbodiff is built for Cloudflare. Before you start, you need:
+To get started with self-hosting you need:
 
 - A Cloudflare account with Workers, Containers, AI Gateway, Hyperdrive,
   Queues, and R2 available.

--- a/README.md
+++ b/README.md
@@ -2,398 +2,135 @@
 
 <img src="public/logo-small.png" alt="Turbodiff logo" width="64" align="right" />
 
-The open-source, composable software factory: agents that can help at any
-contiguous part of delivery, from a free-form idea to an open pull request,
-from an existing pull request to a review, or all the way to a merged and
-verified change. Turbodiff fits into a team's existing process instead of
-requiring the team to replace it. It is a GitHub App hosted end-to-end on
-Cloudflare (Workers, Durable Objects, Hyperdrive, Queues, Containers, R2) and
-built with [Flue](https://flueframework.com).
+Turbodiff is an open-source GitHub app that uses AI to review pull requests
+and turn tasks into code. You can use the hosted version at
+[turbodiff.dev](https://turbodiff.dev) or run it in your own Cloudflare
+account.
 
-Choose where Turbodiff starts, where it stops, and which stages require a
-person. The target lifecycle covers planning, implementation, publication,
-review, repair, verification, and merge. Each stage produces durable artifacts
-that can be handed back to the team or used to continue an automated run.
-
-**Live at [turbodiff.dev](https://turbodiff.dev)** — or self-host on your own
-Cloudflare account ([One-time setup](#one-time-setup)).
+Turbodiff is licensed under the [MIT License](LICENSE.md). You can use, change,
+and share it, including as part of a commercial product.
 
 > [!WARNING]
-> **Turbodiff is under heavy development.** Expect rough edges, bugs, and
-> breaking changes between releases. If something misbehaves, please
-> [open an issue](https://github.com/Ngineer101/turbodiff/issues) — and
-> contributions are very welcome: pull requests, bug reports, and ideas all
-> help. If you want to work on something bigger, open an issue first so we can
-> align on the approach.
+> Turbodiff is under active development. Expect bugs and breaking changes. If
+> you find a problem, please [open an issue](https://github.com/Ngineer101/turbodiff/issues).
 
-## What's inside
+## What it does
 
-**Factory** (in active development — see the
-[composable lifecycle specification](docs/software-factory-lifecycle.md)):
+- Reviews new and updated pull requests.
+- Turns a written task into a plan for you to approve.
+- Writes the code in an isolated container and opens a pull request.
+- Tries to fix review findings and failed checks.
+- Checks the finished work against the approved plan.
+- Lets you choose which steps run automatically and which need approval.
 
-- **Plan** — an agent clones the repo read-only, analyzes your requirements
-  against the real code, asks clarifying questions, and produces a file-level
-  plan plus machine-checkable acceptance criteria for you to approve.
-- **Generate** — an agent implements the approved plan in a sandbox, a
-  per-repo check command gates the push, and a PR opens.
-- **Auto-fix** — a blocking review dispatches a fix agent (max 3 attempts per
-  PR, then a human-handoff comment).
-- **Verify** — every acceptance criterion is checked empirically against the
-  branch: static criteria by reading the tree, runtime criteria by launching
-  the app in the sandbox, visual criteria by driving headless Chrome. The PR
-  gets a report comment with a verdict table and inline screenshots; unmet
-  criteria feed the auto-fix loop.
+## Why self-host
 
-**Review** (where Turbodiff started; also works standalone for existing
-changes through on-demand or automatic repository intake):
+Self-hosting gives you control over where Turbodiff runs, which repositories it
+can access, and which AI models it uses. Your GitHub App keys, database, model
+credentials, and usage data stay in services you manage.
 
-- One durable agent instance per PR (`owner--repo--number`), so re-reviews
-  continue the same conversation and reconcile against earlier findings.
-- Risk tiering sizes the effort: trivial changes get one generalist agent,
-  large or sensitive changes the full agent fleet. A push to a reviewed PR is
-  tiered on what changed since the last review, waits out a per-repo quiet
-  window (a newer push supersedes it), and re-runs only the agents it
-  concerns: those that requested changes, and approvers whose flagged files
-  it touches.
-- Optional blocking mode: a P1 finding posts `REQUEST_CHANGES`, a clean review
-  approves. Approval is coverage-gated: the reviewer receives a complete
-  changed-file manifest, fetches omitted patches in bounded packets, and must
-  account for every reviewable file before Turbodiff can approve.
-- An independent verifier rejects or downgrades unproven candidates before one
-  consolidated review is published. The Quality inbox captures useful,
-  false-positive, fixed, and dismissed labels for precision tracking and evals.
-- Custom review agents (personas) per installation, with optional remote
-  [MCP](https://modelcontextprotocol.io) tool connections (bearer tokens
-  encrypted at rest; servers are treated as untrusted, like the PR itself).
+The application code is all in this repository. A deployment uses Cloudflare
+Workers and Containers, with PostgreSQL for stored data.
 
-Coding runs execute inside Cloudflare Containers with a pinned OpenCode
-harness. Any tool-capable LLM in the Cloudflare AI Gateway catalog can be a
-runner model; authentication, billing, retries, and observability stay
-centralized in Cloudflare. The operator-managed `app.models` table is the sole
-runner catalog: its `runner_default` and `runner_fast_default` roles select the
-normal and low-cost models, with no hard-coded application fallback.
+## Self-hosting
 
-## Architecture
+Turbodiff is built for Cloudflare. Before you start, you need:
 
-Everything runs in one Cloudflare Worker deployment: an HTTP layer (Hono)
-in front of Durable Objects for the long-lived pieces (the per-PR review
-agent, the sandbox container), Cloudflare Workflows for the multi-minute
-factory runs, a queue to decouple intake from execution, PostgreSQL through
-Hyperdrive for relational state, and R2 for artifacts.
+- A Cloudflare account with Workers, Containers, AI Gateway, Hyperdrive,
+  Queues, and R2 available.
+- A PostgreSQL database. The production setup uses PlanetScale, but another
+  PostgreSQL provider can work.
+- A GitHub account that can create a GitHub App.
+- Docker for building the container.
+- [Vite+](https://viteplus.dev) (`vp`) and the Node.js version in
+  [.node-version](.node-version).
 
-```mermaid
-flowchart TB
-  subgraph external ["External"]
-    GH["GitHub<br/>App webhooks · REST API · pull requests"]
-    BROWSER["Browser<br/>React SPA"]
-    MCPS["External MCP servers"]
-    LLM["Cloudflare AI Gateway<br/>OpenAI · Anthropic · Google · Workers AI · …"]
-  end
+### 1. Fork and install
 
-  subgraph worker ["Cloudflare Worker (Hono — src/app.ts)"]
-    WEBHOOKS["/webhooks<br/>HMAC-verified GitHub events"]
-    API["/api<br/>session-cookie JSON for the SPA"]
-    AUTHR["/api/auth<br/>better-auth · GitHub OAuth"]
-    SHELL["/ SPA shell · landing"]
-    ART["/artifacts · /b/:id<br/>signed capability URLs"]
-    PROXY["/mcp-proxy/:id<br/>sealed-grant MCP relay"]
-    MODEL_PROXY["/ai-proxy/v1/*<br/>model-scoped AI relay"]
-    CRON["cron (*/15)<br/>automation poll"]
-    CONSUMER["queue consumer<br/>(src/cloudflare.ts)"]
-  end
+Fork this repository, clone your fork, and install the dependencies:
 
-  subgraph durable ["Durable Objects"]
-    REVIEWER["PrReviewer (Flue agent)<br/>one instance per PR"]
-    FINDING_VERIFIER["Isolated finding verifier<br/>fresh read-only model context"]
-    REVIEW_BOX["Review workspace (container)<br/>per-agent checkout · read-only tools"]
-    SANDBOX["Sandbox (container)<br/>runs pinned OpenCode"]
-  end
-
-  subgraph wf ["Cloudflare Workflows"]
-    GEN["Generation"]
-    VERIFY["Verification"]
-    FIX["Fix"]
-    CONFLICT["Conflict resolve"]
-    AUTO["Automation"]
-  end
-
-  subgraph storage ["State"]
-    PG[("PostgreSQL via Hyperdrive<br/>installations · repos · reviews/findings/feedback<br/>features/plans · connections · automations<br/>(secrets AES-GCM sealed)")]
-    R2[("R2<br/>screenshots · demo videos")]
-    Q[["Queue<br/>turbodiff-factory"]]
-  end
-
-  BROWSER --> SHELL & API & AUTHR
-  GH -->|"PR / push / installation events"| WEBHOOKS
-  WEBHOOKS -->|"review.request signal"| REVIEWER
-  WEBHOOKS -->|"auto-fix · conflict messages"| Q
-  API -->|"feature intake · plan approve<br/>automation CRUD"| Q
-  CRON -->|"due automations"| Q
-  Q --> CONSUMER
-  CONSUMER -->|"plan analyze/refine (inline)"| SANDBOX
-  CONSUMER -->|"creates instances"| wf
-  wf -->|"exec: clone · edit · check"| SANDBOX
-  SANDBOX -->|"git push · open PRs"| GH
-  SANDBOX -->|"JSON/SSE + short-lived model grant"| MODEL_PROXY
-  MODEL_PROXY -->|"Worker-only account token<br/>retry + streaming"| LLM
-  SANDBOX -->|"JSON-RPC + sealed grant"| PROXY
-  PROXY -->|"inject decrypted credential"| MCPS
-  REVIEWER -->|"candidate batch"| FINDING_VERIFIER
-  FINDING_VERIFIER -->|"one consolidated,<br/>coverage-gated review"| GH
-  FINDING_VERIFIER -->|"re-fetch PR + files"| GH
-  REVIEWER & FINDING_VERIFIER -->|"search · configured check"| REVIEW_BOX
-  REVIEW_BOX -->|"short-lived read token<br/>fetch exact PR head"| GH
-  REVIEWER -->|"env.AI binding"| LLM
-  FINDING_VERIFIER -->|"env.AI binding"| LLM
-  REVIEWER -->|"streamable HTTP<br/>per-request auth resolver"| MCPS
-  VERIFY -->|"evidence"| R2
-  ART --> R2
-  worker <--> PG
+```sh
+vp install
 ```
 
-### MCP connections (repo-scoped)
+### 2. Set up Cloudflare
 
-MCP servers are registered once per installation on the integrations page and
-attached to **repositories** (`repo_connections`), with independent toggles
-for the two mount contexts: hosted PR reviews and sandbox automation runs.
-Credentials are sealed (AES-256-GCM) in PostgreSQL and never leave the Worker
-boundary. Hosted reviews mount connections directly — the agent's auth
-resolver decrypts per request. Sandbox runs can't be trusted with
-credentials (they execute repo-influenced code), so they get a relay instead:
+Create an AI Gateway and enable billing for any third-party models you want to
+use. In [wrangler.jsonc](wrangler.jsonc), replace the existing deployment
+values with your own:
 
-```mermaid
-sequenceDiagram
-  participant WF as Automation workflow
-  participant SB as Sandbox (OpenCode)
-  participant PX as Worker /mcp-proxy/:id
-  participant PG as PostgreSQL
-  participant MCP as External MCP server
+- `AI_GATEWAY_ID`
+- `AI_GATEWAY_ACCOUNT_ID`
+- `PUBLIC_BASE_URL`
+- the Hyperdrive configuration ID
+- R2 bucket and queue names, if you changed them
 
-  WF->>PG: listRepoConnections(repo, 'automations')
-  WF->>WF: mint sealed grant (AES-GCM, 1 h TTL,<br/>bound to connection + repo)
-  WF->>SB: inject run config (proxy URL + grant — no credentials)
-  SB->>PX: JSON-RPC request (Bearer grant)
-  PX->>PX: verify grant · enforce tool allowlist on tools/call
-  PX->>PG: resolve + decrypt connection credential
-  PX->>MCP: forward request with real auth header
-  MCP-->>SB: response (streamed back through the proxy)
+The optional Artifacts binding hosts repositories created inside Turbodiff and
+requires access to Cloudflare Artifacts. Remove that binding and its event
+triggers if you only plan to use GitHub repositories.
+
+### 3. Set up PostgreSQL
+
+Create a database, then apply and check the schema using a direct database
+connection:
+
+```sh
+export DATABASE_URL='postgres://...'
+vp run db:migrate
+vp run db:verify
 ```
 
-A prompt-injected repository can therefore at worst _use_ an attached
-connection for the lifetime of one run's grant — it can never read the
-credential itself, and calls outside the connection's tool allowlist are
-rejected at the proxy.
+Create a Hyperdrive connection to the database with query caching disabled,
+then copy its ID into `wrangler.jsonc`:
 
-## Code map
+```sh
+export HYPERDRIVE_DATABASE_URL='postgres://...'
+vp exec wrangler hyperdrive create turbodiff-postgres \
+  --connection-string="$HYPERDRIVE_DATABASE_URL" \
+  --caching-disabled
+```
 
-- [src/ai/agents/pr-reviewer.ts](src/ai/agents/pr-reviewer.ts) — the review agent.
-- [src/ai/tools/github.ts](src/ai/tools/github.ts) — its tools (`fetch_pr`,
-  `fetch_diff`, `fetch_file`, `fetch_review_threads`, `post_review`).
-- [docs/review-quality.md](docs/review-quality.md) — review context, evidence,
-  publication, evaluation, and model-experimentation contracts.
-- [src/ai/runners/planner.ts](src/ai/runners/planner.ts) /
-  [generation workflow](src/ai/workflows/generation.ts) /
-  [fixer.ts](src/ai/runners/fixer.ts) /
-  [verifier.ts](src/ai/runners/verifier.ts) — the factory pipeline stages, each a
-  sandboxed agent run.
-- [src/ai/runtime/coding-agent.ts](src/ai/runtime/coding-agent.ts) and
-  [src/services/ai-gateway-proxy.ts](src/services/ai-gateway-proxy.ts) — the
-  shared OpenCode execution seam and capability-authenticated model relay.
-- [src/ai/runtime/review-workspace.ts](src/ai/runtime/review-workspace.ts) and
-  [src/ai/tools/repository-workspace.ts](src/ai/tools/repository-workspace.ts) —
-  exact-head, credential-free review checkouts with bounded search and checks.
-- [src/cloudflare.ts](src/cloudflare.ts) — the factory queue consumer and the
-  sandbox container export.
-- [src/http/webhooks.ts](src/http/webhooks.ts) and
-  [src/services/github-webhooks.ts](src/services/github-webhooks.ts) — GitHub App webhooks:
-  installation sync, review auto-dispatch, auto-fix trigger.
-- [src/http/api.ts](src/http/api.ts) — the signed-in JSON API for the dashboard,
-  factory, reviews, agents, integrations, and per-repo settings.
-- [src/app.ts](src/app.ts) — the HTTP composition root; operator endpoints live
-  in [src/http/internal.ts](src/http/internal.ts).
-- [docs/architecture.md](docs/architecture.md) — layer boundaries and dependency rules.
-- [docs/coding-harness.md](docs/coding-harness.md) — the model-neutral OpenCode
-  runtime, security boundary, compatibility rules, and benchmark plan.
-- [docs/code-editing.md](docs/code-editing.md) — the in-browser code viewer/editor
-  and how the GitHub and Artifacts storage backends differ.
-- [db/migrations/](db/migrations/) — PostgreSQL schemas for identity,
-  installations, repositories, reviews, agents, factory state, and collaboration.
+Use a database account with only read and write access for Hyperdrive. Keep the
+more powerful migration account separate. See [the PostgreSQL guide](docs/postgres.md)
+for local Docker setup, recommended permissions, and credential rotation.
 
-## One-time setup
+### 4. Create the queue and file bucket
 
-Everything runs on a single Cloudflare account. To self-host, create your own
-GitHub App and deploy:
+```sh
+vp exec wrangler queues create turbodiff-factory
+vp exec wrangler r2 bucket create turbodiff-artifacts
+```
 
-1. **Dependencies**:
+If you use different names, update `wrangler.jsonc`.
 
-   ```sh
-   vp install
-   ```
+### 5. Create a GitHub App
 
-2. **AI Gateway** — set `AI_GATEWAY_ID` and `AI_GATEWAY_ACCOUNT_ID` in
-   [wrangler.jsonc](wrangler.jsonc). Enable Unified Billing for third-party
-   models and ensure the account has sufficient credits. Runner model ids use
-   Cloudflare's canonical REST form: `provider/model` for third-party models
-   (for example `openai/gpt-5.5`) and `@cf/author/model` for Workers AI (for
-   example `@cf/moonshotai/kimi-k2.6`).
+Create a new app in [GitHub App settings](https://github.com/settings/apps)
+with these values:
 
-3. **PostgreSQL + Hyperdrive** — provision PostgreSQL, create a Hyperdrive
-   configuration with caching disabled, put its id in
-   [wrangler.jsonc](wrangler.jsonc), and apply the schema through the direct
-   database URL:
+- **Webhook URL:** `https://<your-domain>/webhooks/github`
+- **Callback URL:** `https://<your-domain>/auth/callback`
+- **Repository permissions:** Contents (read and write), Pull requests (read
+  and write), Issues (read and write), and Actions (read)
+- **Events:** Pull request, Pull request review, Issue comment, Repository, and
+  Workflow run
 
-   ```sh
-   export DATABASE_URL='postgres://...'
-   vp run db:migrate
-   vp run db:verify
-   ```
+Create a webhook secret, note the app ID and OAuth client details, and generate
+a private key. Convert the private key to the format Cloudflare accepts:
 
-   See [docs/postgres.md](docs/postgres.md) for local Docker, database roles,
-   Hyperdrive creation, and deployment details.
+```sh
+openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt \
+  -in app.pem -out app.pkcs8.pem
+```
 
-4. **Queue and R2 bucket** (factory pipeline):
+Set `GITHUB_APP_SLUG` in `wrangler.jsonc` to the name from the app's GitHub URL.
 
-   ```sh
-   npx wrangler queues create turbodiff-factory
-   npx wrangler r2 bucket create turbodiff-artifacts
-   ```
+### 6. Add secrets
 
-5. **GitHub App** — create one at <https://github.com/settings/apps>:
-   - **Webhook URL**: `https://<your-worker>/webhooks/github`, with a secret
-     (`openssl rand -hex 32`).
-   - **Repository permissions**: Contents (read & write — the fix and
-     generation agents push branches), Pull requests (read & write), Issues
-     (read & write, for comment reactions and factory reports), Actions
-     (read — CI-failure auto-fix reads workflow run status and job logs).
-   - **Subscribe to events**: Pull request, Pull request review, Issue comment,
-     Repository, Workflow run.
-   - **Callback URL**: `https://<your-worker>/auth/callback`; note the OAuth
-     client id and generate a client secret.
-   - Generate a **private key** and convert it to PKCS#8 (WebCrypto can't read
-     GitHub's PKCS#1 file):
-
-     ```sh
-     openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in app.pem -out app.pkcs8.pem
-     ```
-
-   - Set `GITHUB_APP_SLUG` in [wrangler.jsonc](wrangler.jsonc).
-   - Existing installations: accept the new Actions permission and Workflow
-     run event subscription in GitHub's UI to start receiving `workflow_run`
-     deliveries — this is a one-time manual step per installation, not
-     something a code deploy alone covers.
-
-6. **Secrets** — locally in `.dev.vars`; in production:
-
-   ```sh
-   npx wrangler secret put GITHUB_APP_ID
-   npx wrangler secret put GITHUB_APP_PRIVATE_KEY   # the PKCS#8 PEM, whole file
-   npx wrangler secret put GITHUB_WEBHOOK_SECRET
-   npx wrangler secret put GITHUB_OAUTH_CLIENT_ID
-   npx wrangler secret put GITHUB_OAUTH_CLIENT_SECRET
-   npx wrangler secret put SESSION_SECRET           # openssl rand -hex 32
-   npx wrangler secret put REVIEW_SECRET            # openssl rand -hex 32 (operator endpoints)
-   # Factory coding runs — Account / Workers AI / Read permission:
-   npx wrangler secret put AI_GATEWAY_API_TOKEN
-   # Only if agents use authenticated external MCP connections:
-   npx wrangler secret put TOKEN_ENCRYPTION_KEY     # openssl rand -hex 32
-   # Only if you use org member invites (Settings > Members on an org installation):
-   npx wrangler secret put RESEND_API_KEY           # from resend.com; pair with RESEND_FROM_ADDRESS var
-   # Only for the skills.sh catalog browser on the Skills page (a Vercel OIDC
-   # token, see https://www.skills.sh/docs/api); without it the catalog shows
-   # as unconfigured and importing by GitHub URL still works:
-   npx wrangler secret put SKILLS_SH_API_TOKEN
-   # Only for Web Push notifications (see below):
-   npx wrangler secret put VAPID_PUBLIC_KEY
-   npx wrangler secret put VAPID_PRIVATE_KEY
-   npx wrangler secret put VAPID_SUBJECT            # mailto:you@example.com
-   ```
-
-   **Web Push (optional).** The Settings page can enable browser push
-   notifications for factory tasks that need your input. Without the three
-   VAPID secrets the toggle shows as unavailable; everything else works.
-   Generate a keypair (ECDSA P-256, in the exact base64url encodings the
-   push library expects):
-
-   ```sh
-   node -e "const{subtle}=require('node:crypto').webcrypto;subtle.generateKey({name:'ECDSA',namedCurve:'P-256'},true,['sign','verify']).then(async kp=>{const raw=Buffer.from(await subtle.exportKey('raw',kp.publicKey));const jwk=await subtle.exportKey('jwk',kp.privateKey);console.log('VAPID_PUBLIC_KEY='+raw.toString('base64url'));console.log('VAPID_PRIVATE_KEY='+jwk.d)})"
-   ```
-
-   Set both halves from the same run — a mismatched pair fails only at send
-   time (silent 403s from the push service), not at subscribe time.
-   `VAPID_SUBJECT` is a `mailto:` address push services can use to contact
-   you. All three are secrets — including the public key, which isn't
-   confidential but must differ per deployment: subscriptions are pinned to
-   the key browsers subscribed with, so a key committed to the repo would
-   break push for every fork (and rotating it later invalidates existing
-   subscriptions until users re-toggle notifications).
-
-7. **Custom domain** (optional) — add it to the Worker, set `PUBLIC_BASE_URL`
-   in [wrangler.jsonc](wrangler.jsonc), and update the GitHub App's webhook +
-   callback URLs.
-
-## Environment reference
-
-Turbodiff has three configuration scopes. Non-secret Worker variables belong
-in `wrangler.jsonc`; Worker secrets belong in the deployed secret store and in
-the ignored `.dev.vars` file for local development; database and deployment
-variables belong only in the shell or GitHub Actions. Cloudflare recommends
-using either `.dev.vars` or `.env`, not both—when `.dev.vars` exists, `.env`
-files are not merged into the local Worker environment. See Cloudflare's
-[environment-variable and secret documentation](https://developers.cloudflare.com/workers/local-development/environment-variables/).
-
-### Worker variables
-
-These are non-secret values under `vars` in `wrangler.jsonc`:
-
-| Name                    | Required                   | Purpose                                                                                                 |
-| ----------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `AI_GATEWAY_ID`         | Yes                        | Name of the AI Gateway used by hosted agents and the sandbox model relay.                               |
-| `AI_GATEWAY_ACCOUNT_ID` | For sandbox coding runs    | Cloudflare account containing the Gateway.                                                              |
-| `PUBLIC_BASE_URL`       | Yes                        | Canonical deployment origin used for OAuth callbacks, proxy URLs, task links, and signed artifact URLs. |
-| `GITHUB_APP_SLUG`       | For GitHub repos           | GitHub App URL slug and bot login prefix.                                                               |
-| `ARTIFACTS_REMOTE_BASE` | For hosted Artifacts repos | Git smart-HTTP base URL for the configured Artifacts namespace.                                         |
-| `RESEND_FROM_ADDRESS`   | With email invites         | Sender address on a Resend-verified domain.                                                             |
-| `REVIEW_DAILY_LIMIT`    | No; defaults to `50`       | Maximum automatic reviews per installation in a rolling 24-hour window.                                 |
-| `TRIVIAL_MODEL`         | No                         | Canonical model id used for trivial PRs; an empty value disables the override.                          |
-
-### Worker secrets
-
-Production values are created with `wrangler secret put <NAME>`. Local values
-go in `.dev.vars`, which is gitignored.
-
-| Name                         | Required                          | Purpose                                                                                                                         |
-| ---------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `GITHUB_APP_ID`              | For GitHub repos                  | Numeric GitHub App id used to issue installation tokens.                                                                        |
-| `GITHUB_APP_PRIVATE_KEY`     | For GitHub repos                  | PKCS#8 PEM private key used to sign GitHub App JWTs.                                                                            |
-| `GITHUB_WEBHOOK_SECRET`      | For GitHub repos                  | HMAC secret used to authenticate webhook deliveries.                                                                            |
-| `GITHUB_OAUTH_CLIENT_ID`     | For GitHub sign-in                | OAuth application client id.                                                                                                    |
-| `GITHUB_OAUTH_CLIENT_SECRET` | For GitHub sign-in                | OAuth application client secret.                                                                                                |
-| `SESSION_SECRET`             | Yes                               | Signs authentication state, MCP OAuth state, and artifact capabilities; use at least 32 random bytes.                           |
-| `REVIEW_SECRET`              | Yes for operator APIs             | Bearer secret protecting `/internal/*` and manual review endpoints.                                                             |
-| `AI_GATEWAY_API_TOKEN`       | For sandbox coding runs           | Worker-only Cloudflare token with `Account / Workers AI / Read`; it never enters the sandbox.                                   |
-| `TOKEN_ENCRYPTION_KEY`       | For authenticated MCP connections | Exactly 64 hexadecimal characters (`openssl rand -hex 32`) used for AES-GCM credential encryption and relay grants.             |
-| `RESEND_API_KEY`             | For email invites                 | Resend API key; pair it with `RESEND_FROM_ADDRESS`.                                                                             |
-| `SKILLS_SH_API_TOKEN`        | For catalog browsing              | Vercel OIDC token for the skills.sh catalog; direct GitHub imports work without it.                                             |
-| `VAPID_PUBLIC_KEY`           | For Web Push                      | Base64url uncompressed P-256 public point. Public by protocol, but stored as a secret so each deployment keeps its own keypair. |
-| `VAPID_PRIVATE_KEY`          | For Web Push                      | Base64url P-256 private scalar paired with `VAPID_PUBLIC_KEY`.                                                                  |
-| `VAPID_SUBJECT`              | For Web Push                      | Contact URI for the application server, normally `mailto:you@example.com`.                                                      |
-
-The three `VAPID_*` values are an optional set and must be configured together.
-Without `VAPID_PUBLIC_KEY`, the UI disables browser subscriptions; a partial
-configuration can fail later while sending. The rest of Turbodiff continues
-to work without Web Push. Generate the keypair with the command in the setup
-section above, keep it stable within an environment, and use distinct pairs
-between local, staging, and production environments.
-
-### Local `.dev.vars` template
-
-The current `.dev.vars` file is not generated, so optional keys do not appear
-until you add them. This template contains every Worker secret, the local-only
-login value, and the common local overrides. Leave an optional integration
-blank when you do not use it. Never commit this file.
+Add these values to `.dev.vars` for local work. For production, save each one
+with `vp exec wrangler secret put <NAME>`.
 
 ```dotenv
-# GitHub App and authentication
 GITHUB_APP_ID=""
 GITHUB_APP_PRIVATE_KEY=""
 GITHUB_WEBHOOK_SECRET=""
@@ -401,109 +138,87 @@ GITHUB_OAUTH_CLIENT_ID=""
 GITHUB_OAUTH_CLIENT_SECRET=""
 SESSION_SECRET=""
 REVIEW_SECRET=""
-
-# Sandbox coding models
 AI_GATEWAY_API_TOKEN=""
-
-# Optional integrations
-TOKEN_ENCRYPTION_KEY=""
-RESEND_API_KEY=""
-SKILLS_SH_API_TOKEN=""
-
-# Optional Web Push — configure all three or none
-VAPID_PUBLIC_KEY=""
-VAPID_PRIVATE_KEY=""
-VAPID_SUBJECT="mailto:you@example.com"
-
-# Local-only login: comma-separated installation ids
-DEV_FAKE_INSTALLATIONS=""
-
-# Optional local overrides for values otherwise read from wrangler.jsonc
-AI_GATEWAY_ACCOUNT_ID=""
-PUBLIC_BASE_URL="http://localhost:5173"
 ```
 
-`DEV_FAKE_INSTALLATIONS` must never be deployed. Use the URL printed by the
-development server if it differs from the example `PUBLIC_BASE_URL`.
+Generate `SESSION_SECRET` and `REVIEW_SECRET` with `openssl rand -hex 32`.
+`AI_GATEWAY_API_TOKEN` needs Cloudflare's **Account / Workers AI / Read**
+permission. It stays in the Worker and is not passed into the code-writing
+container.
 
-### Shell and CI variables
+Optional features use these additional settings:
 
-These configure tooling, not the running Worker:
+| Feature               | Settings                                                     |
+| --------------------- | ------------------------------------------------------------ |
+| Connected tools       | `TOKEN_ENCRYPTION_KEY`                                       |
+| Email invitations     | `RESEND_API_KEY` and `RESEND_FROM_ADDRESS`                   |
+| Skills catalog        | `SKILLS_SH_API_TOKEN`                                        |
+| Browser notifications | `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, and `VAPID_SUBJECT` |
 
-| Name                      | Scope                 | Purpose                                                                                                 |
-| ------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------- |
-| `DATABASE_URL`            | Local shell / CI job  | Direct PostgreSQL URL used by migration, schema verification, and Worker integration-test commands.     |
-| `HYPERDRIVE_DATABASE_URL` | Local shell helper    | Direct database URL passed to Wrangler while creating or updating Hyperdrive; the app does not read it. |
-| `POSTGRES_DATABASE_URL`   | GitHub Actions secret | Production migration-role URL, mapped to `DATABASE_URL` by the deploy workflow.                         |
-| `CLOUDFLARE_API_TOKEN`    | GitHub Actions secret | Credential used by Wrangler to validate and deploy the Worker and container.                            |
-| `CLOUDFLARE_ACCOUNT_ID`   | GitHub Actions secret | Cloudflare account targeted by the deployment workflow.                                                 |
+Use `openssl rand -hex 32` for `TOKEN_ENCRYPTION_KEY`. Browser notifications
+need all three `VAPID_*` values; without them, only notifications are disabled.
 
-Cloudflare bindings—including `AI`, `HYPERDRIVE`, `ARTIFACTS`,
-`GIT_ARTIFACTS`, `FACTORY_QUEUE`, Durable Objects, Workflows, assets, and
-version metadata—are configured structurally in `wrangler.jsonc`; they are not
-`.dev.vars` entries. Likewise, `GIT_TOKEN`, `GIT_REMOTE`, and `TURBODIFF_*`
-values are short-lived variables injected internally into sandbox commands and
-must not be configured by an operator. `PUPPETEER_EXECUTABLE_PATH` and
-`NODE_PATH` are fixed inside the sandbox image for browser verification and are
-also not deployment inputs.
+Never commit `.dev.vars` or any production secret.
 
-## Develop
+### 7. Build and deploy
 
-Local dev needs **Docker running** (the sandbox container image builds on
-first start).
+Check the project before the first deployment:
 
 ```sh
-npm run dev
+vp check
+vp test
+vp run build
 ```
 
-To exercise webhooks locally, use a tunnel (`cloudflared tunnel`, `smee.io`)
-pointed at `/webhooks/github`, or send signed test payloads (HMAC-SHA256 of the
-body in `x-hub-signature-256: sha256=<hex>`).
-
-> Vite+ owns the package-manager and Node versions for this repository; use
-> the `vp` commands documented in [AGENTS.md](AGENTS.md).
-
-## Deploy
-
-Every commit to `main` deploys automatically via
-[GitHub Actions](.github/workflows/deploy.yml). The workflow applies and
-verifies migrations on the existing PlanetScale database, then deploys the
-Worker and sandbox container image. It does not provision PlanetScale or
-Hyperdrive. The workflow needs `POSTGRES_DATABASE_URL`,
-`CLOUDFLARE_API_TOKEN` (Workers Scripts:Edit, Containers:Edit), and
-`CLOUDFLARE_ACCOUNT_ID`. Pull requests run the same validation, integration,
-build, and Wrangler dry-run gates in [CI](.github/workflows/ci.yml), but are
-not deployed.
-
-To deploy manually (Docker required):
+Deploy the database changes and application:
 
 ```sh
+export DATABASE_URL='postgres://...'
+vp run db:migrate
+vp run db:verify
 vp run deploy
 ```
 
-## Use it
+After deployment, update the GitHub App's webhook and callback URLs if your
+public address changed. Install the app on the repositories Turbodiff may use,
+then sign in at your deployment URL.
 
-1. Install the GitHub App, selecting the repositories it may work on.
-2. Sign in — the board at `/` is the factory: add a todo, start it, answer
-   the planning agent's questions, approve the plan, and follow the generated
-   PR through review, auto-fix, and verification in the cockpit.
-3. Every pull request — yours or the factory's — gets an automatic review
-   (capped per installation per day via `REVIEW_DAILY_LIMIT`); recent reviews
-   and costs are on `/usage`.
-4. Configure per-repo behavior on `/settings`: the factory toggle, re-review
-   on push (with its quiet window in minutes), blocking reviews, auto-fix,
-   auto-merge, demo videos, and the sandbox check command.
+## Local development
 
-Operator endpoints (Bearer `REVIEW_SECRET`) mirror the UI for automation:
-`POST /review` (manual re-review), `POST /internal/generate`,
-`POST /internal/plans` + `/answers` + `/approve`, `POST /internal/fix`, and
-`GET /internal/pr-reviewer/<owner--repo--number>` to inspect a review agent's
-conversation.
+Start PostgreSQL and apply the schema:
+
+```sh
+docker compose -f compose.postgres.yml up -d
+export DATABASE_URL='postgres://turbodiff:turbodiff@localhost:5432/turbodiff'
+vp run db:migrate
+vp run db:verify
+```
+
+With Docker running, start the app:
+
+```sh
+vp run dev
+```
+
+For GitHub webhooks, point a tunnel such as Cloudflare Tunnel or smee.io at
+`/webhooks/github`.
+
+Useful commands are listed in [AGENTS.md](AGENTS.md). Pull requests run lint,
+type checks, tests, a build, and a Cloudflare deployment check.
+
+## Learn more
+
+- [Architecture](docs/architecture.md)
+- [PostgreSQL setup](docs/postgres.md)
+- [How code-writing agents run](docs/coding-harness.md)
+- [How pull request reviews work](docs/review-quality.md)
+- [Software factory plans](docs/software-factory-lifecycle.md)
+
+## Contributing
+
+Bug reports, ideas, documentation fixes, and code changes are welcome. For a
+large change, please open an issue first so the approach can be discussed.
 
 ## License
 
-Turbodiff is licensed under the [Functional Source License, Version 1.1, ALv2
-Future License](LICENSE.md) (FSL-1.1-ALv2): use, modify, and self-host freely —
-including inside your company — but don't offer it (or a substantially similar
-service) commercially in competition with Turbodiff. Each release becomes
-Apache 2.0 two years after publication. See [fsl.software](https://fsl.software).
+[MIT](LICENSE.md) © 2026 Nico Botha

--- a/README.md
+++ b/README.md
@@ -1,36 +1,79 @@
 # Turbodiff
 
-<img src="public/logo-small.png" alt="Turbodiff logo" width="64" align="right" />
+<img src="public/logo-small.png" alt="Turbodiff logo" width="64" align="center" />
 
-Turbodiff is an open-source GitHub app that uses AI to review pull requests
-and turn tasks into code. You can use the hosted version at
-[turbodiff.dev](https://turbodiff.dev) or run it in your own Cloudflare
-account.
+Turbodiff is an open-source software factory for GitHub. Give it a task and it
+can plan the work, write the code, open a pull request, review the change, fix
+problems, and check the result. You decide where automation starts and stops,
+and which steps need a person to approve them.
 
-Turbodiff is licensed under the [MIT License](LICENSE.md). You can use, change,
-and share it, including as part of a commercial product.
+You can also use the pull request reviewer on its own. Turbodiff works with
+your existing repositories and GitHub workflow rather than asking you to move
+your code or replace your tools.
+
+The project is self-hosted and licensed under the [MIT License](LICENSE.md).
+You can use, change, and share it, including as part of a commercial product.
 
 > [!WARNING]
-> Turbodiff is under active development. Expect bugs and breaking changes. If
-> you find a problem, please [open an issue](https://github.com/Ngineer101/turbodiff/issues).
+> Turbodiff is under active development. If you find a problem, please
+> [open an issue](https://github.com/Ngineer101/turbodiff/issues).
 
-## What it does
+## A software factory, not just a code generator
 
-- Reviews new and updated pull requests.
-- Turns a written task into a plan for you to approve.
-- Writes the code in an isolated container and opens a pull request.
-- Tries to fix review findings and failed checks.
-- Checks the finished work against the approved plan.
-- Lets you choose which steps run automatically and which need approval.
+Turbodiff covers the path from an idea to a finished pull request:
 
-## Why self-host
+1. **Plan** — read the repository, ask questions, and turn the task into a plan
+   with clear success checks.
+2. **Build** — write the code in an isolated container, run the repository's
+   checks, and open a pull request.
+3. **Review** — inspect the whole change and publish one clear GitHub review.
+4. **Repair** — try to fix important review findings, failed checks, and merge
+   conflicts.
+5. **Verify** — compare the finished work with the approved plan. Turbodiff can
+   run the app and attach screenshots when visual proof is useful.
+6. **Merge** — leave the pull request ready for a person, or merge it
+   automatically when the repository allows that.
 
-Self-hosting gives you control over where Turbodiff runs, which repositories it
-can access, and which AI models it uses. Your GitHub App keys, database, model
-credentials, and usage data stay in services you manage.
+Each step records its result, so a person can take over or let the next step
+continue. Repositories can use the full factory or only the parts they need.
 
-The application code is all in this repository. A deployment uses Cloudflare
-Workers and Containers, with PostgreSQL for stored data.
+### Pull request reviews
+
+The reviewer also works with pull requests created outside Turbodiff. It can:
+
+- Review automatically or only when asked.
+- Remember earlier findings when new commits are pushed.
+- Spend more time on large or sensitive changes and less on small ones.
+- Request changes for serious problems and approve clean pull requests.
+- Run custom review agents for different areas of a codebase.
+- Track whether findings were useful, fixed, or dismissed.
+
+## Open source and self-hosted
+
+The application code is in this repository. Self-hosting gives you control
+over:
+
+- Which repositories Turbodiff can access.
+- Which AI models it uses.
+- Where its database and files are stored.
+- Which features are enabled.
+- How much of the factory runs automatically.
+
+Your GitHub App keys and model credentials stay in services you manage. Code
+writing and verification run in isolated Cloudflare Containers, and permanent
+model credentials are not passed into those containers.
+
+Turbodiff uses:
+
+- **Cloudflare Workers** for the web app and API.
+- **Cloudflare Containers** for code-writing and verification jobs.
+- **Cloudflare AI Gateway** to connect to AI models.
+- **PostgreSQL** for users, repositories, tasks, reviews, and settings.
+- **Cloudflare R2** for logs, screenshots, and other files.
+- **Cloudflare Queues and Workflows** for jobs that take longer than a web
+  request.
+
+More detail is available in the [architecture guide](docs/architecture.md).
 
 ## Self-hosting
 
@@ -38,8 +81,8 @@ Turbodiff is built for Cloudflare. Before you start, you need:
 
 - A Cloudflare account with Workers, Containers, AI Gateway, Hyperdrive,
   Queues, and R2 available.
-- A PostgreSQL database. The production setup uses PlanetScale, but another
-  PostgreSQL provider can work.
+- A PostgreSQL database. The project uses PlanetScale in production, but other
+  PostgreSQL providers can work.
 - A GitHub account that can create a GitHub App.
 - Docker for building the container.
 - [Vite+](https://viteplus.dev) (`vp`) and the Node.js version in
@@ -57,17 +100,13 @@ vp install
 
 Create an AI Gateway and enable billing for any third-party models you want to
 use. In [wrangler.jsonc](wrangler.jsonc), replace the existing deployment
-values with your own:
+values with your own. The complete list is in
+[Environment variables](#environment-variables).
 
-- `AI_GATEWAY_ID`
-- `AI_GATEWAY_ACCOUNT_ID`
-- `PUBLIC_BASE_URL`
-- the Hyperdrive configuration ID
-- R2 bucket and queue names, if you changed them
-
-The optional Artifacts binding hosts repositories created inside Turbodiff and
-requires access to Cloudflare Artifacts. Remove that binding and its event
-triggers if you only plan to use GitHub repositories.
+The optional Cloudflare Artifacts binding is for repositories created inside
+Turbodiff. It requires access to Cloudflare Artifacts. If you only use GitHub
+repositories, remove the `artifacts` binding, its event triggers, and the
+`ARTIFACTS_REMOTE_BASE` variable from `wrangler.jsonc`.
 
 ### 3. Set up PostgreSQL
 
@@ -80,8 +119,8 @@ vp run db:migrate
 vp run db:verify
 ```
 
-Create a Hyperdrive connection to the database with query caching disabled,
-then copy its ID into `wrangler.jsonc`:
+Create a Hyperdrive connection with query caching disabled, then copy its ID
+into `wrangler.jsonc`:
 
 ```sh
 export HYPERDRIVE_DATABASE_URL='postgres://...'
@@ -125,38 +164,15 @@ openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt \
 
 Set `GITHUB_APP_SLUG` in `wrangler.jsonc` to the name from the app's GitHub URL.
 
-### 6. Add secrets
+### 6. Configure the environment
 
-Add these values to `.dev.vars` for local work. For production, save each one
-with `vp exec wrangler secret put <NAME>`.
+Set the required variables and secrets listed below. Put non-secret Worker
+values in `wrangler.jsonc`. For local development, put secrets in `.dev.vars`.
+For a deployed Worker, save each secret with:
 
-```dotenv
-GITHUB_APP_ID=""
-GITHUB_APP_PRIVATE_KEY=""
-GITHUB_WEBHOOK_SECRET=""
-GITHUB_OAUTH_CLIENT_ID=""
-GITHUB_OAUTH_CLIENT_SECRET=""
-SESSION_SECRET=""
-REVIEW_SECRET=""
-AI_GATEWAY_API_TOKEN=""
+```sh
+vp exec wrangler secret put <NAME>
 ```
-
-Generate `SESSION_SECRET` and `REVIEW_SECRET` with `openssl rand -hex 32`.
-`AI_GATEWAY_API_TOKEN` needs Cloudflare's **Account / Workers AI / Read**
-permission. It stays in the Worker and is not passed into the code-writing
-container.
-
-Optional features use these additional settings:
-
-| Feature               | Settings                                                     |
-| --------------------- | ------------------------------------------------------------ |
-| Connected tools       | `TOKEN_ENCRYPTION_KEY`                                       |
-| Email invitations     | `RESEND_API_KEY` and `RESEND_FROM_ADDRESS`                   |
-| Skills catalog        | `SKILLS_SH_API_TOKEN`                                        |
-| Browser notifications | `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, and `VAPID_SUBJECT` |
-
-Use `openssl rand -hex 32` for `TOKEN_ENCRYPTION_KEY`. Browser notifications
-need all three `VAPID_*` values; without them, only notifications are disabled.
 
 Never commit `.dev.vars` or any production secret.
 
@@ -165,7 +181,8 @@ Never commit `.dev.vars` or any production secret.
 Check the project before the first deployment:
 
 ```sh
-vp check
+vp lint
+vp run check:types
 vp test
 vp run build
 ```
@@ -182,6 +199,95 @@ vp run deploy
 After deployment, update the GitHub App's webhook and callback URLs if your
 public address changed. Install the app on the repositories Turbodiff may use,
 then sign in at your deployment URL.
+
+## Environment variables
+
+Turbodiff has three kinds of configuration:
+
+- **Worker variables** are non-secret values in the `vars` section of
+  `wrangler.jsonc`.
+- **Worker secrets** go in `.dev.vars` locally and in Cloudflare's secret store
+  after deployment.
+- **Shell and CI variables** are used by setup and deployment commands. They
+  are not read by the running Worker.
+
+Cloudflare bindings such as Hyperdrive, R2, Queues, Containers, and Workflows
+are also configured in `wrangler.jsonc`, but they are resources rather than
+environment variables.
+
+### Required
+
+These values are required for the full GitHub software factory:
+
+| Name                         | Where         | Purpose                                                      |
+| ---------------------------- | ------------- | ------------------------------------------------------------ |
+| `AI_GATEWAY_ID`              | Worker var    | Name of the Cloudflare AI Gateway used for model requests.   |
+| `AI_GATEWAY_ACCOUNT_ID`      | Worker var    | Cloudflare account that owns the AI Gateway.                 |
+| `PUBLIC_BASE_URL`            | Worker var    | Public address of your deployment, with no trailing slash.   |
+| `GITHUB_APP_SLUG`            | Worker var    | Name at the end of your GitHub App URL.                      |
+| `GITHUB_APP_ID`              | Worker secret | Numeric ID shown in the GitHub App settings.                 |
+| `GITHUB_APP_PRIVATE_KEY`     | Worker secret | Complete PKCS#8 private key for the GitHub App.              |
+| `GITHUB_WEBHOOK_SECRET`      | Worker secret | Checks that webhook calls came from GitHub.                  |
+| `GITHUB_OAUTH_CLIENT_ID`     | Worker secret | Client ID used for GitHub sign-in.                           |
+| `GITHUB_OAUTH_CLIENT_SECRET` | Worker secret | Client secret used for GitHub sign-in.                       |
+| `SESSION_SECRET`             | Worker secret | Signs login state and short-lived access links.              |
+| `AI_GATEWAY_API_TOKEN`       | Worker secret | Cloudflare token used by code-writing agents to call models. |
+| `DATABASE_URL`               | Shell or CI   | Direct PostgreSQL URL used for migrations and schema checks. |
+| `HYPERDRIVE_DATABASE_URL`    | Shell         | PostgreSQL URL used when creating or updating Hyperdrive.    |
+
+Generate `SESSION_SECRET` with `openssl rand -hex 32`.
+`AI_GATEWAY_API_TOKEN` needs Cloudflare's **Account / Workers AI / Read**
+permission. Use a limited database account for `HYPERDRIVE_DATABASE_URL`, not
+the more powerful account used for migrations.
+
+Minimal local `.dev.vars` file:
+
+```dotenv
+GITHUB_APP_ID=""
+GITHUB_APP_PRIVATE_KEY=""
+GITHUB_WEBHOOK_SECRET=""
+GITHUB_OAUTH_CLIENT_ID=""
+GITHUB_OAUTH_CLIENT_SECRET=""
+SESSION_SECRET=""
+AI_GATEWAY_API_TOKEN=""
+```
+
+### Optional
+
+Leave these out unless you use the related feature:
+
+| Name                     | Where         | Used for                                                                 |
+| ------------------------ | ------------- | ------------------------------------------------------------------------ |
+| `ARTIFACTS_REMOTE_BASE`  | Worker var    | Git address for repositories stored in Cloudflare Artifacts.             |
+| `RESEND_FROM_ADDRESS`    | Worker var    | Sender address for organization invitation emails.                       |
+| `REVIEW_DAILY_LIMIT`     | Worker var    | Maximum automatic reviews per installation in 24 hours; defaults to 50.  |
+| `TRIVIAL_MODEL`          | Worker var    | Cheaper model for very small pull requests; empty disables it.           |
+| `REVIEW_SECRET`          | Worker secret | Protects operator-only HTTP endpoints.                                   |
+| `TOKEN_ENCRYPTION_KEY`   | Worker secret | Encrypts credentials for connected tools.                                |
+| `RESEND_API_KEY`         | Worker secret | Sends organization invitation emails.                                    |
+| `SKILLS_SH_API_TOKEN`    | Worker secret | Enables browsing the skills.sh catalog.                                  |
+| `VAPID_PUBLIC_KEY`       | Worker secret | Enables browser notifications; set all three `VAPID_*` values.           |
+| `VAPID_PRIVATE_KEY`      | Worker secret | Enables browser notifications; set all three `VAPID_*` values.           |
+| `VAPID_SUBJECT`          | Worker secret | Contact URI for browser notifications, such as `mailto:you@example.com`. |
+| `DEV_FAKE_INSTALLATIONS` | Local only    | Comma-separated installation IDs for local sign-in without GitHub.       |
+| `POSTGRES_DATABASE_URL`  | CI secret     | Production migration URL used by the GitHub Actions deploy workflow.     |
+| `CLOUDFLARE_API_TOKEN`   | CI secret     | Lets the GitHub Actions deploy workflow publish to Cloudflare.           |
+| `CLOUDFLARE_ACCOUNT_ID`  | CI secret     | Selects the Cloudflare account used by the deploy workflow.              |
+
+Generate `REVIEW_SECRET` and `TOKEN_ENCRYPTION_KEY` with
+`openssl rand -hex 32`. `TOKEN_ENCRYPTION_KEY` is required before anyone can
+save credentials for connected tools.
+
+The three `VAPID_*` values must be configured together. If they are absent,
+only browser notifications are disabled.
+
+When `.dev.vars` exists, you may also put local overrides for
+`AI_GATEWAY_ACCOUNT_ID` and `PUBLIC_BASE_URL` in it. Use the address printed by
+the development server for `PUBLIC_BASE_URL`.
+
+Variables such as `GIT_TOKEN`, `GIT_REMOTE`, `TURBODIFF_*`, `NODE_PATH`, and
+`PUPPETEER_EXECUTABLE_PATH` are created inside Turbodiff's containers. Do not
+set them yourself.
 
 ## Local development
 
@@ -204,7 +310,8 @@ For GitHub webhooks, point a tunnel such as Cloudflare Tunnel or smee.io at
 `/webhooks/github`.
 
 Useful commands are listed in [AGENTS.md](AGENTS.md). Pull requests run lint,
-type checks, tests, a build, and a Cloudflare deployment check.
+type checks, tests, a build, database checks, and a Cloudflare deployment
+check.
 
 ## Learn more
 
@@ -212,7 +319,8 @@ type checks, tests, a build, and a Cloudflare deployment check.
 - [PostgreSQL setup](docs/postgres.md)
 - [How code-writing agents run](docs/coding-harness.md)
 - [How pull request reviews work](docs/review-quality.md)
-- [Software factory plans](docs/software-factory-lifecycle.md)
+- [Software factory lifecycle](docs/software-factory-lifecycle.md)
+- [Cloudflare Artifacts repositories](docs/artifacts-provider.md)
 
 ## Contributing
 

--- a/src/http/landing.tsx
+++ b/src/http/landing.tsx
@@ -364,7 +364,7 @@ function Landing() {
                 </div>
                 <span class="cta-note">
                   Anyone can generate code. We ship proof. &middot; open source &middot;
-                  FSL-licensed
+                  MIT-licensed
                 </span>
               </div>
 

--- a/src/http/site-shell.tsx
+++ b/src/http/site-shell.tsx
@@ -136,7 +136,7 @@ export function SiteFooter() {
     <footer>
       <div class="wrap">
         <span>
-          open source &mdash; <a href={REPO_URL}>Ngineer101/turbodiff</a> &middot; FSL-licensed
+          open source &mdash; <a href={REPO_URL}>Ngineer101/turbodiff</a> &middot; MIT-licensed
         </span>
         <span>fully built &amp; hosted on Cloudflare</span>
         <span>self-host it &mdash; your keys, your gateway</span>


### PR DESCRIPTION
## Summary

- frame Turbodiff as an open-source software factory for the full plan, build, review, repair, verify, and merge path
- document self-hosting and every operator-set environment variable, split into required and optional values
- remove the public hosted-product mention
- replace the Functional Source License with the standard MIT License and update public site labels

## Validation

- vp test (296 tests)
- vp lint
- vp run check:types
- vp run build
- git diff --check