### PR TITLE
Prevent repeated planner research and subagent retry fan-out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Unit tests
         run: pnpm test
 
+      - name: Planning runtime (pinned OpenCode)
+        run: pnpm vp run test:planning
+
       - name: Validate Drizzle migrations
         run: pnpm vp run db:check
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Unit tests
         run: pnpm test
 
+      - name: Planning runtime (pinned OpenCode)
+        run: pnpm vp run test:planning
+
       - name: Validate Drizzle migrations
         run: pnpm vp run db:check
 

--- a/docs/coding-harness.md
+++ b/docs/coding-harness.md
@@ -96,6 +96,23 @@ mounted skills remain available.
 
 ## Performance and reliability choices
 
+Planning disables OpenCode's `task` tool through an explicit permission, including
+under `--auto`. This prevents parallel exploration sessions from multiplying
+gateway retries and losing their research on failure. The planner reuses one
+conversation: it exports the completed session to private R2 task data and imports
+it before refinement, so tool results survive a replaced sandbox. Legacy tasks
+without a saved session still start with their recorded analysis. A saved session
+that cannot be imported fails explicitly rather than silently repeating paid work.
+The checkout is refreshed on refinement; the prompt tells the agent to verify
+relevant changed facts and focus on the new answers or feedback. The eight-minute
+agent timeout is unchanged.
+
+`vp run test:planning` runs the pinned OpenCode executable against a local scripted
+Responses provider through the real model-grant proxy. It verifies a 429 retry,
+tool execution, disabled delegation, and context recovery after deleting the CLI's
+local database. Only the provider is scripted; no production resources are used.
+The check does not measure live model speed or guarantee a planning duration.
+
 - OpenCode is installed once in the sandbox image, not downloaded during a
   run. Its version is pinned, and the Sandbox base image exactly matches the
   resolved SDK version.

