### PR TITLE
Fix planning timeouts that discard successful agent runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Unit tests
         run: pnpm test
 
+      - name: Runner process lifecycle (real Linux processes)
+        run: pnpm vp run test:runner
+
       - name: Validate Drizzle migrations
         run: pnpm vp run db:check
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Unit tests
         run: pnpm test
 
+      - name: Runner process lifecycle (real Linux processes)
+        run: pnpm vp run test:runner
+
       - name: Validate Drizzle migrations
         run: pnpm vp run db:check
 

--- a/docs/coding-harness.md
+++ b/docs/coding-harness.md
@@ -94,6 +94,29 @@ or provider configuration independently. The command contract is
 OpenCode config and plugins are disabled, while `AGENTS.md` instructions and
 mounted skills remain available.
 
+## Planning process lifetime
+
+Planning queue deliveries start `PlanningWorkflow` instead of running the agent
+inside the queue consumer's 15-minute wall clock. A delivery ID identifies one
+Workflow instance, so redelivery does not start another paid run. The paid step
+has no automatic retries; the task remains available for an explicit retry after
+failure.
+
+Each planning stage uses `startProcess` and waits for its exit, then saves the
+output and full OpenCode transcript. A GNU `timeout` supervisor inside the Linux
+container enforces a 30-minute limit and stops the process group, even if the
+Worker disappears. A monitoring error explicitly stops the process before
+returning a failed result. The Workflow's 75-minute budget covers analysis,
+optional immediate planning, and repository setup. The sandbox stays awake for
+45 minutes between requests. This replaces an eight-minute SDK `exec` timeout
+that abandoned the result while the agent continued running.
+
+Run `vp run test:runner` on Linux to test completion, deadline enforcement and
+cancellation using real subprocesses, without model calls. CI runs these tests;
+on macOS they can also run in the existing Linux sandbox image with the repository
+mounted read-only and networking disabled. They test the process supervisor, not
+Cloudflare's remote Sandbox transport or the live model provider.
+
 ## Performance and reliability choices
 
 - OpenCode is installed once in the sandbox image, not downloaded during a

