### PR TITLE
Fix AI Gateway retry headers and Claude system prompts

### DIFF
--- a/src/services/ai-gateway-proxy.test.ts
+++ b/src/services/ai-gateway-proxy.test.ts
@@ -17,7 +17,165 @@ async function request(model: string, grantModel = model): Promise<Request> {
   });
 }
 
+async function messagesRequest(body: string): Promise<Request> {
+  const grant = await createAiGatewayGrant(
+    config.apiToken,
+    'anthropic/claude-opus-4.8',
+    Date.now() + 60_000,
+  );
+  return new Request('https://turbodiff.test/ai-proxy/v1/messages', {
+    method: 'POST',
+    headers: { 'x-api-key': grant, 'anthropic-version': '2023-06-01' },
+    body,
+  });
+}
+
 describe('AI Gateway sandbox proxy', () => {
+  it.each(['60', 'Wed, 09 Sep 2026 18:11:19 GMT'])(
+    'preserves upstream retry timing (%s) and the error stream',
+    async (retryAfter) => {
+      const errorBody = '{"error":{"message":"Wholesale rate limit exceeded"}}';
+      const upstreamResponse = new Response(errorBody, {
+        status: 429,
+        headers: {
+          'content-type': 'application/json',
+          'retry-after': retryAfter,
+          'retry-after-ms': '60000',
+          'set-cookie': 'upstream-only=value',
+        },
+      });
+      const upstream = vi.fn<typeof fetch>().mockResolvedValue(upstreamResponse);
+      const response = await proxyAiGatewayRequest(
+        await request('openai/gpt-5.2-codex'),
+        config,
+        upstream,
+      );
+
+      expect(response.status).toBe(429);
+      expect(response.headers.get('retry-after')).toBe(retryAfter);
+      expect(response.headers.get('retry-after-ms')).toBe('60000');
+      expect(response.headers.get('set-cookie')).toBeNull();
+      expect(response.body).toBe(upstreamResponse.body);
+      expect(await response.text()).toBe(errorBody);
+      expect(upstream).toHaveBeenCalledOnce();
+    },
+  );
+
+  it('adapts Claude system text blocks without changing messages, tools, or generation options', async () => {
+    const payload = {
+      model: 'anthropic/claude-opus-4.8',
+      system: [
+        { type: 'text', text: 'Review carefully.\nKeep this whitespace. ' },
+        { type: 'text', text: 'Respect café conventions.', cache_control: { type: 'ephemeral' } },
+      ],
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Review the diff.' }] }],
+      tools: [{ name: 'read_file', input_schema: { type: 'object', properties: {} } }],
+      max_tokens: 32000,
+      thinking: { type: 'adaptive' },
+      stream: true,
+    };
+    const upstream = vi.fn<typeof fetch>().mockResolvedValue(new Response('data: done\n\n'));
+    const response = await proxyAiGatewayRequest(
+      await messagesRequest(JSON.stringify(payload)),
+      config,
+      upstream,
+    );
+
+    expect(response.status).toBe(200);
+    expect(upstream).toHaveBeenCalledOnce();
+    const [url, init] = upstream.mock.calls[0]!;
+    expect(url).toBe('https://api.cloudflare.com/client/v4/accounts/account-123/ai/v1/messages');
+    expect(await new Request(url, init).json()).toEqual({
+      ...payload,
+      system: 'Review carefully.\nKeep this whitespace. \n\nRespect café conventions.',
+    });
+  });
+
+  it.each([
+    [{}, {}],
+    [{ system: 'Already a string.' }, { system: 'Already a string.' }],
+    [{ system: [] }, {}],
+  ])('handles absent, string, and empty Claude system prompts: %j', async (system, expected) => {
+    const payload = {
+      model: 'anthropic/claude-opus-4.8',
+      messages: [{ role: 'user', content: 'Hello' }],
+      max_tokens: 128,
+    };
+    const upstream = vi.fn<typeof fetch>().mockResolvedValue(new Response('ok'));
+    await proxyAiGatewayRequest(
+      await messagesRequest(JSON.stringify({ ...payload, ...system })),
+      config,
+      upstream,
+    );
+
+    const [url, init] = upstream.mock.calls[0]!;
+    expect(await new Request(url, init).json()).toEqual({
+      ...payload,
+      ...expected,
+    });
+  });
+
+  it.each([null, { type: 'image', source: 'unsupported' }, { type: 'text', text: 123 }])(
+    'rejects unsupported system blocks instead of silently removing instructions: %j',
+    async (block) => {
+      const upstream = vi.fn<typeof fetch>();
+      const response = await proxyAiGatewayRequest(
+        await messagesRequest(
+          JSON.stringify({
+            model: 'anthropic/claude-opus-4.8',
+            system: [{ type: 'text', text: 'Keep these instructions.' }, block],
+            messages: [],
+            max_tokens: 128,
+          }),
+        ),
+        config,
+        upstream,
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({
+        error: { message: 'system must contain only text blocks with string text' },
+      });
+      expect(upstream).not.toHaveBeenCalled();
+    },
+  );
+
+  it('checks the model grant before adapting a Claude request', async () => {
+    const upstream = vi.fn<typeof fetch>();
+    const response = await proxyAiGatewayRequest(
+      await messagesRequest(
+        JSON.stringify({
+          model: 'anthropic/claude-haiku-4.5',
+          system: [{ type: 'text', text: 'Instructions' }],
+        }),
+      ),
+      config,
+      upstream,
+    );
+    expect(response.status).toBe(403);
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
+  it.each(['responses', 'chat/completions'])(
+    'leaves request bodies unchanged outside the Messages endpoint: %s',
+    async (endpoint) => {
+      const model = 'openai/gpt-5.2-codex';
+      const grant = await createAiGatewayGrant(config.apiToken, model, Date.now() + 60_000);
+      const body = JSON.stringify({ model, system: [{ type: 'text', text: 'Instructions' }] });
+      const upstream = vi.fn<typeof fetch>().mockResolvedValue(new Response('ok'));
+      await proxyAiGatewayRequest(
+        new Request(`https://turbodiff.test/ai-proxy/v1/${endpoint}`, {
+          method: 'POST',
+          headers: { authorization: `Bearer ${grant}` },
+          body,
+        }),
+        config,
+        upstream,
+      );
+      expect(upstream.mock.calls[0]![1]?.body).toBe(body);
+    },
+  );
+
   it('exchanges a model grant for Worker-only credentials and preserves streaming', async () => {
     const upstream = vi.fn<typeof fetch>().mockResolvedValue(
       new Response('data: done\n\n', {

--- a/src/services/ai-gateway-proxy.ts
+++ b/src/services/ai-gateway-proxy.ts
@@ -1,5 +1,6 @@
 import { requestUsesGrantedModel } from '../domain/ai-gateway-policy.ts';
 import { verifyAiGatewayGrantWithSecret } from '../integrations/security/ai-gateway-grant.ts';
+import { isJsonObject, isString, parseJson } from '../shared/json.ts';
 
 const MAX_REQUEST_BYTES = 16 * 1024 * 1024;
 const ALLOWED_ENDPOINTS = new Set(['chat/completions', 'responses', 'messages']);
@@ -52,9 +53,29 @@ export async function proxyAiGatewayRequest(
   }
   const bytes = await request.arrayBuffer();
   if (bytes.byteLength > MAX_REQUEST_BYTES) return error('request body too large', 413);
-  const body = new TextDecoder().decode(bytes);
+  let body = new TextDecoder().decode(bytes);
   if (!requestUsesGrantedModel(body, grant.model)) {
     return error('request model does not match the sandbox grant', 403);
+  }
+
+  if (endpoint === 'messages') {
+    // Cloudflare's /ai/v1/messages currently requires a system string, but
+    // Anthropic SDKs emit text blocks. Preserve all text in order; block-level
+    // metadata such as cache_control cannot be represented in this format.
+    // The model check above has already validated that the body is JSON.
+    const parsed = parseJson(body);
+    if (isJsonObject(parsed) && Array.isArray(parsed.system)) {
+      const parts: string[] = [];
+      for (const block of parsed.system) {
+        if (!isJsonObject(block) || block.type !== 'text' || !isString(block.text)) {
+          return error('system must contain only text blocks with string text', 400);
+        }
+        parts.push(block.text);
+      }
+      if (parts.length) parsed.system = parts.join('\n\n');
+      else delete parsed.system;
+      body = JSON.stringify(parsed);
+    }
   }
 
   const accountId = config.accountId.trim();
@@ -84,7 +105,14 @@ export async function proxyAiGatewayRequest(
     },
   );
   const headers = new Headers();
-  for (const name of ['content-type', 'cf-ray', 'request-id', 'x-request-id']) {
+  for (const name of [
+    'content-type',
+    'cf-ray',
+    'request-id',
+    'x-request-id',
+    'retry-after',
+    'retry-after-ms',
+  ]) {
     const value = upstream.headers.get(name);
     if (value) headers.set(name, value);
   }


### PR DESCRIPTION
The sandbox proxy discarded upstream retry timing headers, and Claude requests using the SDK's array-valued `system` prompt failed Cloudflare's `/ai/v1/messages` validation with “expected string, received array.”

Forward `Retry-After` and `retry-after-ms` without buffering the response. For the Messages endpoint, join system text blocks in order with blank-line separators, omit empty system arrays, and reject unsupported blocks before making an upstream request. Preserve the model-grant check and all other payload fields. String and absent system prompts pass through unchanged.

System block metadata, including `cache_control`, cannot be represented in Cloudflare's required string format and is omitted during conversion. This fixes the observed Claude schema incompatibility and improves retry behavior; it does not resolve Cloudflare's separate low-volume wholesale throttling.

Validation:
- All 315 unit tests pass across 44 files, including 16 proxy tests. New regression cases were confirmed to fail against the original implementation.
- `vp run check:types`, `vp lint`, `vp run build`, changed-file formatting, and the staged `vp check --fix` hook pass. Lint reports existing warnings outside these files.
- Repository-wide `vp check` stops on existing formatting in migration snapshots `0013`, `0014`, `0015`, and `0018`; those files are unchanged.
- No production deployment or live provider calls were made to validate this patch. Provider-boundary tests use injected fetch responses.