--- a/scripts/planning-runtime.test.mjs
+++ b/scripts/planning-runtime.test.mjs
@@ -1,0 +1,265 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { createServer } from 'node:http';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { test } from 'node:test';
+import { runCodingAgent } from '../src/ai/runtime/coding-agent.ts';
+import {
+  exportPlanningSession,
+  importPlanningSession,
+  PLANNING_CONFIG,
+} from '../src/ai/runtime/planning-session.ts';
+import { proxyAiGatewayRequest } from '../src/services/ai-gateway-proxy.ts';
+import { createAiGatewayGrant } from '../src/integrations/security/ai-gateway-grant.ts';
+
+const exec = promisify(execFile);
+
+// Only the remote provider is scripted. The pinned OpenCode executable, its
+// tools/session database/retries, our command/config, grant and proxy are real.
+// No production account, credentials, network services or paid inference.
+await test(
+  'planner survives a 429 and a fresh sandbox without delegating or losing research',
+  { timeout: 90_000 },
+  async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'turbodiff-planning-'));
+    const cwd = path.join(root, 'repo');
+    await mkdir(cwd);
+    await writeFile(
+      path.join(cwd, 'evidence.txt'),
+      'Evidence only available from the read tool: amber-7391',
+    );
+    let home = path.join(root, 'first');
+    const sandbox = {
+      async exec(command, options = {}) {
+        const started = Date.now();
+        try {
+          const result = await exec('/bin/sh', ['-c', command], {
+            cwd: options.cwd,
+            env: {
+              ...process.env,
+              XDG_DATA_HOME: home,
+              XDG_CONFIG_HOME: path.join(root, 'config'),
+              XDG_CACHE_HOME: path.join(root, 'cache'),
+              XDG_STATE_HOME: path.join(root, 'state'),
+              ...options.env,
+            },
+            timeout: options.timeout,
+            maxBuffer: 8 * 1024 * 1024,
+          });
+          return {
+            ...result,
+            success: true,
+            exitCode: 0,
+            command,
+            duration: Date.now() - started,
+            timestamp: new Date().toISOString(),
+          };
+        } catch (error) {
+          return {
+            stdout: error.stdout ?? '',
+            stderr: error.stderr ?? '',
+            success: false,
+            exitCode: error.code ?? 1,
+            command,
+            duration: Date.now() - started,
+            timestamp: new Date().toISOString(),
+          };
+        }
+      },
+      writeFile: (file, content) => writeFile(file, content),
+      readFile: async (file) => ({ content: await readFile(file, 'utf8') }),
+    };
+    const model = 'openai/gpt-5.6-sol';
+    const config = {
+      accountId: 'isolated-test',
+      gatewayId: 'isolated-test',
+      apiToken: 'test-only-secret',
+    };
+    const requests = [];
+    let stage = 'analysis';
+    let retryAt;
+    let failure;
+    const upstream = async (_url, init) => {
+      const body = JSON.parse(init.body);
+      requests.push(body);
+      assert.equal(body.model, model);
+      assert.ok(
+        !body.tools.some((tool) => tool.name === 'task'),
+        'delegation must not be offered to the model',
+      );
+      if (requests.length === 1) {
+        retryAt = Date.now();
+        return Response.json(
+          { error: { message: 'Wholesale Rate limited', type: 'rate_limit_error' } },
+          { status: 429, headers: { 'retry-after': '3' } },
+        );
+      }
+      if (requests.length === 2)
+        assert.ok(Date.now() - retryAt >= 2_900, 'Retry-After was ignored');
+      const evidence = body.input.some(
+        (item) =>
+          item.type === 'function_call_output' && String(item.output).includes('amber-7391'),
+      );
+      if (stage === 'refine') {
+        assert.ok(evidence, 'restored session lost the analysis tool result');
+        assert.ok(
+          JSON.stringify(body.input).includes('Grounded analysis complete'),
+          'restored session lost the previous answer',
+        );
+      }
+      const output =
+        stage === 'analysis' && !evidence
+          ? [
+              {
+                type: 'function_call',
+                id: 'fc_evidence',
+                call_id: 'call_evidence',
+                name: 'read',
+                arguments: JSON.stringify({ filePath: path.join(cwd, 'evidence.txt') }),
+              },
+            ]
+          : [
+              {
+                type: 'message',
+                id: `msg_${requests.length}`,
+                role: 'assistant',
+                content: [
+                  {
+                    type: 'output_text',
+                    text:
+                      stage === 'analysis'
+                        ? 'Grounded analysis complete'
+                        : 'Plan uses the preserved evidence',
+                    annotations: [],
+                  },
+                ],
+              },
+            ];
+      const response = {
+        id: `resp_${requests.length}`,
+        object: 'response',
+        created_at: 1,
+        model: 'gpt-5.6-sol',
+        status: 'completed',
+        output,
+        usage: {
+          input_tokens: 100,
+          output_tokens: 10,
+          total_tokens: 110,
+          input_tokens_details: { cached_tokens: 0 },
+        },
+      };
+      const events = [
+        { type: 'response.created', response: { ...response, status: 'in_progress', output: [] } },
+      ];
+      for (const [output_index, item] of output.entries()) {
+        events.push({
+          type: 'response.output_item.added',
+          output_index,
+          item: { ...item, arguments: '', content: [] },
+        });
+        if (item.type === 'function_call') {
+          events.push({
+            type: 'response.function_call_arguments.delta',
+            item_id: item.id,
+            output_index,
+            delta: item.arguments,
+          });
+          events.push({
+            type: 'response.function_call_arguments.done',
+            item_id: item.id,
+            output_index,
+            arguments: item.arguments,
+          });
+        } else
+          events.push({
+            type: 'response.output_text.delta',
+            item_id: item.id,
+            output_index,
+            content_index: 0,
+            delta: item.content[0].text,
+          });
+        events.push({
+          type: 'response.output_item.done',
+          output_index,
+          item: { ...item, status: 'completed' },
+        });
+      }
+      events.push({ type: 'response.completed', response });
+      return new Response(
+        events.map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join(''),
+        { headers: { 'content-type': 'text/event-stream' } },
+      );
+    };
+    const server = createServer(async (req, res) => {
+      try {
+        let body = '';
+        for await (const chunk of req) body += chunk;
+        const response = await proxyAiGatewayRequest(
+          new Request(`http://localhost${req.url}`, {
+            method: req.method,
+            headers: req.headers,
+            body,
+          }),
+          config,
+          upstream,
+        );
+        res.writeHead(response.status, Object.fromEntries(response.headers));
+        res.end(await response.text());
+      } catch (error) {
+        failure = error;
+        res.writeHead(400, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({ error: { message: error.message, type: 'invalid_request_error' } }),
+        );
+      }
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    try {
+      const pinned = (await readFile(new URL('../Dockerfile', import.meta.url), 'utf8')).match(
+        /opencode-ai@([\d.]+)/,
+      )[1];
+      const version = await sandbox.exec('opencode --version', { cwd, timeout: 15_000 });
+      assert.equal(version.stdout.trim(), pinned, 'test must use the production OpenCode version');
+      const auth = {
+        mode: 'gateway',
+        model,
+        baseURL: `http://127.0.0.1:${server.address().port}/ai-proxy/v1`,
+        vars: {
+          TURBODIFF_AI_GATEWAY_GRANT: await createAiGatewayGrant(
+            config.apiToken,
+            model,
+            Date.now() + 90_000,
+          ),
+        },
+      };
+      const promptFile = path.join(root, 'prompt.md');
+      await writeFile(promptFile, 'Analyze the evidence file.');
+      const options = { cwd, promptFile, timeout: 30_000, configExtensionJson: PLANNING_CONFIG };
+      const analysis = await runCodingAgent(sandbox, auth, options);
+      if (failure) throw failure;
+      assert.equal(analysis.success, true, analysis.stderr || analysis.stdout);
+      assert.equal(analysis.resultText, 'Grounded analysis complete');
+      assert.equal(requests.length, 3, 'expected one retry, one tool read, one final response');
+      const snapshot = await exportPlanningSession(sandbox, auth, cwd, analysis.codingSessionId);
+      await rm(home, { recursive: true, force: true });
+      home = path.join(root, 'replacement');
+      await rm(path.join(cwd, 'evidence.txt')); // Resumption must retain the actual read result.
+      const sessionId = await importPlanningSession(sandbox, auth, cwd, snapshot);
+      stage = 'refine';
+      await writeFile(promptFile, 'The user answered: proceed. Produce the plan.');
+      const refined = await runCodingAgent(sandbox, auth, { ...options, sessionId });
+      if (failure) throw failure;
+      assert.equal(refined.success, true, refined.stderr || refined.stdout);
+      assert.equal(refined.codingSessionId, analysis.codingSessionId);
+      assert.equal(refined.resultText, 'Plan uses the preserved evidence');
+      assert.equal(requests.length, 4, 'refinement should use the imported context in one request');
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/src/ai/runners/planner.ts
+++ b/src/ai/runners/planner.ts
@@ -14,6 +14,11 @@ import {
 } from '../../data/db.ts';
 import { persistAgentLog } from '../runtime/agent-runs.ts';
 import { runCodingAgent } from '../runtime/coding-agent.ts';
+import {
+  exportPlanningSession,
+  importPlanningSession,
+  PLANNING_CONFIG,
+} from '../runtime/planning-session.ts';
 import { resolveRunnerAuth } from '../runtime/runner-auth.ts';
 import { runnerSandbox } from '../runtime/sandbox.ts';
 import { redactSecrets } from '../runtime/redaction.ts';
@@ -151,26 +156,47 @@ async function runAgent(
   planId: number,
   // The task's model snapshot (plans.runner_model); null is legacy-only.
   model: string | null,
+  resume = false,
 ): Promise<void> {
   const auth = await resolveRunnerAuth(undefined, model);
   const scrubRun = (value: string) => redactSecrets(scrub(value), Object.values(auth.vars));
+  const sessionKey = `planning-sessions/${planId}.json`;
+  const saved = resume ? await env.ARTIFACTS.get(sessionKey) : null;
+  const sessionId = saved
+    ? await importPlanningSession(sandbox, auth, CLONE_DIR, await saved.text())
+    : null;
   await sandbox.writeFile(`${OUT_DIR}/task.md`, prompt);
   const res = await runCodingAgent(sandbox, auth, {
     promptFile: `${OUT_DIR}/task.md`,
     cwd: CLONE_DIR,
     timeout: AGENT_TIMEOUT_MS,
+    sessionId,
+    configExtensionJson: PLANNING_CONFIG,
   });
-  await persistAgentLog(kind, scrubRun(`${res.resultText}\n${res.stderr}`.trim()), res.success, {
-    planId,
-  });
+  await persistAgentLog(
+    kind,
+    scrubRun(`${res.resultText}\n${res.stderr}`.trim()),
+    res.success,
+    { planId },
+    scrubRun(res.stdout),
+  );
   if (!res.success) {
     throw new Error(
       `planning agent exited ${res.exitCode}: ${scrubRun(`${res.stdout}\n${res.stderr}`).trim().slice(-1_000)}`,
     );
   }
+  if (!res.codingSessionId) throw new Error('Planning agent did not return a session');
+  const snapshot = await exportPlanningSession(sandbox, auth, CLONE_DIR, res.codingSessionId);
+  await env.ARTIFACTS.put(sessionKey, scrubRun(snapshot), {
+    httpMetadata: { contentType: 'application/json' },
+  });
 }
 
 const ATTACH_DIR = '/workspace/plan-attachments';
+const PLANNING_RESEARCH_RULES = `Work directly in this session; delegation is disabled for planning.
+Use targeted searches and bounded file reads to resolve the implementation decisions. Stop exploring once the affected files and behavior are established; do not survey unrelated modules or audit the whole repository.
+Reuse the prior analysis and tool results. On a resumed turn the checkout may have been refreshed, so verify relevant facts that may have changed, then address the new answers or feedback. Do not repeat the initial discovery pass.
+Write the requested outputs as soon as the decisions are resolved. Validate their structure once, then finish.`;
 
 // User-uploaded context files (R2) pulled into the sandbox with the same
 // signed /artifacts capability URLs verification uses. Returns sandbox paths.
@@ -217,6 +243,7 @@ function analyzePrompt(
     const repo = repos[0];
     return `You are a planning agent for ${repo.owner}/${repo.name}. You are in a read-only checkout — study the code but do NOT modify it.
 Keep the analysis proportionate: for a small, localized change, use at most 10 lines and ask questions only for a genuine blocker.
+${PLANNING_RESEARCH_RULES}
 Analyze the feature requirements below against the actual codebase, then write these files (create the directory if needed):
 
 1. ${OUT_DIR}/analysis.md — a short grounding analysis: which files/modules this touches, how it fits existing conventions, and any risks.
@@ -233,6 +260,7 @@ ${extra}`;
   }
   return `You are a planning agent for a feature spanning ${repos.length} repositories. You are in read-only checkouts — study the code but do NOT modify it.
 Keep the analysis proportionate: for a small, localized change, use at most 10 lines and ask questions only for a genuine blocker.
+${PLANNING_RESEARCH_RULES}
 ## Repositories
 ${reposList(dirs)}
 
@@ -265,6 +293,7 @@ function planPrompt(
     return `You are a planning agent for ${repo.owner}/${repo.name}. You are in a read-only checkout — study the code but do NOT modify it.
 ${trivial ? '\nThis request is classified TRIVIAL: a small, localized change. The plan must be proportionate — a reader should grasp it in seconds.\n' : ''}
 Produce an implementation plan for the feature below, grounded in the real code, then write these files:
+${PLANNING_RESEARCH_RULES}
 
 1. ${OUT_DIR}/plan.md — ${trivial ? 'a brief plan (≤15 lines): the exact files to edit and what changes in each. No background essays, no scope-decision narratives.' : 'a file-level implementation plan: what changes in which files, in what order, and why. Concrete enough for an implementation agent to follow without further questions. Constraint: no preamble, no background essays, no surveys of options you rejected; do NOT copy code from the repo or write out full implementations — when logic genuinely needs showing, a few lines of pseudocode or a signature is the ceiling. Prefer naming the file/function and saying what changes over showing how the code will look.'}
 2. ${OUT_DIR}/acceptance.json — a JSON array of at most ${trivial ? 4 : 8} machine-checkable acceptance criteria (strings), each about the observable behavior of the change itself. Rules:
@@ -289,6 +318,7 @@ ${trivial ? '\nThis request is classified TRIVIAL: a small, localized change. Th
 ${reposList(dirs)}
 
 Produce ONE implementation plan for the feature below, grounded in the real code across ALL repositories above, designed as a single coherent feature — not one plan per repo. Then write these files:
+${PLANNING_RESEARCH_RULES}
 
 1. ${OUT_DIR}/plan.md — a file-level implementation plan: what changes in which files, in what order, and why. Concrete enough for an implementation agent to follow without further questions.${trivial ? '' : ' Constraint: no preamble, no background essays, no surveys of options you rejected; do NOT copy code from the repo or write out full implementations — when logic genuinely needs showing, a few lines of pseudocode or a signature is the ceiling. Prefer naming the file/function and saying what changes over showing how the code will look.'} Write one "## <owner>/<name>" section per repository listed above, so each repo's slice of the plan is identifiable.
 2. ${OUT_DIR}/acceptance.json — a JSON array of at most ${trivial ? 4 : 8} machine-checkable acceptance criteria (strings), each about the observable behavior of the change itself. Rules:
@@ -358,6 +388,7 @@ export async function runPlanAnalyze(planId: number): Promise<void> {
         'plan_analyze',
         planId,
         plan.runner_model,
+        true,
       );
       const planMd = await readText(sandbox, `${OUT_DIR}/plan.md`);
       const summary = await readText(sandbox, `${OUT_DIR}/summary.md`);
@@ -451,6 +482,7 @@ export async function runPlanRefine(planId: number): Promise<void> {
       'plan_refine',
       planId,
       plan.runner_model,
+      true,
     );
     const planMd = await readText(sandbox, `${OUT_DIR}/plan.md`);
     const summary = await readText(sandbox, `${OUT_DIR}/summary.md`);

--- a/src/ai/runners/task-model.test.ts
+++ b/src/ai/runners/task-model.test.ts
@@ -44,6 +44,13 @@ const boundary = vi.hoisted(() => {
 vi.mock('@cloudflare/sandbox', () => ({ collectFile: vi.fn() }));
 vi.mock('cloudflare:workers', () => ({
   env: {
+    ARTIFACTS: {
+      get: async (key: string) =>
+        boundary.files.has(key) ? { text: async () => boundary.files.get(key)! } : null,
+      put: async (key: string, content: string) => {
+        boundary.files.set(key, content);
+      },
+    },
     AI_GATEWAY_ACCOUNT_ID: 'test-account',
     AI_GATEWAY_ID: 'test-gateway',
     AI_GATEWAY_API_TOKEN: 'test-only-gateway-secret',
@@ -122,6 +129,20 @@ beforeEach(() => {
   boundary.runs.length = 0;
   boundary.tier = 'trivial';
   boundary.exec.mockImplementation(async (command: string, options?: ExecOptions) => {
+    if (command.startsWith('opencode export ')) {
+      boundary.files.set(
+        options!.env!.TURBODIFF_SESSION_FILE!,
+        JSON.stringify({ info: { id: 'ses_testplanning123' }, messages: [] }),
+      );
+    }
+    if (command.startsWith('opencode import ')) {
+      return {
+        success: true,
+        exitCode: 0,
+        stdout: 'Imported session: ses_testplanning123',
+        stderr: '',
+      };
+    }
     if (command.startsWith('opencode run ')) {
       const env = options?.env ?? {};
       const prompt = boundary.files.get(env.TURBODIFF_AGENT_PROMPT ?? '') ?? '';
@@ -150,7 +171,12 @@ beforeEach(() => {
         );
       }
     }
-    return { success: true, exitCode: 0, stdout: '', stderr: '' };
+    return {
+      success: true,
+      exitCode: 0,
+      stdout: '{"type":"text","sessionID":"ses_testplanning123","part":{"text":"Done"}}',
+      stderr: '',
+    };
   });
 });
 
@@ -189,6 +215,7 @@ describe('task model across planning and verification', () => {
     expect(boundary.runs[0].prompt).toContain('/workspace/plan-out/tier.txt');
     expect(boundary.updatePlan).toHaveBeenCalledWith(10, { tier: 'trivial' });
     expect(boundary.runs[1].prompt).toContain('at most 4');
+    expect(boundary.runs[1].env.TURBODIFF_AGENT_SESSION).toBe('ses_testplanning123');
     expect(boundary.updatePlan).toHaveBeenCalledWith(
       10,
       expect.objectContaining({

--- a/src/ai/runtime/coding-agent.ts
+++ b/src/ai/runtime/coding-agent.ts
@@ -1,6 +1,6 @@
 import type { ExecOptions, ExecResult } from '@cloudflare/sandbox';
 import type { CliUsage } from '../../shared/usage.ts';
-import { runnerEnvironment, type RunnerAuth } from './runner-auth.ts';
+import { runnerEnvironment, type RunnerAuth } from './runner-config.ts';
 import {
   codingAgentResultText,
   codingAgentSessionId,

--- a/src/ai/runtime/planning-session.ts
+++ b/src/ai/runtime/planning-session.ts
@@ -1,0 +1,66 @@
+import type { Sandbox } from '@cloudflare/sandbox';
+import { isJsonObject, isString, parseJson } from '../../shared/json.ts';
+import { runnerEnvironment, type RunnerAuth } from './runner-config.ts';
+
+// Planning is one research conversation. Delegating here multiplied provider
+// retries, then discarded failed subagents' research and repeated it in the
+// parent. Explicit deny remains effective with OpenCode's --auto flag.
+export const PLANNING_CONFIG = JSON.stringify({ permission: { task: 'deny' } });
+
+type SessionSandbox = Pick<Sandbox, 'exec' | 'writeFile' | 'readFile'>;
+const sessionFile = (cwd: string) => `${cwd}/../planning-session.json`;
+
+function sessionId(snapshot: string): string {
+  const data = parseJson(snapshot);
+  const id = isJsonObject(data) && isJsonObject(data.info) ? data.info.id : undefined;
+  if (!isString(id) || !/^ses_[A-Za-z0-9_-]{8,128}$/.test(id)) {
+    throw new Error('Invalid saved planning session');
+  }
+  return id;
+}
+
+// Export/import preserves tool results across sandbox replacement, not only a
+// short summary. These commands make no model calls. The snapshot is private
+// task data in R2, scrubbed by the caller before storage.
+export async function exportPlanningSession(
+  sandbox: SessionSandbox,
+  auth: RunnerAuth,
+  cwd: string,
+  id: string,
+): Promise<string> {
+  const result = await sandbox.exec(
+    'opencode export "$TURBODIFF_AGENT_SESSION" > "$TURBODIFF_SESSION_FILE"',
+    {
+      cwd,
+      env: runnerEnvironment(
+        auth,
+        { TURBODIFF_AGENT_SESSION: id, TURBODIFF_SESSION_FILE: sessionFile(cwd) },
+        PLANNING_CONFIG,
+      ),
+      timeout: 30_000,
+    },
+  );
+  if (!result.success) throw new Error('Could not save planning context');
+  const snapshot = (await sandbox.readFile(sessionFile(cwd))).content;
+  if (sessionId(snapshot) !== id) throw new Error('Planning session export did not match');
+  return snapshot;
+}
+
+export async function importPlanningSession(
+  sandbox: SessionSandbox,
+  auth: RunnerAuth,
+  cwd: string,
+  snapshot: string,
+): Promise<string> {
+  const id = sessionId(snapshot);
+  await sandbox.writeFile(sessionFile(cwd), snapshot);
+  const result = await sandbox.exec('opencode import "$TURBODIFF_SESSION_FILE"', {
+    cwd,
+    env: runnerEnvironment(auth, { TURBODIFF_SESSION_FILE: sessionFile(cwd) }, PLANNING_CONFIG),
+    timeout: 30_000,
+  });
+  if (!result.success || !result.stdout.includes(`Imported session: ${id}`)) {
+    throw new Error('Could not restore planning context');
+  }
+  return id;
+}

--- a/src/ai/runtime/runner-auth.ts
+++ b/src/ai/runtime/runner-auth.ts
@@ -1,20 +1,14 @@
 import { env } from 'cloudflare:workers';
 import { resolveRunnerModel } from '../../data/models.ts';
-import { isJsonObject, parseJson, type JsonObject } from '../../shared/json.ts';
 import {
   AI_GATEWAY_GRANT_TTL_MS,
   createAiGatewayGrant,
 } from '../../integrations/security/ai-gateway-grant.ts';
 
-export type RunnerAuthMode = 'claude_subscription' | 'gateway';
+import type { RunnerAuth } from './runner-config.ts';
 
-export interface RunnerAuth {
-  mode: 'gateway';
-  // Secrets: callers must redact these from surfaced output.
-  vars: Record<string, string>;
-  // Provider/model id understood by Cloudflare AI Gateway's unified catalog.
-  model: string;
-}
+export type RunnerAuthMode = 'claude_subscription' | 'gateway';
+export type { RunnerAuth } from './runner-config.ts';
 
 export async function resolveRunnerAuth(
   requested?: RunnerAuthMode,
@@ -35,6 +29,7 @@ export async function resolveRunnerAuth(
   const normalizedModel = normalizeRunnerModel(model ?? (await resolveRunnerModel()));
   return {
     mode: 'gateway',
+    baseURL: `${env.PUBLIC_BASE_URL}/ai-proxy/v1`,
     vars: {
       TURBODIFF_AI_GATEWAY_GRANT: await createAiGatewayGrant(
         env.AI_GATEWAY_API_TOKEN,
@@ -60,68 +55,4 @@ export function normalizeRunnerModel(model: string): string {
   if (selected === 'anthropic/claude-fable-5-1') return 'anthropic/claude-fable-5.1';
   if (selected === 'anthropic/claude-haiku-4-5-20251001') return 'anthropic/claude-haiku-4.5';
   return selected;
-}
-
-function runnerConfig(auth: RunnerAuth, extensionJson?: string): string {
-  let extension: JsonObject = {};
-  if (extensionJson) {
-    const parsed = parseJson(extensionJson);
-    if (!isJsonObject(parsed)) throw new Error('runner config extension must be a JSON object');
-    extension = parsed;
-  }
-  const existingProvider = isJsonObject(extension.provider) ? extension.provider : {};
-  const configuredGateway = isJsonObject(existingProvider['cloudflare-ai-gateway'])
-    ? existingProvider['cloudflare-ai-gateway']
-    : {};
-  const existingModels = isJsonObject(configuredGateway.models) ? configuredGateway.models : {};
-  const existingOptions = isJsonObject(configuredGateway.options) ? configuredGateway.options : {};
-  const modelProvider = auth.model.startsWith('openai/')
-    ? '@ai-sdk/openai'
-    : auth.model.startsWith('anthropic/')
-      ? '@ai-sdk/anthropic'
-      : '@ai-sdk/openai-compatible';
-  return JSON.stringify({
-    ...extension,
-    $schema: 'https://opencode.ai/config.json',
-    share: 'disabled',
-    enabled_providers: ['cloudflare-ai-gateway'],
-    provider: {
-      ...existingProvider,
-      'cloudflare-ai-gateway': {
-        ...configuredGateway,
-        options: {
-          ...existingOptions,
-          apiKey: '{env:TURBODIFF_AI_GATEWAY_GRANT}',
-          baseURL: `${env.PUBLIC_BASE_URL}/ai-proxy/v1`,
-        },
-        models: {
-          ...existingModels,
-          [auth.model]: { name: auth.model, provider: { npm: modelProvider } },
-        },
-      },
-    },
-  });
-}
-
-export function runnerEnvironment(
-  auth: RunnerAuth,
-  extra: Record<string, string> = {},
-  configExtensionJson?: string,
-) {
-  return {
-    ...auth.vars,
-    TURBODIFF_RUNNER_MODEL: `cloudflare-ai-gateway/${auth.model}`,
-    OPENCODE_CONFIG_CONTENT: runnerConfig(auth, configExtensionJson),
-    OPENCODE_DISABLE_AUTOUPDATE: 'true',
-    OPENCODE_DISABLE_LSP_DOWNLOAD: 'true',
-    OPENCODE_DISABLE_TERMINAL_TITLE: 'true',
-    OPENCODE_DISABLE_MODELS_FETCH: 'true',
-    // Repository-owned OpenCode config/plugins are untrusted harness code.
-    // AGENTS.md and mounted Agent Skills remain discoverable independently.
-    OPENCODE_DISABLE_PROJECT_CONFIG: 'true',
-    OPENCODE_DISABLE_DEFAULT_PLUGINS: 'true',
-    OPENCODE_CLIENT: 'turbodiff',
-    CI: 'true',
-    ...extra,
-  };
 }

--- a/src/ai/runtime/runner-config.ts
+++ b/src/ai/runtime/runner-config.ts
@@ -1,0 +1,74 @@
+import { isJsonObject, parseJson, type JsonObject } from '../../shared/json.ts';
+
+export interface RunnerAuth {
+  mode: 'gateway';
+  baseURL: string;
+  // Secrets: callers must redact these from surfaced output.
+  vars: Record<string, string>;
+  // Provider/model id understood by Cloudflare AI Gateway's unified catalog.
+  model: string;
+}
+
+function runnerConfig(auth: RunnerAuth, extensionJson?: string): string {
+  let extension: JsonObject = {};
+  if (extensionJson) {
+    const parsed = parseJson(extensionJson);
+    if (!isJsonObject(parsed)) throw new Error('runner config extension must be a JSON object');
+    extension = parsed;
+  }
+  const existingProvider = isJsonObject(extension.provider) ? extension.provider : {};
+  const configuredGateway = isJsonObject(existingProvider['cloudflare-ai-gateway'])
+    ? existingProvider['cloudflare-ai-gateway']
+    : {};
+  const existingModels = isJsonObject(configuredGateway.models) ? configuredGateway.models : {};
+  const existingOptions = isJsonObject(configuredGateway.options) ? configuredGateway.options : {};
+  const modelProvider = auth.model.startsWith('openai/')
+    ? '@ai-sdk/openai'
+    : auth.model.startsWith('anthropic/')
+      ? '@ai-sdk/anthropic'
+      : '@ai-sdk/openai-compatible';
+  return JSON.stringify({
+    ...extension,
+    $schema: 'https://opencode.ai/config.json',
+    share: 'disabled',
+    enabled_providers: ['cloudflare-ai-gateway'],
+    provider: {
+      ...existingProvider,
+      'cloudflare-ai-gateway': {
+        ...configuredGateway,
+        options: {
+          ...existingOptions,
+          apiKey: '{env:TURBODIFF_AI_GATEWAY_GRANT}',
+          baseURL: auth.baseURL,
+        },
+        models: {
+          ...existingModels,
+          [auth.model]: { name: auth.model, provider: { npm: modelProvider } },
+        },
+      },
+    },
+  });
+}
+
+export function runnerEnvironment(
+  auth: RunnerAuth,
+  extra: Record<string, string> = {},
+  configExtensionJson?: string,
+) {
+  return {
+    ...auth.vars,
+    TURBODIFF_RUNNER_MODEL: `cloudflare-ai-gateway/${auth.model}`,
+    OPENCODE_CONFIG_CONTENT: runnerConfig(auth, configExtensionJson),
+    OPENCODE_DISABLE_AUTOUPDATE: 'true',
+    OPENCODE_DISABLE_LSP_DOWNLOAD: 'true',
+    OPENCODE_DISABLE_TERMINAL_TITLE: 'true',
+    OPENCODE_DISABLE_MODELS_FETCH: 'true',
+    // Repository-owned OpenCode config/plugins are untrusted harness code.
+    // AGENTS.md and mounted Agent Skills remain discoverable independently.
+    OPENCODE_DISABLE_PROJECT_CONFIG: 'true',
+    OPENCODE_DISABLE_DEFAULT_PLUGINS: 'true',
+    OPENCODE_CLIENT: 'turbodiff',
+    CI: 'true',
+    ...extra,
+  };
+}

--- a/src/services/ai-gateway-proxy.ts
+++ b/src/services/ai-gateway-proxy.ts
@@ -105,6 +105,17 @@ export async function proxyAiGatewayRequest(
     },
   );
   const headers = new Headers();
+  if (!upstream.ok) {
+    // Gateway analytics can omit rejected wholesale requests. Record failures
+    // at our actual HTTP boundary without logging prompts or credentials.
+    console.warn('turbodiff: AI Gateway request failed', {
+      model: grant.model,
+      endpoint,
+      status: upstream.status,
+      ray: upstream.headers.get('cf-ray'),
+      retryAfter: upstream.headers.get('retry-after'),
+    });
+  }
   for (const name of [
     'content-type',
     'cf-ray',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -94,6 +94,11 @@ export default defineConfig({
         dependsOn: ['db:migrate'],
         cache: false,
       },
+      'test:planning': {
+        command:
+          "pnpm --package=opencode-ai@1.18.29 dlx -c 'node --test scripts/planning-runtime.test.mjs'",
+        cache: false,
+      },
       'test:schema': { command: 'node scripts/db-schema-test.mjs' },
       'test:worker': {
         command: 'vp test --config vitest.worker.config.ts',


### PR DESCRIPTION
Planning task 11 launched three very thorough exploration subagents. All three returned “Wholesale Rate limited”; after waiting roughly 3m14s, the parent repeated their research. Refinement also started a new OpenCode session, losing the earlier analysis tool results. The 45 successful Gateway log entries hid the subagent failures; those failures were present in the parent’s tool results.

Planning now explicitly denies the OpenCode task tool, so --auto cannot fan research out into parallel retrying sessions. It exports completed planning sessions to private, redacted task data in R2 and imports them before refinement or immediate synthesis. Tool results survive sandbox replacement, and refinement focuses on answers/feedback instead of restarting discovery. Legacy tasks without a saved session use their recorded analysis; an invalid saved session fails explicitly rather than starting another paid run. Gateway HTTP failures and complete planner transcripts are recorded for diagnosis.

The original eight-minute agent timeout is unchanged. No Workflow or sandbox-lifetime changes are included. This replaces the withdrawn timeout PR #177.

Validation:
- One end-to-end runtime contract scenario executes the pinned OpenCode 1.18.29 CLI through the real config, model grant and HTTP proxy. Only the remote provider is scripted. It returns a 429 with Retry-After, invokes a real file-read tool, then verifies the tool result reaches refinement after the local session database and source evidence are deleted. Delegation must be absent from actual model requests.
- The scenario passes in the Linux Worker sandbox image with external networking disabled, and through the exact CI command. Temporarily enabling delegation or removing session resumption makes it fail.
- All 318 existing tests, all three TypeScript programs, lint and the production build pass.

This verifies the execution contract, not live model speed or a guaranteed completion time. A live MCP probe returned HTTP 200 but the connector failed to expose the response body; that probe is not counted as a verified live result. No deployment has been performed.