--- a/scripts/managed-command.test.mjs
+++ b/scripts/managed-command.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { runManagedCommand } from '../src/ai/runtime/managed-command.ts';
+
+// Run on Linux (the production sandbox OS). Only the Sandbox transport is
+// replaced with spawn; shell quoting, GNU timeout, signals and output are real.
+// No model API, Cloudflare account or production credentials are used.
+function localSandbox({ interruptMonitor = false } = {}) {
+  return {
+    async startProcess(command, options) {
+      const child = spawn('/bin/sh', ['-c', command], {
+        cwd: options.cwd,
+        env: { ...process.env, ...options.env },
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (data) => {
+        stdout += data;
+      });
+      child.stderr.on('data', (data) => {
+        stderr += data;
+      });
+      const done = new Promise((resolve, reject) => {
+        child.once('error', reject);
+        child.once('close', (exitCode) => resolve({ exitCode: exitCode ?? 137 }));
+      });
+      return {
+        async waitForExit(timeout) {
+          if (interruptMonitor) {
+            interruptMonitor = false;
+            // Wait until the child has started so cancellation tests a live process.
+            while (!stdout.includes('started'))
+              await new Promise((resolve) => setTimeout(resolve, 10));
+            throw new Error('simulated transport disconnect');
+          }
+          let timer;
+          try {
+            return await Promise.race([
+              done,
+              new Promise((_, reject) => {
+                timer = setTimeout(() => reject(new Error('waiter expired')), timeout);
+              }),
+            ]);
+          } finally {
+            clearTimeout(timer);
+          }
+        },
+        async kill(signal) {
+          child.kill(signal);
+        },
+        async getLogs() {
+          return { stdout, stderr };
+        },
+      };
+    },
+  };
+}
+
+await test('collects delayed successful output and preserves command quoting and model environment', async () => {
+  const result = await runManagedCommand(
+    localSandbox(),
+    `printf '%s\\n' "$MODEL"; sleep 0.2; printf 'plan complete\\n'; printf 'diagnostic\\n' >&2`,
+    { timeout: 2_000, env: { MODEL: 'provider/selected-model' } },
+  );
+  assert.equal(result.success, true);
+  assert.equal(result.stdout, 'provider/selected-model\nplan complete\n');
+  assert.equal(result.stderr, 'diagnostic\n');
+});
+
+await test('deadline stops the child process group and returns partial output', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'turbodiff-deadline-'));
+  try {
+    const result = await runManagedCommand(
+      localSandbox(),
+      `printf 'started\\n'; (sleep 0.8; touch "$MARKER") & wait`,
+      { timeout: 150, env: { MARKER: path.join(dir, 'orphan') } },
+    );
+    assert.equal(result.success, false);
+    assert.equal(result.exitCode, 124);
+    assert.equal(result.stdout, 'started\n');
+    assert.match(result.stderr, /execution limit and was stopped/);
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    await assert.rejects(readFile(path.join(dir, 'orphan')), { code: 'ENOENT' });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+await test('monitoring failure stops real descendants before returning the partial log', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'turbodiff-disconnect-'));
+  try {
+    const result = await runManagedCommand(
+      localSandbox({ interruptMonitor: true }),
+      `printf 'started\\n'; (sleep 0.8; touch "$MARKER") & wait`,
+      { timeout: 5_000, env: { MARKER: path.join(dir, 'orphan') } },
+    );
+    assert.equal(result.success, false);
+    assert.equal(result.stdout, 'started\n');
+    assert.match(result.stderr, /simulated transport disconnect/);
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    await assert.rejects(readFile(path.join(dir, 'orphan')), { code: 'ENOENT' });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/src/ai/runners/planner.ts
+++ b/src/ai/runners/planner.ts
@@ -14,6 +14,7 @@ import {
 } from '../../data/db.ts';
 import { persistAgentLog } from '../runtime/agent-runs.ts';
 import { runCodingAgent } from '../runtime/coding-agent.ts';
+import { runManagedCommand } from '../runtime/managed-command.ts';
 import { resolveRunnerAuth } from '../runtime/runner-auth.ts';
 import { runnerSandbox } from '../runtime/sandbox.ts';
 import { redactSecrets } from '../runtime/redaction.ts';
@@ -30,7 +31,8 @@ import { notifyPlanUsers } from '../../services/push-notifications.ts';
 
 const CLONE_DIR = '/workspace/plan-repo';
 const OUT_DIR = '/workspace/plan-out';
-const AGENT_TIMEOUT_MS = 8 * 60_000;
+// Each stage has a container-enforced deadline; the Workflow covers both stages.
+const AGENT_TIMEOUT_MS = 30 * 60_000;
 
 // Boot one read-only sandbox for the whole plan (not one per repo — a
 // multi-repo task is designed as a single coherent feature) and clone every
@@ -49,7 +51,7 @@ async function clonePlanRepos(
   const tokens: string[] = [];
   const scrub = (s: string) => redactSecrets(s, tokens);
 
-  const sandbox = runnerSandbox(`plan--${planId}`, { sleepAfter: '10m' });
+  const sandbox = runnerSandbox(`plan--${planId}`, { sleepAfter: '45m' });
   await sandbox.exec(`rm -rf ${CLONE_DIR} ${OUT_DIR} && mkdir -p ${OUT_DIR}`);
 
   const dirs: { repo: RepositoryRow; dir: string; cleanUrl: string }[] = [];
@@ -155,17 +157,27 @@ async function runAgent(
   const auth = await resolveRunnerAuth(undefined, model);
   const scrubRun = (value: string) => redactSecrets(scrub(value), Object.values(auth.vars));
   await sandbox.writeFile(`${OUT_DIR}/task.md`, prompt);
-  const res = await runCodingAgent(sandbox, auth, {
-    promptFile: `${OUT_DIR}/task.md`,
-    cwd: CLONE_DIR,
-    timeout: AGENT_TIMEOUT_MS,
-  });
-  await persistAgentLog(kind, scrubRun(`${res.resultText}\n${res.stderr}`.trim()), res.success, {
-    planId,
-  });
+  const res = await runCodingAgent(
+    { exec: (command, options) => runManagedCommand(sandbox, command, options) },
+    auth,
+    {
+      promptFile: `${OUT_DIR}/task.md`,
+      cwd: CLONE_DIR,
+      timeout: AGENT_TIMEOUT_MS,
+    },
+  );
+  await persistAgentLog(
+    kind,
+    scrubRun(`${res.resultText}\n${res.stderr}`.trim()),
+    res.success,
+    {
+      planId,
+    },
+    scrubRun(res.stdout),
+  );
   if (!res.success) {
     throw new Error(
-      `planning agent exited ${res.exitCode}: ${scrubRun(`${res.stdout}\n${res.stderr}`).trim().slice(-1_000)}`,
+      `planning agent exited ${res.exitCode}: ${scrubRun(`${res.stderr}\n${res.resultText}`).trim().slice(0, 1_000)}`,
     );
   }
 }

--- a/src/ai/runners/task-model.test.ts
+++ b/src/ai/runners/task-model.test.ts
@@ -82,6 +82,13 @@ vi.mock('../../data/db.ts', () => ({
 vi.mock('../runtime/sandbox.ts', () => {
   const sandbox = {
     exec: boundary.exec,
+    startProcess: async (command: string, options: ExecOptions) => {
+      const result = await boundary.exec(command, options);
+      return {
+        waitForExit: async () => ({ exitCode: result.exitCode }),
+        getLogs: async () => ({ stdout: result.stdout, stderr: result.stderr }),
+      };
+    },
     writeFile: async (path: string, content: string) => {
       boundary.files.set(path, content);
     },
@@ -122,7 +129,7 @@ beforeEach(() => {
   boundary.runs.length = 0;
   boundary.tier = 'trivial';
   boundary.exec.mockImplementation(async (command: string, options?: ExecOptions) => {
-    if (command.startsWith('opencode run ')) {
+    if (command.includes('opencode run ')) {
       const env = options?.env ?? {};
       const prompt = boundary.files.get(env.TURBODIFF_AGENT_PROMPT ?? '') ?? '';
       boundary.runs.push({ command, prompt, env });

--- a/src/ai/runtime/managed-command.ts
+++ b/src/ai/runtime/managed-command.ts
@@ -1,0 +1,64 @@
+import type { ExecOptions, ExecResult, Process, ProcessOptions } from '@cloudflare/sandbox';
+
+// One external boundary: the sandbox process API. Keeping command supervision
+// independent of Workers lets us exercise it with actual Linux subprocesses.
+export interface ManagedCommandSandbox {
+  startProcess(
+    command: string,
+    options: ProcessOptions,
+  ): Promise<Pick<Process, 'waitForExit' | 'kill' | 'getLogs'>>;
+}
+
+export async function runManagedCommand(
+  sandbox: ManagedCommandSandbox,
+  command: string,
+  options: ExecOptions = {},
+): Promise<ExecResult> {
+  const timeoutMs = options.timeout;
+  if (!timeoutMs || !Number.isSafeInteger(timeoutMs) || timeoutMs < 1) {
+    throw new Error('managed commands require a positive timeout');
+  }
+  const started = Date.now();
+  // exec makes the tracked PID the supervisor, not an intermediate shell.
+  // GNU timeout supervises the whole process group inside the Linux container,
+  // even if the Worker disappears. SDK exec/wait timeouts alone do not kill it.
+  // The command is trusted harness code; shell quoting also preserves embedded
+  // quotes and leaves environment-variable expansion to the inner shell.
+  const quoted = `'${command.replace(/'/g, `'"'"'`)}'`;
+  const process = await sandbox.startProcess(
+    `exec timeout --signal=TERM --kill-after=10s ${timeoutMs / 1000}s sh -c ${quoted}`,
+    { cwd: options.cwd, env: options.env, autoCleanup: false },
+  );
+  let exitCode: number;
+  let failure = '';
+  try {
+    // Let the container enforce the deadline, then collect the actual exit and
+    // buffered output. The extra allowance covers TERM/KILL and transport lag.
+    ({ exitCode } = await process.waitForExit(timeoutMs + 30_000));
+  } catch (error) {
+    failure = `Agent process monitoring failed: ${error instanceof Error ? error.message : String(error)}`;
+    // Never return a failed run while knowingly leaving its agent running.
+    // TERM is forwarded by GNU timeout to its child process group.
+    await process.kill('SIGTERM');
+    try {
+      await process.waitForExit(15_000);
+    } catch {
+      await process.kill('SIGKILL');
+      await process.waitForExit(5_000);
+    }
+    exitCode = 1;
+  }
+  const logs = await process.getLogs();
+  if ((exitCode === 124 || exitCode === 137) && Date.now() - started >= timeoutMs) {
+    failure = `Agent exceeded the ${timeoutMs / 60_000}-minute execution limit and was stopped.`;
+  }
+  return {
+    ...logs,
+    stderr: [failure, logs.stderr].filter(Boolean).join('\n'),
+    success: exitCode === 0,
+    exitCode,
+    command,
+    duration: Date.now() - started,
+    timestamp: new Date(started).toISOString(),
+  };
+}

--- a/src/ai/workflows/planning.ts
+++ b/src/ai/workflows/planning.ts
@@ -1,0 +1,50 @@
+import { env, WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from 'cloudflare:workers';
+import { getPlan, updatePlan } from '../../data/db.ts';
+import { runPlanAnalyze, runPlanRefine } from '../runners/planner.ts';
+import { notifyPlanLive } from '../../services/live-updates.ts';
+import type { PlanQueueMessage } from '../../shared/factory-messages.ts';
+
+// Planning can run analysis and synthesis back-to-back. It must not inherit
+// the queue consumer's 15-minute wall clock. Paid work is not auto-retried:
+// a failed attempt remains visible for an explicit user retry.
+export class PlanningWorkflow extends WorkflowEntrypoint<unknown, PlanQueueMessage> {
+  async run(event: WorkflowEvent<PlanQueueMessage>, step: WorkflowStep): Promise<void> {
+    const { planId, kind } = event.payload;
+    try {
+      await step.do(
+        'run planning',
+        { retries: { limit: 0, delay: '1 second' }, timeout: '75 minutes' },
+        async () => {
+          const plan = await getPlan(planId);
+          const expected = kind === 'plan_analyze' ? 'analyzing' : 'refining';
+          if (!plan || plan.status !== expected) return;
+          if (kind === 'plan_analyze') await runPlanAnalyze(planId);
+          else await runPlanRefine(planId);
+        },
+      );
+    } catch (error) {
+      await step.do('record planning failure', async () => {
+        const plan = await getPlan(planId);
+        if (plan && (plan.status === 'analyzing' || plan.status === 'refining')) {
+          await updatePlan(planId, {
+            status: 'failed',
+            error:
+              `Planning workflow failed: ${error instanceof Error ? error.message : String(error)}`.slice(
+                0,
+                500,
+              ),
+          });
+        }
+      });
+    }
+    await step.do('notify planning result', () => notifyPlanLive(planId));
+  }
+}
+
+export async function startPlanning(message: PlanQueueMessage, deliveryId: string): Promise<void> {
+  // createBatch is idempotent for existing instance IDs. Queue redelivery must
+  // not start a second paid agent or clear the active planner's workspace.
+  await env.PLAN_WORKFLOW.createBatch([
+    { id: `plan-${message.planId}-${deliveryId}`, params: message },
+  ]);
+}

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -19,11 +19,10 @@ import type { FactoryMessage } from './shared/factory-messages.ts';
 import { startGeneration } from './ai/workflows/generation.ts';
 import { failStrandedGeneration, failStrandedVerifications } from './data/factory.ts';
 import { sweepFactoryPrConflicts } from './services/merge-conflicts.ts';
-import { runPlanAnalyze, runPlanRefine } from './ai/runners/planner.ts';
+import { startPlanning, PlanningWorkflow } from './ai/workflows/planning.ts';
 import { dispatchNativeCrReviews } from './ai/review/native-dispatch.ts';
 import { mergeNativeChangeRequest, runQueuedCrMerge } from './services/change-requests.ts';
 import { startVerification, VerificationWorkflow } from './ai/workflows/verification.ts';
-import { notifyPlanLive } from './services/live-updates.ts';
 import { withDatabaseScope } from './data/database.ts';
 import { runLifecycleStage, scheduleFeatureDelivery } from './services/lifecycle.ts';
 import { dispatchReviewAgent } from './ai/review/dispatch.ts';
@@ -41,6 +40,7 @@ export { GenerationWorkflow } from './ai/workflows/generation.ts';
 // `triggers.events` entries in wrangler.jsonc (docs/artifacts-provider.md).
 export { ArtifactsEventsWorkflow } from './ai/workflows/artifacts-events.ts';
 export { VerificationWorkflow };
+export { PlanningWorkflow };
 export { FixWorkflow };
 export { ChatWorkflow };
 export { AutomationWorkflow };
@@ -72,12 +72,8 @@ export default {
             }
             break;
           case 'plan_analyze':
-            await runPlanAnalyze(body.planId);
-            await notifyPlanLive(body.planId);
-            break;
           case 'plan_refine':
-            await runPlanRefine(body.planId);
-            await notifyPlanLive(body.planId);
+            await startPlanning(body, message.id);
             break;
           case 'verify':
             // Just creates a durable workflow instance — verify runs exceed

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -94,6 +94,7 @@ export default defineConfig({
         dependsOn: ['db:migrate'],
         cache: false,
       },
+      'test:runner': { command: 'node --test scripts/managed-command.test.mjs', cache: false },
       'test:schema': { command: 'node scripts/db-schema-test.mjs' },
       'test:worker': {
         command: 'vp test --config vitest.worker.config.ts',

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -74,6 +74,11 @@
   // silently re-run. The queue message only creates the instance.
   "workflows": [
     {
+      "binding": "PLAN_WORKFLOW",
+      "name": "turbodiff-planning",
+      "class_name": "PlanningWorkflow",
+    },
+    {
       "binding": "GEN_WORKFLOW",
       "name": "turbodiff-generation",
       "class_name": "GenerationWorkflow",


### PR DESCRIPTION
Planning discarded working agents after eight minutes. On task 11, all 45 GPT Sol gateway calls succeeded, but Turbodiff marked the task failed at 21:05:18 UTC; the same agent reported completing the plan at 21:06:24 UTC. The Sandbox exec timeout stopped waiting without stopping the underlying process.

This moves planning into a Workflow so it can outlive the queue consumer’s 15-minute limit. Each stage now runs as a managed background process with a 30-minute container-enforced deadline. Successful completion saves the result and full redacted transcript; deadline or monitoring failure stops the process and retains available diagnostics. Queue redelivery uses an idempotent Workflow instance ID, and paid planning has no automatic retries.

Validation:
- 318 existing unit tests pass; typechecks, lint, production build and Wrangler deployment dry run pass.
- Three focused tests run actual Linux subprocesses with networking disabled: delayed completion/output, deadline termination of descendants, and cancellation after a monitoring failure.
- Mutation checks confirm removing deadline enforcement or explicit cancellation makes the relevant test fail.

The process tests exercise the real shell, GNU timeout and signals through a local transport adapter. They do not exercise Cloudflare’s remote Sandbox transport or a live model call. Deployment must include the new PLAN_WORKFLOW binding; this PR has not been deployed and does not recover previously failed tasks.
