### PR TITLE
Fix OAuth connection testing and re-auth flow

### DIFF
--- a/src/client/pages/integrations.tsx
+++ b/src/client/pages/integrations.tsx
@@ -156,7 +156,14 @@ function IntegrationCard({ conn, repos }: { conn: ApiIntegration; repos: ApiInte
 
   const runTest = useMutation({
     mutationFn: () => api.post<ApiConnectionTest>(`/api/integrations/${conn.id}/test`),
-    onSuccess: setTest,
+    onSuccess: (result) => {
+      if (result.reauth_required && conn.auth_type === 'oauth') {
+        refresh();
+        window.location.href = `/api/integrations/${conn.id}/oauth/start`;
+        return;
+      }
+      setTest(result);
+    },
     onError: onApiError,
   });
   const remove = useMutation({

--- a/src/data/connections.ts
+++ b/src/data/connections.ts
@@ -171,8 +171,7 @@ export async function tryClaimConnectionRefresh(
   const changes = await execute(sql`
     UPDATE app.connections SET oauth_token_expires_at = ${claimUntil}
     WHERE id = ${id}
-      AND (oauth_token_expires_at = ${expectedExpiresAt}
-        OR (oauth_token_expires_at IS NULL AND ${expectedExpiresAt} IS NULL))
+      AND oauth_token_expires_at IS NOT DISTINCT FROM ${expectedExpiresAt}::timestamptz
   `);
   return changes > 0;
 }

--- a/src/data/db.worker.test.ts
+++ b/src/data/db.worker.test.ts
@@ -147,8 +147,8 @@ describe('connection OAuth refresh claims', () => {
     await expect(tryClaimConnectionRefresh(5, expiredAt, claimUntil)).resolves.toBe(false);
     const row = await testDatabase()
       .prepare('SELECT oauth_token_expires_at FROM connections WHERE id = 5')
-      .first<{ oauth_token_expires_at: Date }>();
-    expect(row?.oauth_token_expires_at.toISOString()).toBe(claimUntil);
+      .first<{ oauth_token_expires_at: string }>();
+    expect(new Date(row?.oauth_token_expires_at ?? '').toISOString()).toBe(claimUntil);
   });
 });
 

--- a/src/data/db.worker.test.ts
+++ b/src/data/db.worker.test.ts
@@ -45,6 +45,7 @@ import {
   setChatSessionId,
   setReviewFindingFeedback,
   tryRecordAutomationRun,
+  tryClaimConnectionRefresh,
   tryRecordFixAttempt,
   markReviewFailed,
   markReviewFailedById,
@@ -127,6 +128,28 @@ beforeEach(async () => {
     tables.map((table) => testDatabase().prepare(`DELETE FROM "${table}"`)),
   );
   await seedTenant();
+});
+
+describe('connection OAuth refresh claims', () => {
+  it('atomically claims an expired timestamp, including PostgreSQL nullable comparison typing', async () => {
+    const expiredAt = '2026-09-07T15:11:04.232Z';
+    const claimUntil = '2026-09-09T12:10:52.587Z';
+    await testDatabase()
+      .prepare(
+        `INSERT INTO connections
+           (id, installation_id, name, kind, url, auth_type, oauth_token_expires_at)
+         VALUES (5, 1001, 'cloudflare', 'mcp', 'https://mcp.cloudflare.com/mcp', 'oauth', ?1)`,
+      )
+      .bind(expiredAt)
+      .run();
+
+    await expect(tryClaimConnectionRefresh(5, expiredAt, claimUntil)).resolves.toBe(true);
+    await expect(tryClaimConnectionRefresh(5, expiredAt, claimUntil)).resolves.toBe(false);
+    const row = await testDatabase()
+      .prepare('SELECT oauth_token_expires_at FROM connections WHERE id = 5')
+      .first<{ oauth_token_expires_at: Date }>();
+    expect(row?.oauth_token_expires_at.toISOString()).toBe(claimUntil);
+  });
 });
 
 describe('installation mirroring', () => {

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -113,6 +113,7 @@ import {
   setTodoRepositories,
   updateAgent,
   updateAutomation,
+  updateConnectionAuth,
   updateFeature,
   updatePlan,
   updateSkill,
@@ -124,6 +125,7 @@ import {
   updateFeatureAcceptance,
 } from '../data/db.ts';
 import {
+  ConnectionAuthError,
   completeOAuthConnect,
   connectionSnapshot,
   oauthStatus,
@@ -529,6 +531,9 @@ export interface ApiRouteDependencies {
   skillsSh?: SkillsShClient;
   // Injectable for tests (no agent runtime in the worker pool).
   dispatchExplain?: typeof dispatchExplain;
+  // Injectable for connection-test transport coverage.
+  resolveConnectionAuth?: typeof resolveConnectionAuth;
+  testMcpEndpoint?: typeof testMcpEndpoint;
 }
 
 // POST /factory/features/:id/explain — the head to explain and whether to
@@ -588,6 +593,8 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
   const enqueueFactory = dependencies.enqueueFactory ?? enqueueFactoryMessage;
   const skillsSh = dependencies.skillsSh ?? createSkillsShClient(env.SKILLS_SH_API_TOKEN);
   const explain = dependencies.dispatchExplain ?? dispatchExplain;
+  const resolveAuth = dependencies.resolveConnectionAuth ?? resolveConnectionAuth;
+  const testMcp = dependencies.testMcpEndpoint ?? testMcpEndpoint;
 
   // Every API response exposes its Worker time to DevTools. Slow paths emit a
   // structured event into Workers Observability with a stable 250ms budget.
@@ -3250,12 +3257,22 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
     if (!conn) return c.json({ error: 'unknown integration' }, 404);
     let auth: { headerName: string; headerValue: string } | null;
     try {
-      auth = await resolveConnectionAuth(conn);
+      auth = await resolveAuth(conn);
     } catch (err) {
+      if (err instanceof ConnectionAuthError) {
+        return c.json<ApiConnectionTest>({
+          ok: false,
+          detail: err.message,
+          tools: [],
+          reauth_required: err.reason === 'reauth_required',
+        });
+      }
+      console.error(`turbodiff: could not resolve credentials for connection ${conn.id}:`, err);
       return c.json<ApiConnectionTest>({
         ok: false,
-        detail: err instanceof Error ? err.message : 'could not resolve credentials',
+        detail: 'We could not verify this connection because of an internal error. Try again.',
         tools: [],
+        reauth_required: false,
       });
     }
     if (conn.kind === 'api') {
@@ -3267,20 +3284,39 @@ export function createApiRoutes(dependencies: ApiRouteDependencies = {}) {
           ok: res.ok,
           detail: `HTTP ${res.status} ${res.statusText}`,
           tools: [],
+          reauth_required: false,
         });
       } catch (err) {
+        console.error(`turbodiff: API connection test failed for connection ${conn.id}:`, err);
         return c.json<ApiConnectionTest>({
           ok: false,
-          detail: err instanceof Error ? err.message : 'request failed',
+          detail: 'We could not reach this integration. Check its URL and try again.',
           tools: [],
+          reauth_required: false,
         });
       }
     }
-    const result = await testMcpEndpoint(conn.url, auth ?? undefined);
+    const result = await testMcp(conn.url, auth ?? undefined);
+    if (conn.auth_type === 'oauth' && (result.status === 401 || result.status === 403)) {
+      try {
+        await updateConnectionAuth(conn.id, { oauthNeedsReauth: true });
+      } catch (err) {
+        // The reconnect flow can still repair the credential even if this
+        // best-effort status update fails. Keep persistence details server-side.
+        console.error(`turbodiff: could not mark connection ${conn.id} for OAuth re-auth:`, err);
+      }
+      return c.json<ApiConnectionTest>({
+        ok: false,
+        detail: 'The integration rejected its OAuth authorization. Reconnect it to continue.',
+        tools: [],
+        reauth_required: true,
+      });
+    }
     return c.json<ApiConnectionTest>({
       ok: result.ok,
       detail: result.detail,
       tools: result.tools ?? [],
+      reauth_required: false,
     });
   });
 

--- a/src/http/api.worker.test.ts
+++ b/src/http/api.worker.test.ts
@@ -10,8 +10,10 @@ import type { AuthedUser } from '../services/auth.ts';
 import type {
   ApiAutomationDetail,
   ApiBoard,
+  ApiConnectionTest,
   ApiFeatureDetail,
   ApiFeatureExplanation,
+  ApiIntegrations,
   ApiModels,
   ApiReviewsPage,
   ApiSettings,
@@ -130,6 +132,8 @@ beforeEach(async () => {
     'plans',
     'review_findings',
     'reviews',
+    'repo_connections',
+    'connections',
     'repositories',
     'installations',
     'session',
@@ -141,6 +145,24 @@ beforeEach(async () => {
   );
   await seedTenants();
 });
+
+async function seedOAuthConnection(
+  id: number,
+  authConfig: string | null,
+  expiresAt: string | null,
+  hasRefreshToken: boolean,
+): Promise<void> {
+  await testDatabase()
+    .prepare(
+      `INSERT INTO connections
+         (id, installation_id, name, kind, url, auth_type, auth_config_ciphertext,
+          oauth_token_expires_at, oauth_has_refresh_token)
+       VALUES (?1, 1001, 'cloudflare', 'mcp', 'https://mcp.cloudflare.com/mcp',
+         'oauth', ?2, ?3, ?4)`,
+    )
+    .bind(id, authConfig, expiresAt, hasRefreshToken)
+    .run();
+}
 
 describe('API authentication and CSRF', () => {
   it('rejects a request without a durable session', async () => {
@@ -213,6 +235,89 @@ describe('API authentication and CSRF', () => {
     expect(response.status).toBe(403);
     expect(await response.json()).toEqual({ error: 'cross-origin request rejected' });
     expect(authenticate).not.toHaveBeenCalled();
+  });
+});
+
+describe('integration OAuth status and tests', () => {
+  it('does not call an abandoned OAuth draft connected', async () => {
+    await seedOAuthConnection(501, 'registered-client-draft', null, false);
+
+    const response = await authenticatedApi().request('https://turbodiff.test/api/integrations');
+    const payload = await response.json<ApiIntegrations>();
+
+    expect(payload.connections[0]?.oauth_status).toBe('not_connected');
+  });
+
+  it('never returns an internal credential-resolution error to the browser', async () => {
+    await seedOAuthConnection(502, 'sealed-config', '2026-09-07T15:11:04.232Z', true);
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      const response = await apiApp({
+        authenticate: async () => acmeUser,
+        resolveConnectionAuth: async () => {
+          throw new Error(
+            'Failed query: UPDATE app.connections SET oauth_token_expires_at = $1; params: secret',
+          );
+        },
+      }).request('https://turbodiff.test/api/integrations/502/test', { method: 'POST' });
+      const payload = await response.json<ApiConnectionTest>();
+
+      expect(payload).toEqual({
+        ok: false,
+        detail: 'We could not verify this connection because of an internal error. Try again.',
+        tools: [],
+        reauth_required: false,
+      });
+      expect(payload.detail).not.toContain('UPDATE');
+      expect(payload.detail).not.toContain('secret');
+      expect(errorLog).toHaveBeenCalledOnce();
+    } finally {
+      errorLog.mockRestore();
+    }
+  });
+
+  it('asks the client to reconnect when OAuth was never completed', async () => {
+    await seedOAuthConnection(504, null, null, false);
+    const response = await authenticatedApi().request(
+      'https://turbodiff.test/api/integrations/504/test',
+      { method: 'POST' },
+    );
+    const payload = await response.json<ApiConnectionTest>();
+
+    expect(payload).toEqual({
+      ok: false,
+      detail: 'OAuth is not connected. Reconnect this integration to continue.',
+      tools: [],
+      reauth_required: true,
+    });
+  });
+
+  it('marks rejected OAuth authorization for reconnect and returns the redirect signal', async () => {
+    await seedOAuthConnection(503, 'sealed-config', '2026-09-09T15:11:04.232Z', true);
+    const response = await apiApp({
+      authenticate: async () => acmeUser,
+      resolveConnectionAuth: async () => ({
+        headerName: 'authorization',
+        headerValue: 'Bearer access-token',
+      }),
+      testMcpEndpoint: async () => ({
+        ok: false,
+        detail: 'HTTP 401 Unauthorized: token rejected',
+        status: 401,
+      }),
+    }).request('https://turbodiff.test/api/integrations/503/test', { method: 'POST' });
+    const payload = await response.json<ApiConnectionTest>();
+
+    expect(payload).toEqual({
+      ok: false,
+      detail: 'The integration rejected its OAuth authorization. Reconnect it to continue.',
+      tools: [],
+      reauth_required: true,
+    });
+    const connection = await testDatabase()
+      .prepare('SELECT oauth_needs_reauth FROM connections WHERE id = 503')
+      .first<{ oauth_needs_reauth: boolean }>();
+    expect(connection?.oauth_needs_reauth).toBe(true);
   });
 });
 

--- a/src/integrations/mcp/client.test.ts
+++ b/src/integrations/mcp/client.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { testMcpEndpoint } from './client.ts';
+
+describe('testMcpEndpoint OAuth failures', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reports an authorization rejection that happens during tool discovery', async () => {
+    const responses = [
+      Response.json(
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          result: { serverInfo: { name: 'cloudflare', version: '1.0' } },
+        },
+        { headers: { 'mcp-session-id': 'session-1' } },
+      ),
+      new Response(null, { status: 202 }),
+      new Response('token expired', { status: 401, statusText: 'Unauthorized' }),
+    ];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => responses.shift() ?? new Response(null, { status: 500 })),
+    );
+
+    await expect(testMcpEndpoint('https://mcp.cloudflare.com/mcp')).resolves.toEqual({
+      ok: false,
+      detail: 'HTTP 401 Unauthorized: token expired',
+      status: 401,
+    });
+  });
+});

