### PR TITLE
Honor task model across planning and criteria rewrites

### DIFF
--- a/src/ai/runners/planner.ts
+++ b/src/ai/runners/planner.ts
@@ -16,7 +16,6 @@ import { persistAgentLog } from '../runtime/agent-runs.ts';
 import { runCodingAgent } from '../runtime/coding-agent.ts';
 import { resolveRunnerAuth } from '../runtime/runner-auth.ts';
 import { runnerSandbox } from '../runtime/sandbox.ts';
-import { resolveRunnerModel } from '../../data/models.ts';
 import { redactSecrets } from '../runtime/redaction.ts';
 import { installationToken } from '../../integrations/github/app.ts';
 import { resolveWorkspaceRemote } from '../../integrations/git/provider.ts';
@@ -171,39 +170,6 @@ async function runAgent(
   }
 }
 
-// Cheap-model triage: is this request a small localized change or real
-// feature work? Drives plan depth, criteria count, and the generation
-// agent's budget. Fails open to 'standard' — misclassifying big work as
-// trivial is the only harmful direction.
-async function classifyTier(
-  sandbox: Sandbox,
-  plan: PlanRow,
-  repos: RepositoryRow[],
-): Promise<'trivial' | 'standard'> {
-  const auth = await resolveRunnerAuth(undefined, await resolveRunnerModel(null, 'fast'));
-  const label = repos.map((r) => `${r.owner}/${r.name}`).join(', ');
-  const prompt = `Classify this feature request for ${label}. Reply with EXACTLY one word: trivial or standard.
-
-trivial = a small, localized change: cosmetic/styling tweaks, copy changes, a config value, a small fix confined to a handful of files, no new subsystem, no schema or API changes.
-standard = everything else.
-
-## Request: ${plan.title}
-
-${plan.requirements}
-`;
-  try {
-    await sandbox.writeFile(`${OUT_DIR}/classify.md`, prompt);
-    const res = await runCodingAgent(sandbox, auth, {
-      promptFile: `${OUT_DIR}/classify.md`,
-      cwd: CLONE_DIR,
-      timeout: 2 * 60_000,
-    });
-    return res.success && /\btrivial\b/i.test(res.resultText) ? 'trivial' : 'standard';
-  } catch {
-    return 'standard';
-  }
-}
-
 const ATTACH_DIR = '/workspace/plan-attachments';
 
 // User-uploaded context files (R2) pulled into the sandbox with the same
