### PR TITLE
Enforce review submission before the agent finishes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Unit tests
         run: pnpm test
 
+      - name: Review submission runtime
+        run: pnpm vp run test:review-runtime
+
       - name: Planning runtime (pinned OpenCode)
         run: pnpm vp run test:planning
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Unit tests
         run: pnpm test
 
+      - name: Review submission runtime
+        run: pnpm vp run test:review-runtime
+
       - name: Planning runtime (pinned OpenCode)
         run: pnpm vp run test:planning
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.39.2",
     "@cloudflare/vitest-pool-workers": "^0.21.3",
+    "@earendil-works/pi-ai": "0.83.0",
     "@electric-sql/pglite": "^0.3.14",
     "@flue/cli": "^2.0.1",
     "@flue/vite": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,6 +337,9 @@ importers:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.21.3
         version: 0.21.3(@cloudflare/workers-types@5.20260813.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
+      '@earendil-works/pi-ai':
+        specifier: 0.83.0
+        version: 0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.21.3)(zod@4.4.3)
       '@electric-sql/pglite':
         specifier: ^0.3.14
         version: 0.3.16

--- a/scripts/review-submission-runtime.test.mjs
+++ b/scripts/review-submission-runtime.test.mjs
@@ -1,0 +1,110 @@
+// Real Flue dispatch, tools, finish hooks and SQLite conversation persistence.
+// Only the model and the application review-store boundary are local fixtures;
+// no provider credentials, network requests or AI credits are used.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { defineTool, init, useDelivery, useModel, useTool } from '@flue/runtime';
+import { start } from '@flue/runtime/node';
+import { fauxProvider, fauxAssistantMessage, fauxToolCall } from '@earendil-works/pi-ai';
+import * as v from 'valibot';
+import { useReviewSubmissionGuard } from '../src/ai/review/submission-guard.ts';
+
+await test('prose-only completion continues to real submission, including a second review in the same conversation', async () => {
+  const rows = new Map([
+    [1, 'running'],
+    [2, 'running'],
+  ]);
+  const published = [];
+  const provider = fauxProvider({ provider: 'review-test', models: [{ id: 'reviewer' }] });
+  function Reviewer() {
+    const delivery = useDelivery();
+    const id = Number(delivery.attributes.review_id);
+    useModel('review-test/reviewer');
+    useReviewSubmissionGuard(id, async () => rows.get(id) ?? null);
+    useTool(
+      defineTool({
+        name: 'post_review',
+        description: 'Publish the review',
+        input: v.object({}),
+        run: async () => {
+          published.push(id);
+          rows.set(id, 'completed');
+          return { output: { posted: true } };
+        },
+      }),
+    );
+    return 'Review and call post_review.';
+  }
+  const runtime = await start({ agents: [Reviewer], providers: [provider.provider], env: {} });
+  try {
+    const agent = init(Reviewer, { id: 'repeat-review' });
+    for (const id of [1, 2]) {
+      provider.setResponses([
+        fauxAssistantMessage("I'm posting a clean approval."),
+        (context) => {
+          assert.match(JSON.stringify(context.messages), /This review is still unsubmitted/);
+          assert.equal(rows.get(id), 'running');
+          return fauxAssistantMessage(fauxToolCall('post_review', {}, { id: 'call_post_review' }), {
+            stopReason: 'toolUse',
+          });
+        },
+        fauxAssistantMessage('Posted.'),
+      ]);
+      const receipt = await agent.dispatch({
+        message: {
+          kind: 'signal',
+          type: 'review.request',
+          body: 'Review this change.',
+          attributes: { review_id: String(id) },
+        },
+      });
+      await agent.read(receipt);
+      assert.equal(rows.get(id), 'completed');
+      assert.deepEqual(published, id === 1 ? [1] : [1, 2]);
+      assert.equal(provider.getPendingResponseCount(), 0);
+    }
+  } finally {
+    await runtime.stop();
+  }
+});
+
+await test('a non-throwing post_review that does not complete the row cannot pass the guard or loop indefinitely', async () => {
+  const provider = fauxProvider({ provider: 'unsubmitted-test', models: [{ id: 'reviewer' }] });
+  let calls = 0;
+  function Reviewer() {
+    useModel('unsubmitted-test/reviewer');
+    useReviewSubmissionGuard(3, async () => 'running');
+    useTool(
+      defineTool({
+        name: 'post_review',
+        description: 'Publish the review',
+        input: v.object({}),
+        run: async () => {
+          calls++;
+          return { output: { posted: false } };
+        },
+      }),
+    );
+    return 'Review and call post_review.';
+  }
+  provider.setResponses([
+    fauxAssistantMessage(fauxToolCall('post_review', {}, { id: 'call_post_review' }), {
+      stopReason: 'toolUse',
+    }),
+    fauxAssistantMessage('Posted.'),
+    fauxAssistantMessage('I already posted it.'),
+  ]);
+  const runtime = await start({ agents: [Reviewer], providers: [provider.provider], env: {} });
+  try {
+    const agent = init(Reviewer, { id: 'unsatisfied-review' });
+    const receipt = await agent.dispatch('Review this change.');
+    await assert.rejects(agent.read(receipt), (error) => {
+      assert.equal(error.outcome, 'failed');
+      return true;
+    });
+    assert.equal(calls, 1);
+    assert.equal(provider.state.callCount, 3);
+  } finally {
+    await runtime.stop();
+  }
+});