--- a/src/integrations/mcp/client.ts
+++ b/src/integrations/mcp/client.ts
@@ -15,6 +15,7 @@ export interface McpTestResult {
   ok: boolean;
   detail: string;
   tools?: string[];
+  status?: number;
 }
 
 // The JSON-RPC requests this probe sends.
@@ -88,6 +89,7 @@ export async function testMcpEndpoint(
     return {
       ok: false,
       detail: `HTTP ${initRes.status} ${initRes.statusText}: ${(await initRes.text()).slice(0, 300)}`,
+      status: initRes.status,
     };
   }
 
@@ -116,6 +118,13 @@ export async function testMcpEndpoint(
   try {
     await rpc({ jsonrpc: '2.0', method: 'notifications/initialized' }, session);
     const listRes = await rpc({ jsonrpc: '2.0', id: 2, method: 'tools/list' }, session);
+    if (listRes.status === 401 || listRes.status === 403) {
+      return {
+        ok: false,
+        detail: `HTTP ${listRes.status} ${listRes.statusText}: ${(await listRes.text()).slice(0, 300)}`,
+        status: listRes.status,
+      };
+    }
     const list = parseRpcBody(await listRes.text());
     const listResult = list ? list['result'] : undefined;
     const rawTools = isJsonObject(listResult) ? listResult['tools'] : undefined;

--- a/src/services/connections.ts
+++ b/src/services/connections.ts
@@ -49,6 +49,21 @@ const TOKEN_EXPIRY_MARGIN_MS = 60_000;
 const REFRESH_CLAIM_MS = 45_000;
 const DEFAULT_TOKEN_TTL_MS = 60 * 60_000;
 
+export type ConnectionAuthErrorReason = 'reauth_required' | 'temporarily_unavailable';
+
+// Only messages from this error may cross the HTTP boundary. Lower-level
+// failures can contain SQL, encrypted values, or provider response details
+// and are logged server-side instead.
+export class ConnectionAuthError extends Error {
+  constructor(
+    readonly reason: ConnectionAuthErrorReason,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ConnectionAuthError';
+  }
+}
+
 function stillFresh(expiresAt: string | null | undefined): boolean {
   return !!expiresAt && new Date(expiresAt).getTime() > Date.now() + TOKEN_EXPIRY_MARGIN_MS;
 }
@@ -118,8 +133,9 @@ async function resolveClientCredentials(conn: ConnectionRow): Promise<ResolvedAu
 
 async function resolveOAuthConnection(conn: ConnectionRow): Promise<ResolvedAuth> {
   if (!conn.auth_config_ciphertext) {
-    throw new Error(
-      `turbodiff: connection ${conn.id} has no OAuth credential yet — connect it from the integrations page`,
+    throw new ConnectionAuthError(
+      'reauth_required',
+      'OAuth is not connected. Reconnect this integration to continue.',
     );
   }
   const config = await openJson<OAuthConfig>(conn.auth_config_ciphertext);
@@ -128,8 +144,9 @@ async function resolveOAuthConnection(conn: ConnectionRow): Promise<ResolvedAuth
   }
   if (!config.refreshToken) {
     await updateConnectionAuth(conn.id, { oauthNeedsReauth: true, oauthHasRefreshToken: false });
-    throw new Error(
-      `turbodiff: connection ${conn.id}'s OAuth token expired and has no refresh token — reconnect it from the integrations page`,
+    throw new ConnectionAuthError(
+      'reauth_required',
+      'OAuth authorization expired and cannot be refreshed. Reconnect this integration to continue.',
     );
   }
 
@@ -146,7 +163,10 @@ async function resolveOAuthConnection(conn: ConnectionRow): Promise<ResolvedAuth
     if (freshConfig?.accessToken) {
       return { headerName: 'authorization', headerValue: `Bearer ${freshConfig.accessToken}` };
     }
-    throw new Error(`turbodiff: connection ${conn.id}'s OAuth refresh is in flight — retry`);
+    throw new ConnectionAuthError(
+      'temporarily_unavailable',
+      'OAuth credentials are already being refreshed. Try the connection again in a moment.',
+    );
   }
 
   const refreshed = await refreshOAuthToken(
@@ -159,12 +179,18 @@ async function resolveOAuthConnection(conn: ConnectionRow): Promise<ResolvedAuth
   if (!refreshed.ok) {
     if (refreshed.invalidGrant) {
       await updateConnectionAuth(conn.id, { oauthNeedsReauth: true });
-      throw new Error(
-        `turbodiff: connection ${conn.id}'s OAuth refresh token was revoked (${refreshed.detail}) — reconnect it from the integrations page`,
+      console.warn(
+        `turbodiff: OAuth refresh token was rejected for connection ${conn.id}: ${refreshed.detail}`,
+      );
+      throw new ConnectionAuthError(
+        'reauth_required',
+        'OAuth authorization expired or was revoked. Reconnect this integration to continue.',
       );
     }
-    throw new Error(
-      `turbodiff: connection ${conn.id}'s OAuth refresh failed (${refreshed.detail}) — will retry`,
+    console.warn(`turbodiff: OAuth refresh failed for connection ${conn.id}: ${refreshed.detail}`);
+    throw new ConnectionAuthError(
+      'temporarily_unavailable',
+      'The OAuth provider could not refresh this connection. Try again in a moment.',
     );
   }
 
@@ -325,7 +351,12 @@ export function oauthStatus(
 ): 'not_connected' | 'connected' | 'expired' | 'needs_reauth' | null {
   if (conn.auth_type !== 'oauth') return null;
   if (conn.oauth_needs_reauth) return 'needs_reauth';
-  if (conn.auth_config_ciphertext === null) return 'not_connected';
+  // /oauth/start persists a draft containing discovery/client-registration
+  // data before the user authorizes. Only the callback records an expiry, so
+  // a draft or abandoned flow must not render as connected.
+  if (conn.auth_config_ciphertext === null || conn.oauth_token_expires_at === null) {
+    return 'not_connected';
+  }
   if (
     !conn.oauth_has_refresh_token &&
     conn.oauth_token_expires_at &&

--- a/src/services/mcp-proxy.ts
+++ b/src/services/mcp-proxy.ts
@@ -2,7 +2,7 @@ import { env } from 'cloudflare:workers';
 import { isJsonObject, isNumber, isString, parseJson, type JsonValue } from '../shared/json.ts';
 import { encryptionConfigured, openJson, sealJson } from '../integrations/security/crypto.ts';
 import { getConnection, type ConnectionRow } from '../data/db.ts';
-import { connectionSnapshot, resolveConnectionAuth } from './connections.ts';
+import { ConnectionAuthError, connectionSnapshot, resolveConnectionAuth } from './connections.ts';
 
 // MCP relay for sandbox runs: the sandbox agent's MCP config points every
 // server at /mcp-proxy/:id with a short-lived sealed grant as its bearer
@@ -116,7 +116,13 @@ export async function proxyMcpRequest(connectionId: number, request: Request): P
   try {
     auth = await resolveConnectionAuth(conn);
   } catch (err) {
-    const detail = err instanceof Error ? err.message : 'could not resolve credentials';
+    const detail =
+      err instanceof ConnectionAuthError
+        ? err.message
+        : 'The connection credential could not be resolved because of an internal error.';
+    if (!(err instanceof ConnectionAuthError)) {
+      console.error(`turbodiff: MCP proxy auth failed for connection ${conn.id}:`, err);
+    }
     return Response.json({ error: detail }, { status: 502 });
   }
 

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -544,6 +544,7 @@ export interface ApiConnectionTest {
   ok: boolean;
   detail: string;
   tools: string[];
+  reauth_required: boolean;
 }
 
 export interface ApiRepoSettings {


### PR DESCRIPTION
## Summary

- fix the PostgreSQL OAuth refresh claim that failed on an untyped nullable parameter
- distinguish completed OAuth connections from abandoned authorization drafts
- mark OAuth 401/403 responses as needing re-authentication and restart the OAuth flow in the client
- keep SQL and other internal credential-resolution failures in server logs while returning safe user-facing errors
- cover refresh claims, status reporting, error sanitization, and MCP authorization failures with regression tests

## Root cause

The connection badge reflects stored OAuth state rather than performing a live probe. When an access token expired, Test attempted to refresh it. The SQLite-to-PostgreSQL port duplicated the expected-expiry value into a parameter used only by IS NULL, so PostgreSQL could not infer that parameter type and rejected the refresh claim before the OAuth provider was contacted. The route then returned the database exception message verbatim.

## Verification

- reproduced the original PostgreSQL error and confirmed the corrected query updates the row
- `vp test --run`: 44 files, 303 tests passed
- `vp run check:types`
- changed-file lint and formatting checks
- client and production Worker builds

The PostgreSQL-backed Worker suite was added and type-checked, but could not execute locally because this environment cannot access the Docker socket.