@@ -245,18 +211,17 @@ function analyzePrompt(
   plan: PlanRow,
   repos: RepositoryRow[],
   dirs: { repo: RepositoryRow; dir: string }[],
-  tier: string,
   extra = '',
 ): string {
-  const trivial = tier === 'trivial';
   if (repos.length === 1) {
     const repo = repos[0];
     return `You are a planning agent for ${repo.owner}/${repo.name}. You are in a read-only checkout — study the code but do NOT modify it.
-${trivial ? '\nThis request is classified TRIVIAL: a small, localized change. Keep everything proportionate — a short analysis, and questions only for a genuine blocker.\n' : ''}
+Keep the analysis proportionate: for a small, localized change, use at most 10 lines and ask questions only for a genuine blocker.
 Analyze the feature requirements below against the actual codebase, then write these files (create the directory if needed):
 
-1. ${OUT_DIR}/analysis.md — a ${trivial ? 'brief (≤10 lines)' : 'short'} grounding analysis: which files/modules this touches, how it fits existing conventions, and any risks.
-2. ${OUT_DIR}/questions.json — a JSON array of clarifying questions. Each question is an object: \`{ "text": "...", "options": ["...", "...", "..."], "recommended": "<exact text of one of the options>" }\`. Give 2-3 concrete, mutually-exclusive options that a user could tap to answer, and mark the one you'd recommend by repeating its exact text in \`recommended\`. If a question genuinely has no small set of sensible choices (open-ended input needed), omit \`options\`/\`recommended\` and it will be shown as free text. Include ONLY genuine ambiguities or decisions that would change the implementation. If the requirements are clear enough to implement well, write an empty array [].${trivial ? ' For a trivial request the answer is almost always [].' : ''}
+1. ${OUT_DIR}/analysis.md — a short grounding analysis: which files/modules this touches, how it fits existing conventions, and any risks.
+2. ${OUT_DIR}/questions.json — a JSON array of clarifying questions. Each question is an object: \`{ "text": "...", "options": ["...", "...", "..."], "recommended": "<exact text of one of the options>" }\`. Give 2-3 concrete, mutually-exclusive options that a user could tap to answer, and mark the one you'd recommend by repeating its exact text in \`recommended\`. If a question genuinely has no small set of sensible choices (open-ended input needed), omit \`options\`/\`recommended\` and it will be shown as free text. Include ONLY genuine ambiguities or decisions that would change the implementation. If the requirements are clear enough to implement well, write an empty array [].
+3. ${OUT_DIR}/tier.txt — exactly one word: trivial or standard. Use trivial only for a small, localized change (cosmetic/styling, copy, a config value, or a small fix) with no new subsystem, schema, or API changes. Use standard for everything else, including uncertainty. Classify from the analysis you already performed; do not launch another agent for classification.
 
 ${UNTRUSTED_CONTENT_RULES}
 
@@ -267,14 +232,15 @@ ${plan.requirements}
 ${extra}`;
   }
   return `You are a planning agent for a feature spanning ${repos.length} repositories. You are in read-only checkouts — study the code but do NOT modify it.
-${trivial ? '\nThis request is classified TRIVIAL: a small, localized change. Keep everything proportionate — a short analysis, and questions only for a genuine blocker.\n' : ''}
+Keep the analysis proportionate: for a small, localized change, use at most 10 lines and ask questions only for a genuine blocker.
 ## Repositories
 ${reposList(dirs)}
 
 Analyze the feature requirements below against the actual code in EVERY repository above, as one coherent feature designed across all of them, then write these files (create the directory if needed):
 
-1. ${OUT_DIR}/analysis.md — a ${trivial ? 'brief (≤10 lines)' : 'short'} grounding analysis covering each repository: which files/modules it touches, how it fits existing conventions, and any risks.
-2. ${OUT_DIR}/questions.json — a JSON array of clarifying questions. Each question is an object: \`{ "text": "...", "options": ["...", "...", "..."], "recommended": "<exact text of one of the options>" }\`. Give 2-3 concrete, mutually-exclusive options that a user could tap to answer, and mark the one you'd recommend by repeating its exact text in \`recommended\`. If a question genuinely has no small set of sensible choices (open-ended input needed), omit \`options\`/\`recommended\` and it will be shown as free text. Include ONLY genuine ambiguities or decisions that would change the implementation. If the requirements are clear enough to implement well, write an empty array [].${trivial ? ' For a trivial request the answer is almost always [].' : ''}
+1. ${OUT_DIR}/analysis.md — a short grounding analysis covering each repository: which files/modules it touches, how it fits existing conventions, and any risks.
+2. ${OUT_DIR}/questions.json — a JSON array of clarifying questions. Each question is an object: \`{ "text": "...", "options": ["...", "...", "..."], "recommended": "<exact text of one of the options>" }\`. Give 2-3 concrete, mutually-exclusive options that a user could tap to answer, and mark the one you'd recommend by repeating its exact text in \`recommended\`. If a question genuinely has no small set of sensible choices (open-ended input needed), omit \`options\`/\`recommended\` and it will be shown as free text. Include ONLY genuine ambiguities or decisions that would change the implementation. If the requirements are clear enough to implement well, write an empty array [].
+3. ${OUT_DIR}/tier.txt — exactly one word: trivial or standard. Use trivial only for a small, localized change (cosmetic/styling, copy, a config value, or a small fix) with no new subsystem, schema, or API changes. Use standard for everything else, including uncertainty. Classify from the analysis you already performed; do not launch another agent for classification.
 
 ${UNTRUSTED_CONTENT_RULES}
 
@@ -366,18 +332,20 @@ export async function runPlanAnalyze(planId: number): Promise<void> {
     const booted = await clonePlanRepos(repos, planId);
     sandbox = booted.sandbox;
     dirs = booted.dirs;
-    // Cheap-model triage first: trivial requests get proportionate plans.
-    const tier = await classifyTier(sandbox, plan, repos);
-    await updatePlan(planId, { tier });
     const attachments = attachmentsSection(await fetchPlanAttachments(sandbox, plan));
     await runAgent(
       sandbox,
-      analyzePrompt(plan, repos, dirs, tier, attachments),
+      analyzePrompt(plan, repos, dirs, attachments),
       booted.scrub,
       'plan_analyze',
       planId,
       plan.runner_model,
     );
+    // Classification is an output of this task's analysis, never a separate
+    // agent using the global fast model. Missing/invalid output stays conservative.
+    const tier =
+      (await readText(sandbox, `${OUT_DIR}/tier.txt`)) === 'trivial' ? 'trivial' : 'standard';
+    await updatePlan(planId, { tier });
     const analysis = await readText(sandbox, `${OUT_DIR}/analysis.md`);
     const questions = await readQuestions(sandbox, `${OUT_DIR}/questions.json`);
 

--- a/src/ai/runners/task-model.test.ts
+++ b/src/ai/runners/task-model.test.ts
@@ -4,10 +4,11 @@ import { verifyAiGatewayGrantWithSecret } from '../../integrations/security/ai-g
 import { runPlanAnalyze, runPlanRefine } from './planner.ts';
 import { runVerification } from './verifier.ts';
 
-// Only external boundaries are replaced: the real runners, OpenCode adapter,
-// model configuration and signed capabilities all execute in these tests.
+// Runner contract tests: orchestration, OpenCode command/config generation and
+// capability signing are real. Sandbox execution, persistence and other services
+// are faked; these tests do not exercise the actual CLI, database or provider.
 const boundary = vi.hoisted(() => {
-  const runs: { prompt: string; env: Record<string, string | undefined> }[] = [];
+  const runs: { command: string; prompt: string; env: Record<string, string | undefined> }[] = [];
   return {
     files: new Map<string, string>(),
     runs,
@@ -137,11 +138,12 @@ beforeEach(() => {
   boundary.questions = '[]';
   boundary.repositories = 1;
   boundary.plan.tier = '';
+  boundary.plan.runner_model = 'moonshotai/kimi-k3';
   boundary.exec.mockImplementation(async (command: string, options?: ExecOptions) => {
     if (command.startsWith('opencode run ')) {
       const env = options?.env ?? {};
       const prompt = boundary.files.get(env.TURBODIFF_AGENT_PROMPT ?? '') ?? '';
-      boundary.runs.push({ prompt, env });
+      boundary.runs.push({ command, prompt, env });
       if (env.TURBODIFF_AGENT_PROMPT === '/workspace/plan-out/task.md') {
         boundary.files.set('/workspace/plan-out/analysis.md', 'Update the running-state selector.');
         boundary.files.set('/workspace/plan-out/questions.json', boundary.questions);
@@ -170,17 +172,30 @@ beforeEach(() => {
   });
 });
 
-async function expectSelectedModelOnEveryRun(count: number) {
-  expect(boundary.runs).toHaveLength(count);
-  expect(boundary.resolveRunnerModel).not.toHaveBeenCalled();
-  for (const { env } of boundary.runs) {
-    expect(env.TURBODIFF_RUNNER_MODEL).toBe('cloudflare-ai-gateway/moonshotai/kimi-k3');
+async function expectRunModels(models: string[]) {
+  expect(boundary.runs).toHaveLength(models.length);
+  for (const [index, model] of models.entries()) {
+    const { command, env } = boundary.runs[index];
+    expect(command).toContain(' --model "$TURBODIFF_RUNNER_MODEL"');
+    expect(env.TURBODIFF_RUNNER_MODEL).toBe(`cloudflare-ai-gateway/${model}`);
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? '{}')).toMatchObject({
+      enabled_providers: ['cloudflare-ai-gateway'],
+      provider: {
+        'cloudflare-ai-gateway': {
+          options: {
+            apiKey: '{env:TURBODIFF_AI_GATEWAY_GRANT}',
+            baseURL: 'https://turbodiff.test/ai-proxy/v1',
+          },
+          models: { [model]: { name: model } },
+        },
+      },
+    });
     expect(
       await verifyAiGatewayGrantWithSecret(
         'test-only-gateway-secret',
         env.TURBODIFF_AI_GATEWAY_GRANT ?? '',
       ),
-    ).toMatchObject({ model: 'moonshotai/kimi-k3' });
+    ).toMatchObject({ model });
   }
 }
 
@@ -191,7 +206,7 @@ describe('task model across planning and verification', () => {
       boundary.repositories = repositories;
       await runPlanAnalyze(10);
 
-      await expectSelectedModelOnEveryRun(2);
+      await expectRunModels([boundary.plan.runner_model, boundary.plan.runner_model]);
       expect(boundary.runs[0].prompt).toContain('/workspace/plan-out/tier.txt');
       expect(boundary.runs[0].prompt).toContain('exactly one word: trivial or standard');
       expect(boundary.updatePlan).toHaveBeenCalledWith(10, { tier: 'trivial' });
@@ -213,25 +228,27 @@ describe('task model across planning and verification', () => {
       boundary.omitTier = tier === undefined;
       await runPlanAnalyze(10);
 
-      await expectSelectedModelOnEveryRun(2);
+      await expectRunModels([boundary.plan.runner_model, boundary.plan.runner_model]);
       expect(boundary.updatePlan).toHaveBeenCalledWith(10, { tier: 'standard' });
       expect(boundary.runs[1].prompt).toContain('at most 8');
     },
   );
 
-  it('persists the tier while waiting for answers and uses it on the selected-model refinement', async () => {
+  it('requests tier persistence and honors a model change when refinement starts', async () => {
     boundary.questions = '[{"text":"Which task states should count?"}]';
     await runPlanAnalyze(10);
-    await expectSelectedModelOnEveryRun(1);
+    await expectRunModels([boundary.plan.runner_model]);
     expect(boundary.updatePlan).toHaveBeenCalledWith(
       10,
       expect.objectContaining({ status: 'awaiting_answers' }),
     );
     expect(boundary.updatePlan).toHaveBeenCalledWith(10, { tier: 'trivial' });
 
+    // Emulate the persisted tier and a user changing the model before the next run.
     boundary.plan.tier = 'trivial';
+    boundary.plan.runner_model = 'openai/gpt-5.2-codex';
     await runPlanRefine(10);
-    await expectSelectedModelOnEveryRun(2);
+    await expectRunModels(['moonshotai/kimi-k3', 'openai/gpt-5.2-codex']);
     expect(boundary.runs[1].prompt).toContain('at most 4');
     expect(boundary.updatePlan).toHaveBeenLastCalledWith(
       10,
@@ -242,7 +259,7 @@ describe('task model across planning and verification', () => {
   it('keeps the selected model when a human-directed fix requires a criteria rewrite', async () => {
     await runVerification(20);
 
-    await expectSelectedModelOnEveryRun(2);
+    await expectRunModels([boundary.plan.runner_model, boundary.plan.runner_model]);
     expect(boundary.setProposedAcceptance).toHaveBeenCalledWith(20, [
       'Indicator follows automations and manual tasks',
     ]);

--- a/src/ai/runners/task-model.test.ts
+++ b/src/ai/runners/task-model.test.ts
@@ -1,0 +1,257 @@
+import type { ExecOptions } from '@cloudflare/sandbox';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { verifyAiGatewayGrantWithSecret } from '../../integrations/security/ai-gateway-grant.ts';
+import { runPlanAnalyze, runPlanRefine } from './planner.ts';
+import { runVerification } from './verifier.ts';
+
+// Only external boundaries are replaced: the real runners, OpenCode adapter,
+// model configuration and signed capabilities all execute in these tests.
+const boundary = vi.hoisted(() => {
+  const runs: { prompt: string; env: Record<string, string | undefined> }[] = [];
+  return {
+    files: new Map<string, string>(),
+    runs,
+    tier: 'trivial',
+    omitTier: false,
+    questions: '[]',
+    repositories: 1,
+    plan: {
+      id: 10,
+      repository_id: 1,
+      title: 'Show running tasks in the factory indicator',
+      requirements: 'Include manual tasks in the existing running indicator.',
+      runner_model: 'moonshotai/kimi-k3',
+      tier: '',
+      feedback: null,
+      questions: [],
+      answers: [],
+      attachments: [],
+    },
+    repo: {
+      id: 1,
+      installation_id: 1,
+      owner: 'test-owner',
+      name: 'test-repo',
+      provider: 'artifacts',
+      default_branch: 'main',
+      enabled: true,
+      demo_videos: false,
+      launchable: false,
+      run_command: null,
+      auto_fix: true,
+    },
+    updatePlan: vi.fn(),
+    finishVerification: vi.fn(),
+    setProposedAcceptance: vi.fn(),
+    resolveRunnerModel: vi.fn(async () => 'anthropic/claude-opus-4.8'),
+    exec: vi.fn(),
+  };
+});
+
+vi.mock('@cloudflare/sandbox', () => ({ collectFile: vi.fn() }));
+vi.mock('cloudflare:workers', () => ({
+  env: {
+    AI_GATEWAY_ACCOUNT_ID: 'test-account',
+    AI_GATEWAY_ID: 'test-gateway',
+    AI_GATEWAY_API_TOKEN: 'test-only-gateway-secret',
+    PUBLIC_BASE_URL: 'https://turbodiff.test',
+  },
+}));
+vi.mock('../../data/models.ts', () => ({ resolveRunnerModel: boundary.resolveRunnerModel }));
+vi.mock('../../data/db.ts', () => ({
+  getPlan: async () => boundary.plan,
+  listReposForPlan: async () =>
+    Array.from({ length: boundary.repositories }, (_, i) => ({
+      ...boundary.repo,
+      id: i + 1,
+      name: `repo-${i + 1}`,
+    })),
+  updatePlan: boundary.updatePlan,
+  approvePlanFeatures: vi.fn(),
+  getFeature: async () => ({
+    id: 20,
+    repository_id: 1,
+    branch: 'feature-20',
+    pr_number: 7,
+    title: boundary.plan.title,
+    runner_model: boundary.plan.runner_model,
+    acceptance: ['Indicator follows automation state'],
+    acceptance_updated_at: null,
+  }),
+  getRepoById: async () => boundary.repo,
+  createVerification: async () => 30,
+  finishVerification: boundary.finishVerification,
+  latestFixedAttempt: async () => ({
+    trigger: 'cockpit_comment',
+    created_at: '2026-09-09T19:00:00Z',
+  }),
+  setFeatureCriteriaConflict: vi.fn(),
+  listCockpitComments: async () => [
+    { path: 'indicator.tsx', line: 10, body: 'Include manual tasks.' },
+  ],
+  setProposedAcceptance: boundary.setProposedAcceptance,
+}));
+vi.mock('../runtime/sandbox.ts', () => {
+  const sandbox = {
+    exec: boundary.exec,
+    writeFile: async (path: string, content: string) => {
+      boundary.files.set(path, content);
+    },
+    readFile: async (path: string) => {
+      const content = boundary.files.get(path);
+      if (content === undefined) throw new Error('File not found');
+      return { content };
+    },
+  };
+  return { runnerSandbox: () => sandbox, generationSandbox: () => sandbox };
+});
+vi.mock('../runtime/agent-runs.ts', () => ({ persistAgentLog: vi.fn() }));
+vi.mock('../runtime/repository-workspace.ts', () => ({ prepareCachedWorktree: vi.fn() }));
+vi.mock('../../integrations/github/app.ts', () => ({ installationToken: vi.fn() }));
+vi.mock('../../integrations/github/client.ts', () => ({ githubRequest: vi.fn() }));
+vi.mock('../../integrations/git/provider.ts', () => ({
+  resolveWorkspaceRemote: async () => ({
+    token: 'test-repo-token',
+    configFlags: '',
+    authUrl: 'https://git.test/repo',
+    cleanUrl: 'https://git.test/repo',
+    env: {},
+  }),
+}));
+vi.mock('../../services/push-notifications.ts', () => ({ notifyPlanUsers: vi.fn() }));
+vi.mock('../../services/auto-merge.ts', () => ({ maybeAutoMerge: vi.fn() }));
+vi.mock('../../services/merge-conflicts.ts', () => ({ maybeResolveConflict: vi.fn() }));
+vi.mock('../../services/change-requests.ts', () => ({
+  CR_BOT_AUTHOR: 'test-bot',
+  maybeAutoMergeCr: vi.fn(),
+}));
+vi.mock('../../services/factory-queue.ts', () => ({ enqueueFactoryMessage: vi.fn() }));
+vi.mock('../../services/certificates.ts', () => ({ certificateUrl: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  boundary.files.clear();
+  boundary.runs.length = 0;
+  boundary.tier = 'trivial';
+  boundary.omitTier = false;
+  boundary.questions = '[]';
+  boundary.repositories = 1;
+  boundary.plan.tier = '';
+  boundary.exec.mockImplementation(async (command: string, options?: ExecOptions) => {
+    if (command.startsWith('opencode run ')) {
+      const env = options?.env ?? {};
+      const prompt = boundary.files.get(env.TURBODIFF_AGENT_PROMPT ?? '') ?? '';
+      boundary.runs.push({ prompt, env });
+      if (env.TURBODIFF_AGENT_PROMPT === '/workspace/plan-out/task.md') {
+        boundary.files.set('/workspace/plan-out/analysis.md', 'Update the running-state selector.');
+        boundary.files.set('/workspace/plan-out/questions.json', boundary.questions);
+        if (!boundary.omitTier) boundary.files.set('/workspace/plan-out/tier.txt', boundary.tier);
+        boundary.files.set(
+          '/workspace/plan-out/plan.md',
+          'Update the selector and verify manual task states.',
+        );
+        boundary.files.set(
+          '/workspace/plan-out/acceptance.json',
+          '["Manual tasks activate the indicator"]',
+        );
+      } else if (env.TURBODIFF_AGENT_PROMPT === '/workspace/verify-out-20/task.md') {
+        boundary.files.set(
+          '/workspace/verify-out-20/results.json',
+          '[{"index":0,"verdict":"fail","note":"Manual tasks now activate the indicator too"}]',
+        );
+      } else if (env.TURBODIFF_AGENT_PROMPT === '/workspace/criteria-prompt-20.md') {
+        boundary.files.set(
+          '/workspace/criteria-proposal-20.json',
+          '["Indicator follows automations and manual tasks"]',
+        );
+      }
+    }
+    return { success: true, exitCode: 0, stdout: '', stderr: '' };
+  });
+});
+
+async function expectSelectedModelOnEveryRun(count: number) {
+  expect(boundary.runs).toHaveLength(count);
+  expect(boundary.resolveRunnerModel).not.toHaveBeenCalled();
+  for (const { env } of boundary.runs) {
+    expect(env.TURBODIFF_RUNNER_MODEL).toBe('cloudflare-ai-gateway/moonshotai/kimi-k3');
+    expect(
+      await verifyAiGatewayGrantWithSecret(
+        'test-only-gateway-secret',
+        env.TURBODIFF_AI_GATEWAY_GRANT ?? '',
+      ),
+    ).toMatchObject({ model: 'moonshotai/kimi-k3' });
+  }
+}
+
+describe('task model across planning and verification', () => {
+  it.each([1, 2])(
+    'analyzes and plans %i repositories with the selected model and no preliminary agent',
+    async (repositories) => {
+      boundary.repositories = repositories;
+      await runPlanAnalyze(10);
+
+      await expectSelectedModelOnEveryRun(2);
+      expect(boundary.runs[0].prompt).toContain('/workspace/plan-out/tier.txt');
+      expect(boundary.runs[0].prompt).toContain('exactly one word: trivial or standard');
+      expect(boundary.updatePlan).toHaveBeenCalledWith(10, { tier: 'trivial' });
+      expect(boundary.runs[1].prompt).toContain('at most 4');
+      expect(boundary.updatePlan).toHaveBeenCalledWith(
+        10,
+        expect.objectContaining({
+          status: 'plan_ready',
+          acceptance: ['Manual tasks activate the indicator'],
+        }),
+      );
+    },
+  );
+
+  it.each([undefined, 'not trivial', 'trivial\nstandard'])(
+    'keeps full planning depth for missing or ambiguous classification: %s',
+    async (tier) => {
+      boundary.tier = tier ?? '';
+      boundary.omitTier = tier === undefined;
+      await runPlanAnalyze(10);
+
+      await expectSelectedModelOnEveryRun(2);
+      expect(boundary.updatePlan).toHaveBeenCalledWith(10, { tier: 'standard' });
+      expect(boundary.runs[1].prompt).toContain('at most 8');
+    },
+  );
+
+  it('persists the tier while waiting for answers and uses it on the selected-model refinement', async () => {
+    boundary.questions = '[{"text":"Which task states should count?"}]';
+    await runPlanAnalyze(10);
+    await expectSelectedModelOnEveryRun(1);
+    expect(boundary.updatePlan).toHaveBeenCalledWith(
+      10,
+      expect.objectContaining({ status: 'awaiting_answers' }),
+    );
+    expect(boundary.updatePlan).toHaveBeenCalledWith(10, { tier: 'trivial' });
+
+    boundary.plan.tier = 'trivial';
+    await runPlanRefine(10);
+    await expectSelectedModelOnEveryRun(2);
+    expect(boundary.runs[1].prompt).toContain('at most 4');
+    expect(boundary.updatePlan).toHaveBeenLastCalledWith(
+      10,
+      expect.objectContaining({ status: 'plan_ready' }),
+    );
+  });
+
+  it('keeps the selected model when a human-directed fix requires a criteria rewrite', async () => {
+    await runVerification(20);
+
+    await expectSelectedModelOnEveryRun(2);
+    expect(boundary.setProposedAcceptance).toHaveBeenCalledWith(20, [
+      'Indicator follows automations and manual tasks',
+    ]);
+    expect(boundary.finishVerification).toHaveBeenCalledWith(
+      30,
+      'failed',
+      expect.objectContaining({
+        results: [expect.objectContaining({ index: 0, verdict: 'fail' })],
+      }),
+    );
+  });
+});

--- a/src/ai/runners/task-model.test.ts
+++ b/src/ai/runners/task-model.test.ts
@@ -1,7 +1,7 @@
 import type { ExecOptions } from '@cloudflare/sandbox';
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { verifyAiGatewayGrantWithSecret } from '../../integrations/security/ai-gateway-grant.ts';
-import { runPlanAnalyze, runPlanRefine } from './planner.ts';
+import { runPlanAnalyze } from './planner.ts';
 import { runVerification } from './verifier.ts';
 
 // Runner contract tests: orchestration, OpenCode command/config generation and
@@ -13,19 +13,12 @@ const boundary = vi.hoisted(() => {
     files: new Map<string, string>(),
     runs,
     tier: 'trivial',
-    omitTier: false,
-    questions: '[]',
-    repositories: 1,
     plan: {
       id: 10,
       repository_id: 1,
       title: 'Show running tasks in the factory indicator',
       requirements: 'Include manual tasks in the existing running indicator.',
       runner_model: 'moonshotai/kimi-k3',
-      tier: '',
-      feedback: null,
-      questions: [],
-      answers: [],
       attachments: [],
     },
     repo: {
@@ -42,7 +35,6 @@ const boundary = vi.hoisted(() => {
       auto_fix: true,
     },
     updatePlan: vi.fn(),
-    finishVerification: vi.fn(),
     setProposedAcceptance: vi.fn(),
     resolveRunnerModel: vi.fn(async () => 'anthropic/claude-opus-4.8'),
     exec: vi.fn(),
@@ -61,12 +53,7 @@ vi.mock('cloudflare:workers', () => ({
 vi.mock('../../data/models.ts', () => ({ resolveRunnerModel: boundary.resolveRunnerModel }));
 vi.mock('../../data/db.ts', () => ({
   getPlan: async () => boundary.plan,
-  listReposForPlan: async () =>
-    Array.from({ length: boundary.repositories }, (_, i) => ({
-      ...boundary.repo,
-      id: i + 1,
-      name: `repo-${i + 1}`,
-    })),
+  listReposForPlan: async () => [boundary.repo],
   updatePlan: boundary.updatePlan,
   approvePlanFeatures: vi.fn(),
   getFeature: async () => ({
@@ -81,7 +68,7 @@ vi.mock('../../data/db.ts', () => ({
   }),
   getRepoById: async () => boundary.repo,
   createVerification: async () => 30,
-  finishVerification: boundary.finishVerification,
+  finishVerification: vi.fn(),
   latestFixedAttempt: async () => ({
     trigger: 'cockpit_comment',
     created_at: '2026-09-09T19:00:00Z',
@@ -134,11 +121,6 @@ beforeEach(() => {
   boundary.files.clear();
   boundary.runs.length = 0;
   boundary.tier = 'trivial';
-  boundary.omitTier = false;
-  boundary.questions = '[]';
-  boundary.repositories = 1;
-  boundary.plan.tier = '';
-  boundary.plan.runner_model = 'moonshotai/kimi-k3';
   boundary.exec.mockImplementation(async (command: string, options?: ExecOptions) => {
     if (command.startsWith('opencode run ')) {
       const env = options?.env ?? {};
@@ -146,8 +128,8 @@ beforeEach(() => {
       boundary.runs.push({ command, prompt, env });
       if (env.TURBODIFF_AGENT_PROMPT === '/workspace/plan-out/task.md') {
         boundary.files.set('/workspace/plan-out/analysis.md', 'Update the running-state selector.');
-        boundary.files.set('/workspace/plan-out/questions.json', boundary.questions);
-        if (!boundary.omitTier) boundary.files.set('/workspace/plan-out/tier.txt', boundary.tier);
+        boundary.files.set('/workspace/plan-out/questions.json', '[]');
+        boundary.files.set('/workspace/plan-out/tier.txt', boundary.tier);
         boundary.files.set(
           '/workspace/plan-out/plan.md',
           'Update the selector and verify manual task states.',
@@ -200,75 +182,36 @@ async function expectRunModels(models: string[]) {
 }
 
 describe('task model across planning and verification', () => {
-  it.each([1, 2])(
-    'analyzes and plans %i repositories with the selected model and no preliminary agent',
-    async (repositories) => {
-      boundary.repositories = repositories;
-      await runPlanAnalyze(10);
-
-      await expectRunModels([boundary.plan.runner_model, boundary.plan.runner_model]);
-      expect(boundary.runs[0].prompt).toContain('/workspace/plan-out/tier.txt');
-      expect(boundary.runs[0].prompt).toContain('exactly one word: trivial or standard');
-      expect(boundary.updatePlan).toHaveBeenCalledWith(10, { tier: 'trivial' });
-      expect(boundary.runs[1].prompt).toContain('at most 4');
-      expect(boundary.updatePlan).toHaveBeenCalledWith(
-        10,
-        expect.objectContaining({
-          status: 'plan_ready',
-          acceptance: ['Manual tasks activate the indicator'],
-        }),
-      );
-    },
-  );
-
-  it.each([undefined, 'not trivial', 'trivial\nstandard'])(
-    'keeps full planning depth for missing or ambiguous classification: %s',
-    async (tier) => {
-      boundary.tier = tier ?? '';
-      boundary.omitTier = tier === undefined;
-      await runPlanAnalyze(10);
-
-      await expectRunModels([boundary.plan.runner_model, boundary.plan.runner_model]);
-      expect(boundary.updatePlan).toHaveBeenCalledWith(10, { tier: 'standard' });
-      expect(boundary.runs[1].prompt).toContain('at most 8');
-    },
-  );
-
-  it('requests tier persistence and honors a model change when refinement starts', async () => {
-    boundary.questions = '[{"text":"Which task states should count?"}]';
+  it('plans with the selected model without a separate classifier session', async () => {
     await runPlanAnalyze(10);
-    await expectRunModels([boundary.plan.runner_model]);
+
+    await expectRunModels(['moonshotai/kimi-k3', 'moonshotai/kimi-k3']);
+    expect(boundary.runs[0].prompt).toContain('/workspace/plan-out/tier.txt');
+    expect(boundary.updatePlan).toHaveBeenCalledWith(10, { tier: 'trivial' });
+    expect(boundary.runs[1].prompt).toContain('at most 4');
     expect(boundary.updatePlan).toHaveBeenCalledWith(
       10,
-      expect.objectContaining({ status: 'awaiting_answers' }),
-    );
-    expect(boundary.updatePlan).toHaveBeenCalledWith(10, { tier: 'trivial' });
-
-    // Emulate the persisted tier and a user changing the model before the next run.
-    boundary.plan.tier = 'trivial';
-    boundary.plan.runner_model = 'openai/gpt-5.2-codex';
-    await runPlanRefine(10);
-    await expectRunModels(['moonshotai/kimi-k3', 'openai/gpt-5.2-codex']);
-    expect(boundary.runs[1].prompt).toContain('at most 4');
-    expect(boundary.updatePlan).toHaveBeenLastCalledWith(
-      10,
-      expect.objectContaining({ status: 'plan_ready' }),
+      expect.objectContaining({
+        status: 'plan_ready',
+        acceptance: ['Manual tasks activate the indicator'],
+      }),
     );
   });
 
-  it('keeps the selected model when a human-directed fix requires a criteria rewrite', async () => {
+  it('does not shorten the plan when classification says "not trivial"', async () => {
+    boundary.tier = 'not trivial';
+    await runPlanAnalyze(10);
+
+    expect(boundary.updatePlan).toHaveBeenCalledWith(10, { tier: 'standard' });
+    expect(boundary.runs[1].prompt).toContain('at most 8');
+  });
+
+  it('uses the selected model for criteria rewrites after a human-directed fix', async () => {
     await runVerification(20);
 
-    await expectRunModels([boundary.plan.runner_model, boundary.plan.runner_model]);
+    await expectRunModels(['moonshotai/kimi-k3', 'moonshotai/kimi-k3']);
     expect(boundary.setProposedAcceptance).toHaveBeenCalledWith(20, [
       'Indicator follows automations and manual tasks',
     ]);
-    expect(boundary.finishVerification).toHaveBeenCalledWith(
-      30,
-      'failed',
-      expect.objectContaining({
-        results: [expect.objectContaining({ index: 0, verdict: 'fail' })],
-      }),
-    );
   });
 });

--- a/src/ai/runners/verifier.ts
+++ b/src/ai/runners/verifier.ts
@@ -43,7 +43,6 @@ import { installationToken } from '../../integrations/github/app.ts';
 import { resolveWorkspaceRemote } from '../../integrations/git/provider.ts';
 import { NPM_CACHE_ENV } from '../runtime/sandbox-deps.ts';
 import { UNTRUSTED_CONTENT_RULES } from '../../domain/prompt-security.ts';
-import { resolveRunnerModel } from '../../data/models.ts';
 
 // Phase 4 (docs/software-factory-design.md): empirical verification of factory
 // PRs, doubling as the spec-conformance gate. A verifier agent checks each
@@ -602,7 +601,7 @@ that conflict; each criterion must be empirically checkable against the
 running app. Write ONLY a JSON array of criterion strings to ${PROPOSAL_FILE}.
 `;
   await sandbox.writeFile(`/workspace/criteria-prompt-${feature.id}.md`, prompt);
-  const auth = await resolveRunnerAuth(undefined, await resolveRunnerModel(null, 'fast'));
+  const auth = await resolveRunnerAuth(undefined, feature.runner_model);
   const run = await runCodingAgent(sandbox, auth, {
     promptFile: `/workspace/criteria-prompt-${feature.id}.md`,
     cwd: '/workspace',


### PR DESCRIPTION
A task saved with Kimi K3 still sent Opus requests before planning because tier classification ignored the task model and used the catalog's fast default. That classifier also launched a full OpenCode session, allowing repository exploration and retries before the selected-model planning stage started.

Remove the separate classifier and have the existing analysis stage write `tier.txt` alongside its analysis and questions. Both single- and multi-repository tasks now classify and plan using the task's saved model, without an extra agent session. Only an exact `trivial` result enables the shorter plan; absent or ambiguous output keeps standard planning depth. Persist the tier for later refinement. Criteria rewrites after human-directed fixes now also use the feature's saved model instead of the fast default.

Validation:
- Three focused runner contract tests cover selected-model planning without a separate classifier, conservative handling of negated classification, and selected-model criteria rewrites.
- Each retained scenario catches a distinct deliberate defect: default-model substitution during planning, treating "not trivial" as trivial, or default-model substitution during criteria rewriting.
- 318 tests pass. All three TypeScript programs, lint, changed-file formatting, and the production build passed during implementation; tests, Worker typecheck, lint and formatting were rerun after reducing the tests. Existing lint and bundle-size warnings remain.
- Sandbox execution, database reads/writes, and supporting service effects are faked. The runners, CLI command/configuration generation, and signed model capabilities execute. These tests do not prove real CLI behavior, SQL persistence, or Cloudflare/provider acceptance. No live model requests or production mutations were used for validation.

This addresses unexpected model usage and removes unnecessary classification calls. Cloudflare's wholesale 429s remain a separate issue; this PR does not change account limits or billing settings.