--- a/src/ai/agents/pr-reviewer.ts
+++ b/src/ai/agents/pr-reviewer.ts
@@ -7,7 +7,8 @@ import {
   type AgentProps,
   type McpConnectionDefinition,
 } from '@flue/runtime';
-import { getConnection } from '../../data/db.ts';
+import { getConnection, getReviewRunGuard } from '../../data/db.ts';
+import { useReviewSubmissionGuard } from '../review/submission-guard.ts';
 import type { ConnectionSnapshot } from '../../shared/connections.ts';
 import { resolveConnectionAuth } from '../../services/connections.ts';
 import { DEFAULT_MODEL } from '../../domain/personas.ts';
@@ -170,6 +171,13 @@ async function resolveMountAuth(connectionId: number): Promise<string> {
 
 export function PrReviewer(props: AgentProps) {
   const cfg = deliveryConfig();
+  const reviewId = cfg.crPin?.reviewId ?? cfg.pin?.reviewId;
+  if (reviewId !== undefined) {
+    useReviewSubmissionGuard(
+      reviewId,
+      async () => (await getReviewRunGuard(reviewId))?.status ?? null,
+    );
+  }
 
   // The current Flue Gateway provider maps this onto each model's native
   // reasoning protocol, including adaptive thinking for Claude 5. Review is

--- a/src/ai/review/submission-guard.ts
+++ b/src/ai/review/submission-guard.ts
@@ -1,0 +1,51 @@
+import {
+  useAgentFinish,
+  useDelivery,
+  usePersistentState,
+  type AgentAppendMessage,
+} from '@flue/runtime';
+
+// A model saying "I'm posting an approval" does not publish anything. Check
+// the exact dispatch's durable row: even a non-throwing post_review can return
+// posted:false. A completed but inconclusive review still settles normally;
+// lifecycle coverage/verification gates retain authority over readiness.
+export function useReviewSubmissionGuard(
+  reviewId: number,
+  readStatus: () => Promise<string | null>,
+): void {
+  const delivery = useDelivery();
+  const [remindedReviewId, setRemindedReviewId] = usePersistentState<number | null>(
+    'review-submission-reminder',
+    null,
+  );
+  useAgentFinish(async ({ append }) => {
+    const status = await readStatus();
+    if (status === 'completed') return;
+    if (status !== 'running') {
+      throw new Error(`Review ${reviewId} is no longer active (${status ?? 'missing'}).`);
+    }
+    if (remindedReviewId === reviewId) {
+      throw new Error(
+        `Review ${reviewId} was not submitted: post_review did not complete the review after a corrective continuation.`,
+      );
+    }
+    setRemindedReviewId(reviewId);
+    const reminder: AgentAppendMessage = {
+      kind: 'signal',
+      // Appends become the render-time delivery. Keep the original dispatch
+      // attributes, otherwise the next turn loses its model and review pin.
+      type: delivery.kind === 'signal' ? delivery.type : 'review.submission_required',
+      body:
+        'This review is still unsubmitted. Your chat response does not post a GitHub or native review. ' +
+        'Use the evidence already gathered and call post_review now with your candidate findings and fileEvidence, ' +
+        'including an empty findings array when there are no supported findings. ' +
+        'If a tool failed, address its error; do not claim success without completing post_review. ' +
+        'Do not restart the review or repeat successful repository checks.',
+    };
+    if (delivery.kind === 'signal') {
+      reminder.attributes = delivery.attributes;
+      reminder.tagName = delivery.tagName;
+    }
+    append(reminder);
+  });
+}

--- a/src/services/lifecycle.ts
+++ b/src/services/lifecycle.ts
@@ -475,7 +475,10 @@ type ReviewStageOutput = {
 
 async function publishReviewReadiness(stageRunId: number): Promise<void> {
   await publishReviewReadinessCheckForStage(stageRunId).catch((error) =>
-    console.error('turbodiff: publishing review readiness check failed', error),
+    console.error('turbodiff: publishing review readiness check failed', {
+      stageRunId,
+      error: error instanceof Error ? error.message : String(error),
+    }),
   );
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -99,6 +99,10 @@ export default defineConfig({
           "pnpm --package=opencode-ai@1.18.29 dlx -c 'node --test scripts/planning-runtime.test.mjs'",
         cache: false,
       },
+      'test:review-runtime': {
+        command: 'node --test scripts/review-submission-runtime.test.mjs',
+        cache: false,
+      },
       'test:schema': { command: 'node scripts/db-schema-test.mjs' },
       'test:worker': {
         command: 'vp test --config vitest.worker.config.ts',


### PR DESCRIPTION
Feature 9 generated PR #176 successfully and its GitHub CI passed, but both review-stage attempts stopped because the Code Review agent finished with prose instead of calling `post_review`. The retry's final response said “I'm posting a clean approval”; review row 225 was still running and was therefore failed by settlement. The security review completed independently.

The user-visible regression comes from the September 9 lifecycle change in `e8ef32c`: previously a review stage continued when at least one reviewer completed; now any failed reviewer stops the stage. Production records show the same missing-submission failure on September 5–8, including stage 60 with one completed and one failed review that was marked completed. Feature 9 has the same split and now stops. This PR mitigates the missing submission; it does not revert that stricter review policy or prove that model compliance is universally reliable.


The reviewer now checks the exact dispatch's saved review status at Flue's finish hook. An unsubmitted review gets one corrective continuation using its existing evidence. The continuation preserves the original model, repository/head pin and dispatch attributes. Only the saved completed state ends the guard successfully; coverage, stale-head, finding verification and lifecycle readiness checks remain authoritative. A second omission fails instead of repeatedly spending credits.

Readiness-check errors now log the stage ID and explicit error message. Separately, production inspection confirmed the Ngineer101 GitHub App installation has no `checks` permission. That requires granting Checks: read and write and accepting the installation permission update; this PR does not change app permissions.

Validation:
- Two real Flue runtime/SQLite tests exercise prose-only completion, a second review in the same conversation, and a non-throwing `post_review` that leaves the review unsubmitted. Only the model and application review-store boundary use local fixtures; no AI credits are consumed. Both tests fail when the guard is bypassed.
- 318 unit tests pass; Worker/client typechecks, lint (existing warnings), and production build pass.
- Runtime tests run in CI and deployment validation. Live provider compliance and production GitHub publication are not claimed by these tests.

After deployment, resume feature 9's failed review stage. Regenerating its code is unnecessary.
